### PR TITLE
Enable item editing in the search dialog

### DIFF
--- a/Source/Gral/GRALDomForms/Search_Item.Designer.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.Designer.cs
@@ -51,6 +51,8 @@ namespace GralDomForms
             this.label1 = new System.Windows.Forms.Label();
             this.button2 = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.button3 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
@@ -60,21 +62,22 @@ namespace GralDomForms
             this.dataGridView1.AllowUserToAddRows = false;
             this.dataGridView1.AllowUserToDeleteRows = false;
             this.dataGridView1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.dataGridView1.Location = new System.Drawing.Point(9, 54);
+            this.dataGridView1.Location = new System.Drawing.Point(0, 54);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(2);
             this.dataGridView1.MinimumSize = new System.Drawing.Size(338, 81);
             this.dataGridView1.Name = "dataGridView1";
-            this.dataGridView1.ReadOnly = true;
             this.dataGridView1.RowTemplate.Height = 24;
-            this.dataGridView1.Size = new System.Drawing.Size(589, 271);
+            this.dataGridView1.Size = new System.Drawing.Size(721, 271);
             this.dataGridView1.TabIndex = 0;
             this.dataGridView1.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridView1ColumnHeaderMouseClick);
+            this.dataGridView1.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.dataGridView1_DataError);
             this.dataGridView1.RowHeaderMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridView1RowHeaderMouseDoubleClick);
+            this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
             // 
             // button1
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.button1.Location = new System.Drawing.Point(26, 356);
+            this.button1.Location = new System.Drawing.Point(10, 373);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(121, 27);
@@ -85,7 +88,7 @@ namespace GralDomForms
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(16, 13);
+            this.label2.Location = new System.Drawing.Point(16, 15);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(41, 19);
@@ -97,14 +100,14 @@ namespace GralDomForms
             this.textBox1.Location = new System.Drawing.Point(62, 12);
             this.textBox1.Margin = new System.Windows.Forms.Padding(2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(76, 20);
+            this.textBox1.Size = new System.Drawing.Size(134, 20);
             this.textBox1.TabIndex = 4;
             this.toolTip1.SetToolTip(this.textBox1, "Item name");
             this.textBox1.TextChanged += new System.EventHandler(this.TextBox1TextChanged);
             // 
             // label3
             // 
-            this.label3.Location = new System.Drawing.Point(158, 13);
+            this.label3.Location = new System.Drawing.Point(235, 15);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(42, 19);
@@ -113,7 +116,7 @@ namespace GralDomForms
             // 
             // textBox2
             // 
-            this.textBox2.Location = new System.Drawing.Point(204, 12);
+            this.textBox2.Location = new System.Drawing.Point(281, 12);
             this.textBox2.Margin = new System.Windows.Forms.Padding(2);
             this.textBox2.Name = "textBox2";
             this.textBox2.Size = new System.Drawing.Size(76, 20);
@@ -123,7 +126,7 @@ namespace GralDomForms
             // 
             // label4
             // 
-            this.label4.Location = new System.Drawing.Point(309, 13);
+            this.label4.Location = new System.Drawing.Point(412, 15);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(52, 19);
@@ -132,7 +135,7 @@ namespace GralDomForms
             // 
             // textBox3
             // 
-            this.textBox3.Location = new System.Drawing.Point(366, 12);
+            this.textBox3.Location = new System.Drawing.Point(469, 12);
             this.textBox3.Margin = new System.Windows.Forms.Padding(2);
             this.textBox3.Name = "textBox3";
             this.textBox3.Size = new System.Drawing.Size(76, 20);
@@ -154,14 +157,14 @@ namespace GralDomForms
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox1.Size = new System.Drawing.Size(589, 40);
+            this.groupBox1.Size = new System.Drawing.Size(721, 40);
             this.groupBox1.TabIndex = 5;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Filter";
             // 
             // textBox4
             // 
-            this.textBox4.Location = new System.Drawing.Point(509, 12);
+            this.textBox4.Location = new System.Drawing.Point(629, 12);
             this.textBox4.Margin = new System.Windows.Forms.Padding(2);
             this.textBox4.Name = "textBox4";
             this.textBox4.Size = new System.Drawing.Size(76, 20);
@@ -170,7 +173,7 @@ namespace GralDomForms
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(478, 13);
+            this.label1.Location = new System.Drawing.Point(598, 15);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(27, 19);
@@ -179,9 +182,9 @@ namespace GralDomForms
             // 
             // button2
             // 
-            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(447, 356);
+            this.button2.Location = new System.Drawing.Point(609, 373);
             this.button2.Margin = new System.Windows.Forms.Padding(2);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(121, 27);
@@ -190,23 +193,52 @@ namespace GralDomForms
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.Button2Click);
             // 
+            // button3
+            // 
+            this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.button3.Location = new System.Drawing.Point(206, 373);
+            this.button3.Margin = new System.Windows.Forms.Padding(2);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(129, 27);
+            this.button3.TabIndex = 8;
+            this.button3.Text = "&Save the changes";
+            this.button3.UseVisualStyleBackColor = true;
+            this.button3.Click += new System.EventHandler(this.button3_Click);
+            // 
+            // button4
+            // 
+            this.button4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.button4.Location = new System.Drawing.Point(408, 373);
+            this.button4.Margin = new System.Windows.Forms.Padding(2);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(121, 27);
+            this.button4.TabIndex = 10;
+            this.button4.Text = "&Delete Items";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
             // Search_Item
             // 
             this.AcceptButton = this.button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.button2;
-            this.ClientSize = new System.Drawing.Size(607, 392);
+            this.ClientSize = new System.Drawing.Size(741, 411);
+            this.Controls.Add(this.button4);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.button2);
+            this.Controls.Add(this.button3);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.dataGridView1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(2);
+            this.MinimumSize = new System.Drawing.Size(700, 450);
             this.Name = "Search_Item";
-            this.Text = "GRAL GUI Search & filter items";
+            this.Text = "GRAL GUI Search, filter and edit items";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Search_Item_FormClosed);
             this.Load += new System.EventHandler(this.Search_ItemLoad);
             this.ResizeEnd += new System.EventHandler(this.Search_ItemResizeEnd);
+            this.Resize += new System.EventHandler(this.Search_Item_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
@@ -226,5 +258,7 @@ namespace GralDomForms
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.Button button1;
 		private System.Windows.Forms.DataGridView dataGridView1;
-	}
+        private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button button4;
+    }
 }

--- a/Source/Gral/GRALDomForms/Search_Item.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.cs
@@ -45,8 +45,22 @@ namespace GralDomForms
 		
 		private bool[] _visible = new bool[100];
 		public bool[] Items_visible{set {_visible = value;} get {return _visible;} }
-		
-		public Search_Item()
+        public Size FormSize;
+
+        public GralItemForms.EditPointSources EditPSSearch;
+        public GralItemForms.EditAreaSources EditASSearch;
+        public GralItemForms.EditLinesources EditLSSearch;
+        public GralItemForms.EditBuildings EditBSearch;
+        public GralItemForms.EditPortalSources EditPortalsSearch;
+        public GralItemForms.EditReceptors EditRSearch;
+        public GralItemForms.EditWalls EditWallSearch;
+        public GralItemForms.EditVegetation EditVegetationSearch;
+
+        public bool Locked = false;
+
+        private DataGridViewCellStyle ChangedCellStyle;
+
+        public Search_Item()
 		{
 			//
 			// The InitializeComponent() call is required for Windows Forms designer support.
@@ -59,8 +73,7 @@ namespace GralDomForms
 		}
 		
 		void Search_ItemLoad(object sender, EventArgs e)
-		{
-			
+		{		
 			datasorted = new DataView(_data); // create DataView from DataTable
 			dataGridView1.DataSource = datasorted; // connect DataView to GridView
 			dataGridView1.ColumnHeadersHeight = 26;
@@ -80,47 +93,293 @@ namespace GralDomForms
 			dataGridView1.Columns["Diameter"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
 			dataGridView1.Columns["Exit_velocity"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
 			dataGridView1.Columns["Temperature"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
-			#endif
-
-			for (int i = 1; i < 11; i++)
+            dataGridView1.Columns["ER_SG"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
+#endif
+            if (Locked == false)
+            {
+                dataGridView1.Columns[0].ReadOnly = true;
+                dataGridView1.Columns[2].ReadOnly = true;
+                dataGridView1.Columns[9].ReadOnly = true;
+                button3.Enabled = true;
+                button4.Enabled = true;
+            }
+            else
+            {
+                for (int i = 0; i < dataGridView1.Columns.Count; i++)
+                {
+                    dataGridView1.Columns[i].ReadOnly = true;
+                }
+                button3.Enabled = false;
+                button4.Enabled = false;
+            }
+            for (int i = 1; i < 11; i++)
 			{
 				dataGridView1.Columns["ER Nr. " + Convert.ToString(i)].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
 				#if __MonoCS__
 				#else
 				dataGridView1.Columns["ER Nr. " + Convert.ToString(i)].Name = DataGridViewContentAlignment.MiddleRight.ToString();
-				#endif
-			}
+#endif
+                dataGridView1.Columns["Poll. " + Convert.ToString(i)].ReadOnly = true;
+            }
 			dataGridView1.Columns["Source_group"].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
 			#if __MonoCS__
 			#else
 			dataGridView1.Columns["Source_group"].Name = DataGridViewContentAlignment.MiddleCenter.ToString();
-			#endif
-			for (int i = 0; i < _data.Columns.Count; i++)
-				dataGridView1.Columns[i].Visible = _visible[i];
-		}
-		
-		void Button1Click(object sender, EventArgs e) //OK
-		{
-			int selectedRowCount =
-				dataGridView1.Rows.GetRowCount(DataGridViewElementStates.Selected);
-			
-			if (selectedRowCount > 0) // a line selected?
-			{
-				int index = dataGridView1.SelectedRows[0].Index;
-				_selected_item = Convert.ToInt32(dataGridView1[0, index].Value);
-				_selected_type = Convert.ToString(dataGridView1[2, index].Value);
-    		}
-			
-			Close();
-		}
-		
-		void Button2Click(object sender, EventArgs e) // Cancel
-		{
-			_selected_item = 0;
-			Close();
-		}
-		
-		void TextBox1TextChanged(object sender, EventArgs e)
+#endif
+            for (int i = 0; i < _data.Columns.Count; i++)
+            {
+                dataGridView1.Columns[i].Visible = _visible[i];
+            }
+            ChangedCellStyle = new DataGridViewCellStyle();
+            ChangedCellStyle.Font = new Font(dataGridView1.Font, FontStyle.Bold);
+            ChangedCellStyle.BackColor = Color.Beige;
+            dataGridView1.CellValueChanged += new DataGridViewCellEventHandler(dataGridView1_CellValueChanged);
+            Search_ItemResizeEnd(null, null);
+        }
+
+        void Button1Click(object sender, EventArgs e) //OK
+        {
+            int selectedRowCount =
+                dataGridView1.Rows.GetRowCount(DataGridViewElementStates.Selected);
+
+            if (selectedRowCount > 0) // a line selected?
+            {
+                int index = dataGridView1.SelectedRows[0].Index;
+                _selected_item = Convert.ToInt32(dataGridView1[0, index].Value);
+                _selected_type = Convert.ToString(dataGridView1[2, index].Value);
+            }
+            Close();
+        }
+
+        private void button3_Click(object sender, EventArgs e)
+        {
+            if (Locked == false)
+            {
+                for (int i = dataGridView1.RowCount - 1; i >= 0; i--)
+                {
+                    int index = dataGridView1.Rows[i].Index;
+                    int selected_item = Convert.ToInt32(dataGridView1[0, index].Value) - 1;
+                    string selected_type = Convert.ToString(dataGridView1[2, index].Value);
+
+                    if (selected_type == "Point source" && EditPSSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.PointSourceData _dta in EditPSSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.Poll.SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    if (string.IsNullOrEmpty(_dta.VelocityTimeSeries))
+                                    {
+                                        _dta.Velocity = Convert.ToSingle(dataGridView1[6, index].Value);
+                                    }
+                                    if (string.IsNullOrEmpty(_dta.TemperatureTimeSeries))
+                                    {
+                                        _dta.Temperature = Convert.ToSingle(dataGridView1[7, index].Value);
+                                    }
+                                    _dta.Diameter = Convert.ToSingle(dataGridView1[8, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll.EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Line source" && EditLSSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.LineSourceData _dta in EditLSSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    int SGIndex = Convert.ToInt32(dataGridView1[9, index].Value);
+                                    _dta.Poll[SGIndex].SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll[SGIndex].EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Portal source" && EditPortalsSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.PortalsData _dta in EditPortalsSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    
+                                    if (string.IsNullOrEmpty(_dta.VelocityTimeSeries))
+                                    {
+                                        _dta.ExitVel = Convert.ToSingle(dataGridView1[6, index].Value);
+                                    }
+                                    if (string.IsNullOrEmpty(_dta.TemperatureTimeSeries))
+                                    {
+                                        _dta.DeltaT = Convert.ToSingle(dataGridView1[7, index].Value);
+                                    }
+                                    int SGIndex = Convert.ToInt32(dataGridView1[9, index].Value);
+                                    _dta.Poll[SGIndex].SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll[SGIndex].EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Area source" && EditASSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.AreaSourceData _dta in EditASSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.Poll.SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll.EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Receptor point" && EditRSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.ReceptorData _dta in EditRSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Building" && EditBSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.BuildingData _dta in EditBSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Wall" && EditWallSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.WallData _dta in EditWallSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Vegetation" && EditVegetationSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.VegetationData _dta in EditVegetationSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                }
+            }
+
+            _selected_item = -1; // marker that values should be saved
+            Close();
+        }
+
+        void Button2Click(object sender, EventArgs e) // Cancel
+        {
+            _selected_item = 0;
+            Close();
+        }
+
+        void TextBox1TextChanged(object sender, EventArgs e)
 		{
 			try
 			{
@@ -197,8 +456,16 @@ namespace GralDomForms
 
 		void Search_ItemResizeEnd(object sender, EventArgs e)
 		{
-			dataGridView1.Height = Math.Max(300, Height - 177);
-			dataGridView1.Width = Math.Max(400, Width - 50);
+            int h = Height - 60 - (Height - button1.Top);
+            if (h > 0)
+            {
+                dataGridView1.Height = h;
+            }
+            dataGridView1.Width = Math.Max(400, Width - SystemInformation.VerticalScrollBarWidth);
+            if (sender != null && WindowState != FormWindowState.Maximized && WindowState != FormWindowState.Minimized)
+            {
+                FormSize = this.Size;
+            }
 		}
 		
 		void DataGridView1RowHeaderMouseDoubleClick(object sender, DataGridViewCellMouseEventArgs e)
@@ -233,5 +500,190 @@ namespace GralDomForms
 			//MessageBox.Show(sender.ToString() + mi.Index.ToString());
 		}
 
-	}
+        private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Delete && dataGridView1.SelectedRows.Count > 0 && Locked == false)
+            {
+                DeleteItems();
+            }
+            try
+            {
+                if (e.Modifiers == Keys.Control)
+                {
+                    switch (e.KeyCode)
+                    {
+                        case Keys.C:
+                            break;
+
+                        case Keys.V:
+                            PasteClipboard();
+                            break;
+                    }
+                }
+            }
+            catch
+            {
+
+            }
+        }
+
+        private void button4_Click(object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count > 0 && Locked == false)
+            {
+                DeleteItems();
+            }
+        }
+
+        private void DeleteItems()
+        {
+            string _it = "items?";
+            if (dataGridView1.SelectedRows.Count == 1)
+            {
+                _it = "item?";
+            }
+            if (MessageBox.Show(this, "Delete " + dataGridView1.SelectedRows.Count.ToString() +
+                    " selected " + _it, "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                for (int i = dataGridView1.RowCount - 1; i >= 0; i--)
+                {
+                    if (dataGridView1.SelectedRows.Contains(dataGridView1.Rows[i]))
+                    {
+                        int index = dataGridView1.Rows[i].Index;
+                        int selected_item = Convert.ToInt32(dataGridView1[0, index].Value) - 1;
+                        string selected_type = Convert.ToString(dataGridView1[2, index].Value);
+
+                        if (selected_type == "Point source" && EditPSSearch != null)
+                        {
+                            EditPSSearch.ItemDisplayNr = selected_item;
+                            EditPSSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Portal source" && EditPortalsSearch != null)
+                        {
+                            EditPortalsSearch.ItemDisplayNr = selected_item;
+                            EditPortalsSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Line source" && EditLSSearch != null)
+                        {
+                            EditLSSearch.ItemDisplayNr = selected_item;
+                            EditLSSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Area source" && EditASSearch != null)
+                        {
+                            EditASSearch.ItemDisplayNr = selected_item;
+                            EditASSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Building" && EditBSearch != null)
+                        {
+                            EditBSearch.ItemDisplayNr = selected_item;
+                            EditBSearch.RemoveOne(false, false);
+                        }
+                        if (selected_type == "Receptor point" && EditRSearch != null)
+                        {
+                            EditRSearch.ItemDisplayNr = selected_item;
+                            EditRSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Wall" && EditWallSearch != null)
+                        {
+                            EditWallSearch.ItemDisplayNr = selected_item;
+                            EditWallSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Vegetation" && EditVegetationSearch != null)
+                        {
+                            EditVegetationSearch.ItemDisplayNr = selected_item;
+                            EditVegetationSearch.RemoveOne(false);
+                        }
+
+                        _selected_item = -1; // marker, that changed items need to be written to disk
+                        Close();
+                    }
+                }
+            }
+        }
+
+        private void Search_Item_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            _data = null;
+            Data = null;
+            ChangedCellStyle.Font.Dispose();
+            ChangedCellStyle = null;
+            dataGridView1.CellValueChanged -= new DataGridViewCellEventHandler(dataGridView1_CellValueChanged);         
+        }
+
+        private void dataGridView1_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (sender == dataGridView1)
+            {
+                dataGridView1.Rows[e.RowIndex].Cells[e.ColumnIndex].Style = ChangedCellStyle;
+            }
+        }
+
+        private void Search_Item_Resize(object sender, EventArgs e)
+        {
+            if (WindowState == FormWindowState.Maximized)
+            {
+                Search_ItemResizeEnd(null, null);
+            }
+            if (WindowState == FormWindowState.Normal)
+            {
+                Search_ItemResizeEnd(null, null);
+            }
+        }
+
+        void PasteClipboard()
+        {
+            try
+            {
+                string s = Clipboard.GetText();
+                string[] lines = s.Split('\n');
+
+                int iRow = dataGridView1.CurrentCell.RowIndex;
+                int iCol = dataGridView1.CurrentCell.ColumnIndex;
+                DataGridViewCell oCell;
+
+                foreach (string line in lines)
+                {
+                    if (iRow < dataGridView1.RowCount && line.Length > 0)
+                    {
+                        string[] sCells = line.Split('\t');
+                        for (int i = 0; i < sCells.GetLength(0); ++i)
+                        {
+                            double test = 0;
+                            if (double.TryParse(sCells[i], out test) == false)
+                            {
+                                sCells[i] = test.ToString("0.0");
+                            }
+                            if (iCol + i < dataGridView1.ColumnCount)
+                            {
+                                oCell = dataGridView1[iCol + i, iRow];
+                                oCell.Value = Convert.ChangeType(sCells[i].Replace("\r", ""), oCell.ValueType);
+                                oCell.Style = ChangedCellStyle;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        iRow++;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (FormatException)
+            {
+                return;
+            }
+        }
+
+        private void dataGridView1_DataError(object sender, DataGridViewDataErrorEventArgs e)
+        {
+            DataGridViewCell ocell = dataGridView1[e.ColumnIndex, e.RowIndex];
+            MessageBox.Show(this, "Only numeric inputs allowed", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            ocell.Value = Convert.ChangeType(_data.Rows[e.RowIndex][e.ColumnIndex], ocell.ValueType);
+            e.Cancel = false;
+        }
+    }
 }

--- a/Source/Gral/GRALDomain/Domain.cs
+++ b/Source/Gral/GRALDomain/Domain.cs
@@ -230,6 +230,10 @@ namespace GralDomain
         /// </summary>
         private bool[] SearchDatagridviewVisible = new bool[100];
         /// <summary>
+        /// Size of the search form
+        /// </summary>
+        private Size SearchFormSize = new Size(760, 450);
+        /// <summary>
         /// Show the lenght label?
         /// </summary>
         private bool ShowLenghtLabel = true;
@@ -3626,7 +3630,54 @@ namespace GralDomain
             
             Picturebox1_Paint();
         }
-        
+
+        void WriteAllItemsToDisk(object sender, EventArgs e)
+        {
+            if (EditAS.ItemData.Count > 0)
+            {
+                EditAndSaveAreaSourceData(sender, e);
+                EditAS.FillValues();
+            }
+
+            if (EditLS.ItemData.Count > 0)
+            {
+                EditAndSaveLineSourceData(sender, e);
+                EditLS.FillValues();
+            }
+            if (EditPS.ItemData.Count > 0)
+            {
+                EditAndSavePointSourceData(sender, e);
+                EditPS.FillValues();
+            }
+            if (EditPortals.ItemData.Count > 0)
+            {
+                EditAndSavePortalSourceData(sender, e);
+                EditPortals.FillValues();
+            }
+            if (EditB.ItemData.Count > 0)
+            {
+                EditAndSaveBuildingsData(sender, e);
+                EditB.FillValues();
+            }
+            if (EditR.ItemData.Count > 0)
+            {
+                EditAndSaveReceptorData(sender, e);
+                EditR.FillValues();
+            }
+            if (EditWall.ItemData.Count > 0)
+            {
+                EditAndSaveWallData(sender, e);
+                EditWall.FillValues();
+            }
+            if (EditVegetation.ItemData.Count > 0)
+            {
+                EditAndSaveVegetationData(sender, e);
+                EditVegetation.FillValues();
+            }
+            
+            Picturebox1_Paint();
+        }
+
         void CrossCursorToolStripMenuItemClick(object sender, EventArgs e)
         {
             Cursor = Cursors.Cross;

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickReceptor.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickReceptor.cs
@@ -92,7 +92,7 @@ namespace GralDomain
 			}
 			if (mi.Index == 2) // Delete Receptor
 			{
-				EditR.RemoveOne();
+				EditR.RemoveOne(true);
 				EditAndSaveReceptorData(null, null); // save changes
 				Picturebox1_Paint();
 				if (EditR.ItemData.Count > 0)

--- a/Source/Gral/GRALItemForms/EditReceptors.cs
+++ b/Source/Gral/GRALItemForms/EditReceptors.cs
@@ -199,16 +199,24 @@ namespace GralItemForms
         //remove actual receptor
         private void button2_Click(object sender, EventArgs e)
         {
-            RemoveOne();
+            RemoveOne(true);
             RedrawDomain(this, null);
         }
 
         /// <summary>
     	/// Remove the recent item object from the item list
     	/// </summary>
-        public void RemoveOne()
+        public void RemoveOne(bool ask)
         {
-           if (St_F.InputBox("Attention", "Do you really want to delete this receptor?", this) == DialogResult.OK)
+            if (ask == true)
+            {
+                if (St_F.InputBox("Attention", "Do you really want to delete this receptor?", this) == DialogResult.OK)
+                    ask = false;
+                else
+                    ask = true; // Cancel -> do not delete!
+            }
+
+            if (ask == false)
             {
                 textBox1.Text = "";
                 textBox2.Text = "";


### PR DESCRIPTION
Items can be deleted and the values within the table, like height, vertical dimension, name, source group, emission rates can be changed, except the pollutant type, because there might be conflicts with the deposition settings. Unneeded values are ignored (e.g. if a time series is set for an exit temperature, because the temp is unused in these cases)
Invallid inputs are reset, the user gets a warning message. Valid inputs are highlighted.
The size of the search form is restored when it is opened again.