### PR TITLE
Improve and fix meteo zeitreihe

### DIFF
--- a/Contribute.md
+++ b/Contribute.md
@@ -3,6 +3,37 @@ Thank you very much for developing the GRAL User Interface (GUI) further or for 
 
 Do not hesitate to contact the project maintainers at the beginning of your work. 
 
+## Branch Configuration
+
+```
+-- master  : production and bug fixes
+-- develop : release ready commits and bug fixes
+-- features/feature-xx: always branch from develop and delete after merging to develop
+```
+
+- *master* branch is inteded for production release. Keep it simple and easy to rollback
+- *develop* branch is for release preparation. Only for release ready commits.
+
+
+## Recommended Process
+
+If you're developing a **new feature**
+
+1. Create a feature branch from `develop` branch
+2. Branch name dependend on your new `feature`
+3. When your code is ready for release, pull request to the `develop` branch
+4. Delete the feature branch
+
+
+If you're making a **bug fix**
+
+1. Pull request to the `develop` branch
+2. Add an issue tag in the commit message or pull request message
+
+If you're making a **hot fix**, which has to be deployed immediately.
+1. Pull request to `develop` **and** `master` branch
+
+
 ## Code of Conduct
 This project and everyone participating in it is governed by the our Code of Conduct. By participating, you are expected to uphold this code. 
 In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project

--- a/Source/Gral/GRALBackgroundworkers/Background_Allinout.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_Allinout.cs
@@ -182,7 +182,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			string wgmet;

--- a/Source/Gral/GRALBackgroundworkers/Background_Compost.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_Compost.cs
@@ -8,7 +8,7 @@
 /// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
 /// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
 ///</remarks>
-#endregion
+#endregion#
 
 /*
  * Created by SharpDevelop.
@@ -123,7 +123,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			string wgmet;

--- a/Source/Gral/GRALBackgroundworkers/Background_Gen_MeteoFile.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_Gen_MeteoFile.cs
@@ -66,7 +66,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Path_GRAMMwindfield, @"meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			// read mettimeseries
@@ -74,7 +74,7 @@ namespace GralBackgroundworkers
 			ReadMettimeseries(Path.Combine(mydata.Path_GRAMMwindfield, @"mettimeseries.dat"), ref data_mettimeseries);
 			if (data_mettimeseries.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read mettimeseries.dat");
+				BackgroundThreadMessageBox ("Error reading mettimeseries.dat");
 			}
 
 			//loop over all weather situations

--- a/Source/Gral/GRALBackgroundworkers/Background_HighPercentiles.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_HighPercentiles.cs
@@ -103,7 +103,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			foreach(string line_meteopgt in data_meteopgt)	
@@ -275,7 +275,7 @@ namespace GralBackgroundworkers
 			ReadMettimeseries(Path.Combine(mydata.Projectname, "Computation", "mettimeseries.dat"), ref data_mettimeseries);
 			if (data_mettimeseries.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read mettimeseries.dat");
+				BackgroundThreadMessageBox ("Error reading mettimeseries.dat");
 			}
 
 			int count_ws = -1;

--- a/Source/Gral/GRALBackgroundworkers/Background_Mean.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_Mean.cs
@@ -150,7 +150,7 @@ namespace GralBackgroundworkers
 
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			string wgmet;

--- a/Source/Gral/GRALBackgroundworkers/Background_MeanMaxDaymax.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_MeanMaxDaymax.cs
@@ -110,7 +110,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			foreach(string line_meteopgt in data_meteopgt)
@@ -270,7 +270,7 @@ namespace GralBackgroundworkers
 			ReadMettimeseries(Path.Combine(mydata.Projectname, "Computation", "mettimeseries.dat"), ref data_mettimeseries);
 			if (data_mettimeseries.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read mettimeseries.dat");
+				BackgroundThreadMessageBox ("Error reading mettimeseries.dat");
 			}
 
 			int count_ws = -1;

--- a/Source/Gral/GRALBackgroundworkers/Background_OdourHours.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_OdourHours.cs
@@ -189,7 +189,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			string wgmet;

--- a/Source/Gral/GRALBackgroundworkers/Background_OdourHoursTransient.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_OdourHoursTransient.cs
@@ -111,7 +111,7 @@ namespace GralBackgroundworkers
 			ReadMeteopgtAll(Path.Combine(mydata.Projectname, "Computation", "meteopgt.all"), ref data_meteopgt);
 			if (data_meteopgt.Count == 0) // no data available
 			{ 
-				BackgroundThreadMessageBox ("Can't read meteopgt.all");
+				BackgroundThreadMessageBox ("Error reading meteopgt.all");
 			}
 
 			int nnn = 0;

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -337,6 +337,25 @@ namespace GralBackgroundworkers
                             {
                                 NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
 
+                                //check all source groups within the file ReceptorConcentrations.dat
+                                List<int> containedSourceGroups = new List<int>();
+                                string[] headerSourceGroups = ConcentrationHeader[0].Split(new char[] { ':', '\t'});
+                                for(int i = 1; i < headerSourceGroups.Length; i += 2) 
+                                {
+                                    int _sg = 0;
+                                    if (Int32.TryParse(headerSourceGroups[i], out _sg))
+                                    {
+                                        if (!containedSourceGroups.Contains(_sg))
+                                        {
+                                            containedSourceGroups.Add(_sg);
+                                        }
+                                    }
+                                }
+                                if (containedSourceGroups.Count() != sg_names.Count())
+                                {
+                                    BackgroundThreadMessageBox("The number of source groups between calculation and current project does not match!");
+                                }
+
                                 //if the project has been changed - who knows what user are doing...
                                 if (NumberOfReceptors > xrec.Count)
                                 {
@@ -386,9 +405,9 @@ namespace GralBackgroundworkers
             string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
             int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
             
-            double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-            double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-            int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_u = new double[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_v = new double[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            int[,] GRAL_SC = new int[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
             string[] ReceptorMeteoCoors = new string[5];
             
             if (File.Exists(GRAL_metfile))
@@ -818,12 +837,13 @@ namespace GralBackgroundworkers
                     {
                         string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                         int numberOfReceptors = (int)(columns.Length / columnOffset);
+                        
                         int count = 0;
                         
                         for (int numbrec = 0; numbrec < numberOfReceptors; numbrec++)
                         {
                             //check if this situation has been computed, otherwise this line is 0
-                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= numberOfReceptors)
+                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= (numberOfReceptors - 1))
                             {
                                 GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
                                 GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -30,7 +30,7 @@ namespace GralBackgroundworkers
     {
         private string decsep;
         private List<double> xrec = new List<double>();
-        
+
         /// <summary>
         /// Calculate receptor concentrations and GRAL flow field receptor wind fields 
         /// </summary>
@@ -41,23 +41,23 @@ namespace GralBackgroundworkers
             int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
             int maxcomputedsourcegroup = mydata.MaxSourceComputed;
             decsep = mydata.Decsep;
-            
+
             double[,] emifac_day = new double[24, maxsource];
             double[,] emifac_mon = new double[12, maxsource];
             string[] text = new string[15];
-            for (int k=0; k <15; k++) text[k] = "";
-            
-            string dummy;
-            string newpath="";
-            int[]  sg_numbers = new int[maxsource];
+            for (int k = 0; k < 15; k++) text[k] = "";
+
+            string dummy = string.Empty;
+            string newpath = "";
+            int[] sg_numbers = new int[maxsource];
             string[] sg_names = mydata.Sel_Source_Grp.Split(',');
             string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
-            
+
             //in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
             bool transient = false;
             InDatVariables data = new InDatVariables();
             InDatFileIO ReadInData = new InDatFileIO();
-            data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
+            data.InDatPath = Path.Combine(mydata.Projectname, "Computation", "in.dat");
             ReadInData.Data = data;
             if (ReadInData.ReadInDat() == true)
             {
@@ -65,8 +65,8 @@ namespace GralBackgroundworkers
                 {
                     transient = true;
                 }
-            }	
-            
+            }
+
             //get variation for source group
             if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
             {
@@ -75,14 +75,14 @@ namespace GralBackgroundworkers
                 {
                     try
                     {
-                        for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
+                        for (int sg = 0; sg < sg_names.Length; sg++) // check all selected source groups
                         {
                             if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
                             {
                                 sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
                                 // MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
                                 // Read modulation of that source-group
-                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
+                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3, '0') + ".dat");
                                 using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
                                 {
                                     for (int j = 0; j < 24; j++)
@@ -107,13 +107,13 @@ namespace GralBackgroundworkers
                             }
                         }
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
-                        BackgroundThreadMessageBox (ex.Message);
+                        BackgroundThreadMessageBox(ex.Message);
                     }
                 }
             }
-            
+
             //read mettimeseries.dat to get file length necessary to define some array lengths
             newpath = Path.Combine("Computation", "mettimeseries.dat");
             int mettimefilelength = 0;
@@ -129,11 +129,11 @@ namespace GralBackgroundworkers
             }
             if (mettimefilelength == 0) // File-lenght must > 0
             {
-                BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
+                BackgroundThreadMessageBox("Error reading mettimeseries.txt");
                 return; // leave method
             }
             //mettimefilelength--;
-            
+
             //if file emissions_timeseries.txt exists, these modulation factors will be used
             int[] sg_time = new int[maxsource];
             double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
@@ -150,7 +150,7 @@ namespace GralBackgroundworkers
                 }
 
                 // read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
-                newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
+                newpath = Path.Combine(mydata.Projectname, "Computation", "emissions_timeseries.txt");
                 if (File.Exists(newpath) == true)
                 {
                     try
@@ -199,16 +199,16 @@ namespace GralBackgroundworkers
                                 }
                             }
                         }
-                        
+
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
-                        BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
+                        BackgroundThreadMessageBox(ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
                         return;
                     }
                 } // read value from emissions_timeseries.txt
             }
-            
+
             List<string> wgmet = new List<string>();
             List<string> wrmet = new List<string>();
             List<string> akmet = new List<string>();
@@ -220,41 +220,41 @@ namespace GralBackgroundworkers
             string month;
             string hour;
             string day;
-            
-            List<string> rec_names=new List<string>();
-            
+
+            List<string> rec_names = new List<string>();
+
             //get number of receptor points and names of receptors
-            string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
-            if(File.Exists(receptorfile))
+            string receptorfile = Path.Combine(mydata.Projectname, "Computation", "Receptor.dat");
+            if (File.Exists(receptorfile))
             {
                 try
                 {
-                    using(StreamReader read=new StreamReader(receptorfile))
+                    using (StreamReader read = new StreamReader(receptorfile))
                     {
-                        dummy=read.ReadLine(); // 1st line with number of receptor points
-                        
+                        dummy = read.ReadLine(); // 1st line with number of receptor points
+
                         while (read.EndOfStream == false)
                         {
                             text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                            
+
                             if (text.Length > 1) // valid line?
                             {
                                 xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
-                                
+
                                 string a = text[0]; 	// take number as name
                                 if (text.Length > 4) 	// get name from line
-                                    a = text[4];   
-                                
+                                    a = text[4];
+
                                 if (text.Length >= 5) // if the Receptor-Name contains ","
                                 {
-                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
+                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is part of the Receptor point name
                                     {
                                         if (text[k] != "") a = a + "_" + text[k];
                                     }
                                 }
-                                
+
                                 // if the receptor name contains invalid characters for a file!
-                                a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
+                                a = string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
                                 rec_names.Add(a);
                             }
                         }
@@ -262,16 +262,16 @@ namespace GralBackgroundworkers
                 }
                 catch
                 {
-                    BackgroundThreadMessageBox ("Error reading Receptor.dat");
+                    BackgroundThreadMessageBox("Error reading Receptor.dat");
                     return;
                 }
-                
+
             }
-            
+
             //MessageBox.Show(Convert.ToString(rec_names.Count));
-            
+
             //read meteopgt.all
-            newpath = Path.Combine("Computation","meteopgt.all");
+            newpath = Path.Combine("Computation", "meteopgt.all");
             using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
             {
                 text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
@@ -287,21 +287,23 @@ namespace GralBackgroundworkers
                     }
                     catch
                     {
-                        BackgroundThreadMessageBox ("Error reading meteopgt.all");
+                        BackgroundThreadMessageBox("Error reading meteopgt.all");
                         return;
                     }
                 }
             }
-            
+
+            //BackgroundThreadMessageBox(wrmet[0] + "/" + wgmet[0] + "/" + akmet[0]);
             double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
                                                         => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
                                                                                  => new double[wrmet.Count]));
             double fmod = 1;
 
             //read all computed concentrations from file zeitreihe.dat or ReceptorConcentration.dat
-            bool zeitflag = false;
+            bool writeConcentrationFiles = false;
             string[] text5 = new string[xrec.Count * sg_names.Length];
-            int numbwet = 0;
+            //number of existing weather situations
+            int existingWeatherSituations = 0;
 
             //switch between new (V21.01) and old GRAL concentration files
             receptorfile = Path.Combine(mydata.Projectname, "Computation", "ReceptorConcentrations.dat");
@@ -315,12 +317,13 @@ namespace GralBackgroundworkers
                 receptorfile = Path.Combine(mydata.Projectname, "Computation", "zeitreihe.dat");
             }
 
+            // Read concentration file into conc[][][]
             string[] ConcentrationHeader = new string[6];
             int NumberOfReceptors = xrec.Count;
 
             if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
             {
-                zeitflag = true;
+                writeConcentrationFiles = true;
                 try
                 {
                     using (StreamReader read = new StreamReader(receptorfile))
@@ -367,7 +370,7 @@ namespace GralBackgroundworkers
                         }
 
                         // read concentration file
-                        numbwet = 0;
+                        existingWeatherSituations = 0;
                         while (read.EndOfStream == false)
                         {
                             text5 = read.ReadLine().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
@@ -382,12 +385,13 @@ namespace GralBackgroundworkers
                                     //check if this situation has been computed, otherwise this line is 0
                                     if (text5.Length > count)
                                     {
-                                        conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
+                                        conc[numbrec][sg_number][existingWeatherSituations] = Convert.ToDouble(text5[count].Replace(".", decsep));
                                     }
                                     count++;
                                 }
                             }
-                            numbwet++;
+
+                            existingWeatherSituations++; // use weather situations from ReceptorConcentrations.dat
                         }
                     }
                 }
@@ -400,7 +404,7 @@ namespace GralBackgroundworkers
             }
             
             //read all wind speeds from file GRAL_Meteozeitreihe.dat
-            bool metflag = false;
+            bool meteoDataAvailable = false;
             bool local_SCL = false;
             string[] text7 = new string[xrec.Count];
             
@@ -414,18 +418,23 @@ namespace GralBackgroundworkers
             
             if (File.Exists(GRAL_metfile))
             {
-                metflag = true;
-                numbwet = 0;
-                
-                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
+                meteoDataAvailable = true;
+                int weatherSit = 0;         
+                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref weatherSit, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
                 {
-                    metflag = false;
+                    meteoDataAvailable = false;
+                }
+                else
+                {
+                    existingWeatherSituations = weatherSit; // use number of weather situations from MeteoTimeseries
                 }
             }
 
+            //BackgroundThreadMessageBox(numbwet.ToString());
+
             if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
             {
-                if (zeitflag == true) // write mettime series for all receptor points
+                if (writeConcentrationFiles == true) // write mettime series for all receptor points
                 {
                     try
                     {
@@ -439,8 +448,8 @@ namespace GralBackgroundworkers
                             catch{}
                         }
 
-                        //write results to file receptor_timeseries.txt
-                        using (StreamWriter recwrite = new StreamWriter(writerRecTimeSeries))
+                        //write results to file ReceptorTimeSeries.txt in Unicode encoding
+                        using (StreamWriter recwrite = new StreamWriter(writerRecTimeSeries, false, System.Text.Encoding.Unicode))
                         {
                             //write header line
                             if (NewFileFormat)
@@ -448,6 +457,7 @@ namespace GralBackgroundworkers
                                 string[] headerInfo = {"Name", "Source group", "X", "Y", "Z", "-----"};
 
                                 System.Globalization.CultureInfo ci = System.Threading.Thread.CurrentThread.CurrentCulture;
+
                                 for (int ianz = 0; ianz < 6; ianz++)
                                 {
                                     // use local culture for user files
@@ -483,7 +493,7 @@ namespace GralBackgroundworkers
                                 //consider, if meteopgt.all represents a time series or a statistics
                                 int dispersionsituations = 0;
                                 if (mydata.Checkbox19 == true)
-                                    dispersionsituations = numbwet + 1;
+                                    dispersionsituations = existingWeatherSituations + 1;
                                 else
                                     dispersionsituations = wrmet.Count;
 
@@ -495,7 +505,7 @@ namespace GralBackgroundworkers
                                     count_ws++;
                                     count_dispsit_in_mettime += 1;
 
-                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
+                                    if ((count_dispsit_in_mettime >= existingWeatherSituations) && (mydata.Checkbox19 == true))
                                         break;
 
                                     month = text3[1];
@@ -514,7 +524,7 @@ namespace GralBackgroundworkers
                                         if ((wgmet[n].Equals(wgmettime)) && (wrmet[n].Equals(wrmettime)) && (akmet[n].Equals(akmettime)))
                                         {
                                             //take care if not all dispersion situations have been computed
-                                            if (n >= numbwet - 1)
+                                            if (n >= existingWeatherSituations)
                                             {
                                                 //write results
                                                 recwrite.WriteLine(string.Empty);
@@ -586,7 +596,7 @@ namespace GralBackgroundworkers
                 }
             }
             
-            if (metflag == true) // write meteorological data for all receptor points
+            if (meteoDataAvailable == true) // write meteorological data for all receptor points
             {
                 try
                 {
@@ -609,41 +619,39 @@ namespace GralBackgroundworkers
                         double windspeed_GRAL = 0;
                         double winddirection_GRAL = 0;
 
-                        string file = Path.Combine(mydata.Projectname, @"Metfiles", "GRAL" + Convert.ToString(k + 1) + "_" + rec_names[k] + ".met");
-                        if (File.Exists(file))
+                        string meteoFile = Path.Combine(mydata.Projectname, @"Metfiles", "GRAL" + Convert.ToString(k + 1) + "_" + rec_names[k] + ".met");
+                        if (File.Exists(meteoFile))
                         {
                             try
                             {
-                                File.Delete(file);
+                                File.Delete(meteoFile);
                             }
                             catch { }
                         }
 
-                        using (StreamWriter recwrite = new StreamWriter(file))
+                        using (StreamWriter meteoWriter = new StreamWriter(meteoFile))
                         {
                             //write header lines
                             if (string.IsNullOrEmpty(ReceptorMeteoCoors[0]) || k >= recname.Length)
                             {
-                                recwrite.WriteLine("//" + Path.GetFileName(file));
+                                meteoWriter.WriteLine("//" + Path.GetFileName(meteoFile));
                             }
                             else
                             {
                                 try
                                 {
-                                    recwrite.WriteLine(recname[k]);
-                                    recwrite.WriteLine(@"\\X=" + recX[k]);
-                                    recwrite.WriteLine(@"\\Y=" + recY[k]);
-                                    recwrite.WriteLine(@"\\Z=" + recZ[k]);
+                                    meteoWriter.WriteLine(recname[k]);
+                                    meteoWriter.WriteLine(@"\\X=" + recX[k]);
+                                    meteoWriter.WriteLine(@"\\Y=" + recY[k]);
+                                    meteoWriter.WriteLine(@"\\Z=" + recZ[k]);
                                 }
                                 catch { }
                             }
 
                             string[] text6 = new string[2];
-
-                            //read mettimeseries.dat
-                            newpath = Path.Combine("Computation", "mettimeseries.dat");
                             
-                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                            //read mettimeseries.dat
+                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, "Computation", "mettimeseries.dat")))
                             {
                                 text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                                 text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
@@ -654,23 +662,27 @@ namespace GralBackgroundworkers
                                 //consider, if meteopgt.all represents a time series or a statistics
                                 int dispersionsituations = 0;
                                 if (mydata.Checkbox19 == true || transient == true)
-                                    dispersionsituations = numbwet + 1;
+                                    dispersionsituations = existingWeatherSituations + 1;
                                 else
                                     dispersionsituations = wrmet.Count;
                                 
-                                int count_dispsit_in_mettime = 0;
+                                int count_dispsit_in_mettime = -1;
 
                                 while (!string.IsNullOrEmpty(text2[0]))
                                 {
                                     count_dispsit_in_mettime++;
-                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
+                                    
+                                    if ((count_dispsit_in_mettime >= existingWeatherSituations) && (mydata.Checkbox19 == true || transient == true))
+                                    {
                                         break;
+                                    }
 
                                     month = text3[1];
                                     day = text3[0];
                                     hour = text2[1];
                                     if (hour == "24")
                                         hourplus = 1;
+
                                     wgmettime = text2[2];
                                     wrmettime = text2[3];
                                     akmettime = text2[4];
@@ -680,26 +692,26 @@ namespace GralBackgroundworkers
                                         year_increase += 1;
                                     monthold = Convert.ToInt32(text3[1]);
 
-                                    int corr_situation = 0;
-                                    
+                                    int corr_situation = -2;
                                     if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
                                     {
                                         //search in file meteopgt.all for the corresponding dispersion situation
                                         for (int n = 0; n < dispersionsituations; n++)
                                         {
-                                            if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                            if ((wgmet[n].Equals(wgmettime)) && (wrmet[n].Equals(wrmettime)) && (akmet[n].Equals(akmettime)))
                                             {
                                                 //take care if not all dispersion situations have been computed
-                                                if (n >= numbwet)
+                                                if (n >= existingWeatherSituations)
                                                 {
                                                     //write results
-                                                    //dummy = "";
-                                                    //recwrite.WriteLine(dummy);
+                                                    //recwrite.WriteLine(string.Empty);
+                                                    corr_situation = -3;
+                                                    n = dispersionsituations;
                                                 }
                                                 else
                                                 {
                                                     corr_situation = n;
-                                                    break;
+                                                    n = dispersionsituations; // // situation found -> stop searching
                                                 }
                                             }
                                         }
@@ -708,55 +720,67 @@ namespace GralBackgroundworkers
                                     {
                                         corr_situation = count_dispsit_in_mettime;
                                     }
-                                    
-                                    if (corr_situation > 0)
+
+                                    if (corr_situation > -1)
                                     {
                                         int n  = corr_situation;
                                         SetText("Day.Month: " + day + "." + month);
                                         
-                                        int std = Convert.ToInt32(hour);
-                                        int mon = Convert.ToInt32(month) - 1;
-
                                         //write results
-                                        dummy = "";
                                         dummy_year = Convert.ToString(1990 + year_increase);
-                                        dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
+                                        dummy = day + "." + month + "." + dummy_year + "," + hour + ":00,";
+                                        
                                         //compute wind speed and direction
                                         windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
-                                        if (GRAL_v[k,n] == 0)
-                                            winddirection_GRAL = 90;
-                                        else
-                                            winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
-                                        if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
-                                            winddirection_GRAL = 180 - winddirection_GRAL;
-                                        if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
-                                            winddirection_GRAL = 180 + winddirection_GRAL;
-                                        if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
-                                            winddirection_GRAL = 360 - winddirection_GRAL;
 
-                                        dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
-
-                                        if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
+                                        if (windspeed_GRAL == 0) // wind speed 0 => this sit was not calculated
                                         {
-                                            if (GRAL_SC[k, n] > 0) // if this situation is not available yet
+                                            winddirection_GRAL = 0;
+                                            dummy += "0,0,4";
+                                        }
+                                        else
+                                        {
+                                            if (GRAL_v[k, n] == 0)
+                                                winddirection_GRAL = 90;
+                                            else
+                                                winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / Math.PI);
+
+                                            if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
+                                                winddirection_GRAL = 180 - winddirection_GRAL;
+                                            if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
+                                                winddirection_GRAL = 180 + winddirection_GRAL;
+                                            if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
+                                                winddirection_GRAL = 360 - winddirection_GRAL;
+
+                                            dummy += Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0), ic);
+
+                                            if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
                                             {
-                                                dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
+                                                if (GRAL_SC[k, n] > 0 && GRAL_SC[k, n] < 8) // if this situation is not available yet
+                                                {
+                                                    dummy += "," + Convert.ToString(GRAL_SC[k, n], ic);
+                                                }
+                                                else
+                                                {
+                                                    dummy += "," + Convert.ToString(akmettime, ic);
+                                                }
                                             }
                                             else
                                             {
-                                                dummy = dummy + "," + Convert.ToString(akmettime);
+                                                dummy += "," + Convert.ToString(akmettime, ic);
                                             }
                                         }
-                                        else
-                                        {
-                                            dummy = dummy + "," + Convert.ToString(akmettime);
-                                        }
-                                        
-                                        recwrite.WriteLine(dummy);
-                                        //consider, if meteopgt.all represents a time series or a statistics
-//										if (mydata.Checkbox19 == true || transient == true)
-//											break;
+                                        meteoWriter.WriteLine(dummy);
                                     }
+                                    else if (corr_situation > -3) // found no corresponding situation but end of numbwet not reached
+                                    {
+                                        dummy_year = Convert.ToString(1990 + year_increase);
+                                        dummy = day + "." + month + "." + dummy_year + "," + hour + ":00,";
+                                        dummy = dummy + Convert.ToString(0, ic) + "," + Convert.ToString(0, ic) + "," + Convert.ToString(4);
+                                        //BackgroundThreadMessageBox(dummy);
+                                        meteoWriter.WriteLine(dummy);
+                                    }
+
                                     try
                                     {
                                         if (read.EndOfStream)
@@ -771,7 +795,7 @@ namespace GralBackgroundworkers
                                     }
                                     catch
                                     {
-                                        break;
+                                        text2[0] = string.Empty; //quit reading
                                     }
                                 }
                             } // using read
@@ -788,12 +812,13 @@ namespace GralBackgroundworkers
             {
                 //MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+            Computation_Completed = true; // set flag, that computation was successful
         }
         
         private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
         {
-            numbwet = 1;
+            numbwet = 0;
             int columnOffset = 2; // old file format
             int headerLineNumber = 0;
 
@@ -881,9 +906,7 @@ namespace GralBackgroundworkers
                     BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
                     return false;
                 }
-            }
-            
-            Computation_Completed = true; // set flag, that computation was successful
+            } 
             return true;
         } // Read_GRAL_Meteozeitreihe
         

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -332,18 +332,18 @@ namespace GralBackgroundworkers
                             {
                                 ConcentrationHeader[ianz] = read.ReadLine();
                             }
-                        }
 
-                        if (sg_names.Count() > 0)
-                        {
-                            NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
-
-                            //if the project has been changed - who knows what user are doing...
-                            if (NumberOfReceptors > xrec.Count)
+                            if (sg_names.Count() > 0)
                             {
-                                conc = GralIO.Landuse.CreateArray<double[][]>(NumberOfReceptors, ()
-                                                        => GralIO.Landuse.CreateArray<double[]>(maxsource, ()
-                                                                                 => new double[wrmet.Count]));
+                                NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
+
+                                //if the project has been changed - who knows what user are doing...
+                                if (NumberOfReceptors > xrec.Count)
+                                {
+                                    conc = GralIO.Landuse.CreateArray<double[][]>(NumberOfReceptors, ()
+                                                            => GralIO.Landuse.CreateArray<double[]>(maxsource, ()
+                                                                                     => new double[wrmet.Count]));
+                                }
                             }
                         }
 

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -25,289 +25,289 @@ using System.IO;
 
 namespace GralBackgroundworkers
 {
-	public partial class ProgressFormBackgroundworker
-	{
-    	private string decsep;
-    	private List<double> xrec = new List<double>();
-    	
-		/// <summary>
+    public partial class ProgressFormBackgroundworker
+    {
+        private string decsep;
+        private List<double> xrec = new List<double>();
+        
+        /// <summary>
         /// Calculate receptor concentrations and GRAL flow field receptor wind fields 
         /// </summary>
-		private void ReceptorConcentration(GralBackgroundworkers.BackgroundworkerData mydata,
+        private void ReceptorConcentration(GralBackgroundworkers.BackgroundworkerData mydata,
                                            System.ComponentModel.DoWorkEventArgs e)
         {
-			//reading emission variations
-			int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
-			int maxcomputedsourcegroup = mydata.MaxSourceComputed;
-			decsep = mydata.Decsep;
-			
-			double[,] emifac_day = new double[24, maxsource];
-			double[,] emifac_mon = new double[12, maxsource];
-			string[] text = new string[15];
-			for (int k=0; k <15; k++) text[k] = "";
-			
-			string dummy;
-			string newpath="";
-			int[]  sg_numbers = new int[maxsource];
-			string[] sg_names = mydata.Sel_Source_Grp.Split(',');
-			string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
-			
-			//in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
-			bool transient = false;
-			InDatVariables data = new InDatVariables();
-			InDatFileIO ReadInData = new InDatFileIO();
-			data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
-			ReadInData.Data = data;
-			if (ReadInData.ReadInDat() == true)
-			{
-				if (data.Transientflag == 0)
-				{
-					transient = true;
-				}
-			}	
-			
-			//get variation for source group
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				// Read the emission factors of all selected source-groups
-				for (int itm = 0; itm < maxsource; itm++)
-				{
-					try
-					{
-						for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
-						{
-							if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
-							{
-								sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
-								// MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
-								// Read modulation of that source-group
-								newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
-								using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-								{
-									for (int j = 0; j < 24; j++)
-									{
-										text = myreader.ReadLine().Split(new char[] { ',' });
-										emifac_day[j, itm] = Convert.ToDouble(text[1].Replace(".", decsep));
-										if (j < 12)
-											emifac_mon[j, itm] = Convert.ToDouble(text[2].Replace(".", decsep));
-									}
-								}
-								sg = sg_names.Length + 1; // break
-							}
-							else // source group not selected
-							{
-								for (int j = 0; j < 24; j++)
-								{
-									emifac_day[j, itm] = 0;
-									if (j < 12)
-										emifac_mon[j, itm] = 0;
-								}
-								sg_numbers[itm] = -1;
-							}
-						}
-					}
-					catch(Exception ex)
-					{
-						BackgroundThreadMessageBox (ex.Message);
-					}
-				}
-			}
-			
-			//read mettimeseries.dat to get file length necessary to define some array lengths
-			newpath = Path.Combine("Computation", "mettimeseries.dat");
-			int mettimefilelength = 0;
-			string[] text2 = new string[5];
-			using (StreamReader sr = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-			{
-				//text2 = sr.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				while (sr.EndOfStream == false)
-				{
-					mettimefilelength++;
-					sr.ReadLine();
-				}
-			}
-			if (mettimefilelength == 0) // File-lenght must > 0
-			{
-				BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
-				return; // leave method
-			}
-			//mettimefilelength--;
-			
-			//if file emissions_timeseries.txt exists, these modulation factors will be used
-			int[] sg_time = new int[maxsource];
-			double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
+            //reading emission variations
+            int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
+            int maxcomputedsourcegroup = mydata.MaxSourceComputed;
+            decsep = mydata.Decsep;
+            
+            double[,] emifac_day = new double[24, maxsource];
+            double[,] emifac_mon = new double[12, maxsource];
+            string[] text = new string[15];
+            for (int k=0; k <15; k++) text[k] = "";
+            
+            string dummy;
+            string newpath="";
+            int[]  sg_numbers = new int[maxsource];
+            string[] sg_names = mydata.Sel_Source_Grp.Split(',');
+            string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
+            
+            //in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
+            bool transient = false;
+            InDatVariables data = new InDatVariables();
+            InDatFileIO ReadInData = new InDatFileIO();
+            data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
+            ReadInData.Data = data;
+            if (ReadInData.ReadInDat() == true)
+            {
+                if (data.Transientflag == 0)
+                {
+                    transient = true;
+                }
+            }	
+            
+            //get variation for source group
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                // Read the emission factors of all selected source-groups
+                for (int itm = 0; itm < maxsource; itm++)
+                {
+                    try
+                    {
+                        for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
+                        {
+                            if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
+                            {
+                                sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
+                                // MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
+                                // Read modulation of that source-group
+                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
+                                using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                                {
+                                    for (int j = 0; j < 24; j++)
+                                    {
+                                        text = myreader.ReadLine().Split(new char[] { ',' });
+                                        emifac_day[j, itm] = Convert.ToDouble(text[1].Replace(".", decsep));
+                                        if (j < 12)
+                                            emifac_mon[j, itm] = Convert.ToDouble(text[2].Replace(".", decsep));
+                                    }
+                                }
+                                sg = sg_names.Length + 1; // break
+                            }
+                            else // source group not selected
+                            {
+                                for (int j = 0; j < 24; j++)
+                                {
+                                    emifac_day[j, itm] = 0;
+                                    if (j < 12)
+                                        emifac_mon[j, itm] = 0;
+                                }
+                                sg_numbers[itm] = -1;
+                            }
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        BackgroundThreadMessageBox (ex.Message);
+                    }
+                }
+            }
+            
+            //read mettimeseries.dat to get file length necessary to define some array lengths
+            newpath = Path.Combine("Computation", "mettimeseries.dat");
+            int mettimefilelength = 0;
+            string[] text2 = new string[5];
+            using (StreamReader sr = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+            {
+                //text2 = sr.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                while (sr.EndOfStream == false)
+                {
+                    mettimefilelength++;
+                    sr.ReadLine();
+                }
+            }
+            if (mettimefilelength == 0) // File-lenght must > 0
+            {
+                BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
+                return; // leave method
+            }
+            //mettimefilelength--;
+            
+            //if file emissions_timeseries.txt exists, these modulation factors will be used
+            int[] sg_time = new int[maxsource];
+            double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
 
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				//it is necessary to set all values of the array emifac_timeseries equal to 1
-				for (int i = 0; i < mettimefilelength + 1; i++)
-				{
-					for (int n = 0; n < maxsource; n++)
-					{
-						emifac_timeseries[i, n] = 1;
-					}
-				}
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                //it is necessary to set all values of the array emifac_timeseries equal to 1
+                for (int i = 0; i < mettimefilelength + 1; i++)
+                {
+                    for (int n = 0; n < maxsource; n++)
+                    {
+                        emifac_timeseries[i, n] = 1;
+                    }
+                }
 
-				// read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
-				newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
-				if (File.Exists(newpath) == true)
-				{
-					try
-					{
-						//read timeseries of emissions
-						string[] text10 = new string[1];
-						using (StreamReader read1 = new StreamReader(newpath))
-						{
-							//get source group numbers
-							text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
-							for (int i = 2; i < text10.Length; i++)
-							{
-								//get the column corresponding with the source group number stored in sg_numbers
-								string sg_temp = text10[i];
-								for (int itm1 = 0; itm1 < maxsource; itm1++)
-								{
-									if (sg_numbers[itm1] == Convert.ToInt32(sg_temp))
-									{
-										sg_time[itm1] = i;
+                // read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
+                newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
+                if (File.Exists(newpath) == true)
+                {
+                    try
+                    {
+                        //read timeseries of emissions
+                        string[] text10 = new string[1];
+                        using (StreamReader read1 = new StreamReader(newpath))
+                        {
+                            //get source group numbers
+                            text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
+                            for (int i = 2; i < text10.Length; i++)
+                            {
+                                //get the column corresponding with the source group number stored in sg_numbers
+                                string sg_temp = text10[i];
+                                for (int itm1 = 0; itm1 < maxsource; itm1++)
+                                {
+                                    if (sg_numbers[itm1] == Convert.ToInt32(sg_temp))
+                                    {
+                                        sg_time[itm1] = i;
 
-										//set emifac_day and emifac_mon equal one -> only for those source groups that are defined in emissions_timeseries.txt
-										for (int j = 0; j < 24; j++)
-										{
-											emifac_day[j, itm1] = 1;
-											if (j < 12)
-												emifac_mon[j, itm1] = 1;
-										}
-									}
-								}
+                                        //set emifac_day and emifac_mon equal one -> only for those source groups that are defined in emissions_timeseries.txt
+                                        for (int j = 0; j < 24; j++)
+                                        {
+                                            emifac_day[j, itm1] = 1;
+                                            if (j < 12)
+                                                emifac_mon[j, itm1] = 1;
+                                        }
+                                    }
+                                }
 
-							}
+                            }
 
-							for (int i = 0; i < mettimefilelength; i++)
-							{
-								text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
-								for (int n = 0; n < maxsource; n++)
-								{
-									if (sg_time[n] == 0)
-									{
-										emifac_timeseries[i, n] = 1;
-									}
-									else
-									{
-										emifac_timeseries[i, n] = Convert.ToDouble(text10[sg_time[n]].Replace(".", decsep));
-									}
-								}
-							}
-						}
-						
-					}
-					catch(Exception ex)
-					{
-						BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
-						return;
-					}
-				} // read value from emissions_timeseries.txt
-			}
-			
-			List<string> wgmet = new List<string>();
-			List<string> wrmet = new List<string>();
-			List<string> akmet = new List<string>();
-			string[] text3 = new string[2];
-			int hourplus = 0;
-			string wgmettime;
-			string wrmettime;
-			string akmettime;
-			string month;
-			string hour;
-			string day;
-			
-			List<string> rec_names=new List<string>();
-			
-			//get number of receptor points and names of receptors
-			string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
-			if(File.Exists(receptorfile))
-			{
-				try
-				{
-					using(StreamReader read=new StreamReader(receptorfile))
-					{
-						dummy=read.ReadLine(); // 1st line with number of receptor points
-						
-						while (read.EndOfStream == false)
-						{
-							text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-							
-							if (text.Length > 1) // valid line?
-							{
-								xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
-								
-								string a = text[0]; 	// take number as name
-								if (text.Length > 4) 	// get name from line
-									a = text[4];   
-								
-								if (text.Length >= 5) // if the Receptor-Name contains ","
-								{
-									for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
-									{
-										if (text[k] != "") a = a + "_" + text[k];
-									}
-								}
-								
-								// if the receptor name contains invalid characters for a file!
-								a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
-								rec_names.Add(a);
-							}
-						}
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error reading Receptor.dat");
-					return;
-				}
-				
-			}
-			
-			//MessageBox.Show(Convert.ToString(rec_names.Count));
-			
-			//read meteopgt.all
-			newpath = Path.Combine("Computation","meteopgt.all");
-			using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-			{
-				text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				while (myReader.EndOfStream == false)
-				{
-					try
-					{
-						text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-						wrmet.Add(text[0]);
-						wgmet.Add(text[1]);
-						akmet.Add(text[2]);
-					}
-					catch
-					{
-						BackgroundThreadMessageBox ("Error reading meteopgt.all");
-						return;
-					}
-				}
-			}
-			
-			double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
-			                                            => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
-			                                                                     => new double[wrmet.Count]));
-			double fmod = 1;
+                            for (int i = 0; i < mettimefilelength; i++)
+                            {
+                                text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
+                                for (int n = 0; n < maxsource; n++)
+                                {
+                                    if (sg_time[n] == 0)
+                                    {
+                                        emifac_timeseries[i, n] = 1;
+                                    }
+                                    else
+                                    {
+                                        emifac_timeseries[i, n] = Convert.ToDouble(text10[sg_time[n]].Replace(".", decsep));
+                                    }
+                                }
+                            }
+                        }
+                        
+                    }
+                    catch(Exception ex)
+                    {
+                        BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
+                        return;
+                    }
+                } // read value from emissions_timeseries.txt
+            }
+            
+            List<string> wgmet = new List<string>();
+            List<string> wrmet = new List<string>();
+            List<string> akmet = new List<string>();
+            string[] text3 = new string[2];
+            int hourplus = 0;
+            string wgmettime;
+            string wrmettime;
+            string akmettime;
+            string month;
+            string hour;
+            string day;
+            
+            List<string> rec_names=new List<string>();
+            
+            //get number of receptor points and names of receptors
+            string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
+            if(File.Exists(receptorfile))
+            {
+                try
+                {
+                    using(StreamReader read=new StreamReader(receptorfile))
+                    {
+                        dummy=read.ReadLine(); // 1st line with number of receptor points
+                        
+                        while (read.EndOfStream == false)
+                        {
+                            text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                            
+                            if (text.Length > 1) // valid line?
+                            {
+                                xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
+                                
+                                string a = text[0]; 	// take number as name
+                                if (text.Length > 4) 	// get name from line
+                                    a = text[4];   
+                                
+                                if (text.Length >= 5) // if the Receptor-Name contains ","
+                                {
+                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
+                                    {
+                                        if (text[k] != "") a = a + "_" + text[k];
+                                    }
+                                }
+                                
+                                // if the receptor name contains invalid characters for a file!
+                                a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
+                                rec_names.Add(a);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error reading Receptor.dat");
+                    return;
+                }
+                
+            }
+            
+            //MessageBox.Show(Convert.ToString(rec_names.Count));
+            
+            //read meteopgt.all
+            newpath = Path.Combine("Computation","meteopgt.all");
+            using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+            {
+                text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                while (myReader.EndOfStream == false)
+                {
+                    try
+                    {
+                        text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        wrmet.Add(text[0]);
+                        wgmet.Add(text[1]);
+                        akmet.Add(text[2]);
+                    }
+                    catch
+                    {
+                        BackgroundThreadMessageBox ("Error reading meteopgt.all");
+                        return;
+                    }
+                }
+            }
+            
+            double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
+                                                        => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
+                                                                                 => new double[wrmet.Count]));
+            double fmod = 1;
 
-			//read all computed concentrations from file zeitreihe.dat
-			bool zeitflag = false;
-			string[] text5 = new string[xrec.Count * sg_names.Length];
-			int numbwet = 0;
-			receptorfile=Path.Combine(mydata.Projectname, "Computation","zeitreihe.dat");
-			if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
-			{
-				zeitflag = true;
-				
-				try
-				{
+            //read all computed concentrations from file zeitreihe.dat
+            bool zeitflag = false;
+            string[] text5 = new string[xrec.Count * sg_names.Length];
+            int numbwet = 0;
+            receptorfile=Path.Combine(mydata.Projectname, "Computation","zeitreihe.dat");
+            if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
+            {
+                zeitflag = true;
+                
+                try
+                {
                     using (StreamReader read = new StreamReader(receptorfile))
                     {
                         while (read.EndOfStream == false)
@@ -321,8 +321,12 @@ namespace GralBackgroundworkers
 
                                 for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
                                 {
-                                    conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
-                                    count++;
+                                    //check if this situation has been computed, otherwise this line is 0
+                                    if (text5.Length > count)
+                                    {
+                                        conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
+                                        count++;
+                                    }
                                 }
                             }
                             numbwet++;
@@ -330,185 +334,182 @@ namespace GralBackgroundworkers
                     }
                 }
                 catch
-				{
-					BackgroundThreadMessageBox ("Error reading zeitreihe.dat. Is this file available?" + Environment.NewLine +
-												"Has the number of receptors or source groups changed?");
-					return;
-				}
-				
-				
-			}
-			
-			//read all wind speeds from file GRAL_Meteozeitreihe.dat
-			bool metflag = false;
-			bool local_SCL = false;
-			string[] text7 = new string[xrec.Count];
-			
-			string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
-			int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
-			
-			double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-			double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-			int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+                {
+                    BackgroundThreadMessageBox ("Error reading zeitreihe.dat. Is this file available?" + Environment.NewLine +
+                                                "Has the number of receptors or source groups changed?");
+                    return;
+                }			
+            }
+            
+            //read all wind speeds from file GRAL_Meteozeitreihe.dat
+            bool metflag = false;
+            bool local_SCL = false;
+            string[] text7 = new string[xrec.Count];
+            
+            string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
+            int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
+            
+            double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
             string[] ReceptorMeteoCoors = new string[5];
-			
-			if (File.Exists(GRAL_metfile))
-			{
-				metflag = true;
-				numbwet = 0;
-				
-				if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
-				{
+            
+            if (File.Exists(GRAL_metfile))
+            {
+                metflag = true;
+                numbwet = 0;
+                
+                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
+                {
                     metflag = false;
-				}
-			}
+                }
+            }
 
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				if (zeitflag == true) // write mettime series for all receptor points
-				{
-					try
-					{
-						string file = Path.Combine(mydata.Projectname, "Computation","Receptor_timeseries_"+ mydata.Prefix + mydata.Pollutant + ".txt");
-						if (File.Exists(file))
-						{
-							try
-							{
-								File.Delete(file);
-							}
-							catch{}
-						}
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                if (zeitflag == true) // write mettime series for all receptor points
+                {
+                    try
+                    {
+                        string file = Path.Combine(mydata.Projectname, "Computation","Receptor_timeseries_"+ mydata.Prefix + mydata.Pollutant + ".txt");
+                        if (File.Exists(file))
+                        {
+                            try
+                            {
+                                File.Delete(file);
+                            }
+                            catch{}
+                        }
 
-						//write results to file receptor_timeseries.txt
-						using (StreamWriter recwrite = new StreamWriter(file))
-						{
-							//write header line
-							string[] text6 = new string[2];
-							//write source groups
-							recwrite.Write("Date \t Time \t"); // Header Date, Time
-							
-							foreach (string hy in sg_names)
-							{
-								for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-								{
-									text6 = hy.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-									recwrite.Write(text6[0]+"-Rec:"+Convert.ToString(numbrec+1) + "\t"); // Header source-groups use Tabulator
-								}
-							}
-							recwrite.WriteLine();
-							
-							//read mettimeseries.dat
-							newpath = Path.Combine("Computation", "mettimeseries.dat");
-							StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath));
-							text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-							text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                        //write results to file receptor_timeseries.txt
+                        using (StreamWriter recwrite = new StreamWriter(file))
+                        {
+                            //write header line
+                            string[] text6 = new string[2];
+                            //write source groups
+                            recwrite.Write("Date \t Time \t"); // Header Date, Time
+                            
+                            foreach (string hy in sg_names)
+                            {
+                                for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                                {
+                                    text6 = hy.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                                    recwrite.Write(text6[0]+"-Rec:"+Convert.ToString(numbrec+1) + "\t"); // Header source-groups use Tabulator
+                                }
+                            }
+                            recwrite.WriteLine();
+                            
+                            //read mettimeseries.dat
+                            newpath = Path.Combine("Computation", "mettimeseries.dat");
+                            StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath));
+                            text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                            text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
 
-							//consider, if meteopgt.all represents a time series or a statistics
-							int dispersionsituations = 0;
-							if (mydata.Checkbox19 == true)
-								dispersionsituations = numbwet + 1;
-							else
-								dispersionsituations = wrmet.Count;
-							
-							int count_dispsit_in_mettime = 0;
-							int count_ws = -1;
+                            //consider, if meteopgt.all represents a time series or a statistics
+                            int dispersionsituations = 0;
+                            if (mydata.Checkbox19 == true)
+                                dispersionsituations = numbwet + 1;
+                            else
+                                dispersionsituations = wrmet.Count;
+                            
+                            int count_dispsit_in_mettime = 0;
+                            int count_ws = -1;
 
-							while (text2[0] != "")
-							{
-								count_ws++;
-								count_dispsit_in_mettime += 1;
-								
-								if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
-									break;
+                            while (text2[0] != "")
+                            {
+                                count_ws++;
+                                count_dispsit_in_mettime += 1;
+                                
+                                if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
+                                    break;
 
-								month = text3[1];
-								day = text3[0];
-								hour = text2[1];
-								if (hour == "24")
-									hourplus = 1;
-								wgmettime = text2[2];
-								wrmettime = text2[3];
-								akmettime = text2[4];
+                                month = text3[1];
+                                day = text3[0];
+                                hour = text2[1];
+                                if (hour == "24")
+                                    hourplus = 1;
+                                wgmettime = text2[2];
+                                wrmettime = text2[3];
+                                akmettime = text2[4];
 
-								//search in file meteopgt.all for the corresponding dispersion situation
+                                //search in file meteopgt.all for the corresponding dispersion situation
 
-								for (int n = 0; n < dispersionsituations; n++)
-								{
-									if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
-									{
-										//take care if not all dispersion situations have been computed
-										if (n >= numbwet)
-										{
-											//write results
-											dummy = "";
-											recwrite.WriteLine(dummy);
-										}
-										else
-										{
-											SetText("Day.Month: " + day + "." + month);
-											
-											int std = Convert.ToInt32(hour);
-											int mon = Convert.ToInt32(month) - 1;
+                                for (int n = 0; n < dispersionsituations; n++)
+                                {
+                                    if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                    {
+                                        //take care if not all dispersion situations have been computed
+                                        if (n >= numbwet)
+                                        {
+                                            //write results
+                                            dummy = "";
+                                            recwrite.WriteLine(dummy);
+                                        }
+                                        else
+                                        {
+                                            SetText("Day.Month: " + day + "." + month);
+                                            
+                                            int std = Convert.ToInt32(hour);
+                                            int mon = Convert.ToInt32(month) - 1;
 
-											//write results
-											dummy = "";
-											dummy = day + "." + month + "\t" + hour+":00\t";
-											fmod = 1;
-											foreach (string hy in sg_names)
-											{
-												{
-													int itm = Convert.ToInt32(GetSgNumbers(hy)) - 1;
-													
-													//compute emission modulation factor
-													fmod = emifac_day[std - hourplus, itm] * emifac_mon[mon, itm] * emifac_timeseries[count_ws, itm];
-													
-													for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-													{
-													    dummy = dummy + Convert.ToString(conc[numbrec][itm][n] * fmod) + "\t";
-													}
-												}
-												
-											}
-											recwrite.WriteLine(dummy);
-											//consider, if meteopgt.all represents a time series or a statistics
-											if (mydata.Checkbox19 == true)
-												break;
-										}
-									}
-								}
-								try
-								{
-									text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-									text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-								}
-								catch
-								{
-									break;
-								}
-							}
-							
-						} // using
-					}
-					catch
-					{
-						BackgroundThreadMessageBox ("Error writing the file receptor_timeseries.txt");
-						return;
-					}
-				}
-				else
-				{
-					BackgroundThreadMessageBox ("File zeitreihe.dat not found");
-				}
-			}
-			
-			if (metflag == true) // write meteorological data for all receptor points
-			{
+                                            //write results
+                                            dummy = "";
+                                            dummy = day + "." + month + "\t" + hour+":00\t";
+                                            fmod = 1;
+                                            foreach (string hy in sg_names)
+                                            {
+                                                {
+                                                    int itm = Convert.ToInt32(GetSgNumbers(hy)) - 1;
+                                                    
+                                                    //compute emission modulation factor
+                                                    fmod = emifac_day[std - hourplus, itm] * emifac_mon[mon, itm] * emifac_timeseries[count_ws, itm];
+                                                    
+                                                    for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                                                    {
+                                                        dummy = dummy + Convert.ToString(conc[numbrec][itm][n] * fmod) + "\t";
+                                                    }
+                                                }										
+                                            }
+                                            recwrite.WriteLine(dummy);
+                                            //consider, if meteopgt.all represents a time series or a statistics
+                                            if (mydata.Checkbox19 == true)
+                                                break;
+                                        }
+                                    }
+                                }
+                                try
+                                {
+                                    text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                    text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                }
+                                catch
+                                {
+                                    break;
+                                }
+                            }
+                            
+                        } // using
+                    }
+                    catch
+                    {
+                        BackgroundThreadMessageBox ("Error writing the file receptor_timeseries.txt");
+                        return;
+                    }
+                }
+                else
+                {
+                    BackgroundThreadMessageBox ("File zeitreihe.dat not found");
+                }
+            }
+            
+            if (metflag == true) // write meteorological data for all receptor points
+            {
                 try
                 {
-                    string[] recname = new string[0];
-                    string[] recX = new string[0];
-                    string[] recY = new string[0];
-                    string[] recZ = new string[0];
+                    string[] recname = Array.Empty<string>();
+                    string[] recX = Array.Empty<string>();
+                    string[] recY = Array.Empty<string>();
+                    string[] recZ = Array.Empty<string>();
                    
                     if (!string.IsNullOrEmpty(ReceptorMeteoCoors[0]))
                     {
@@ -553,171 +554,170 @@ namespace GralBackgroundworkers
                                 catch { }
                             }
 
-							string[] text6 = new string[2];
+                            string[] text6 = new string[2];
 
-							//read mettimeseries.dat
-							newpath = Path.Combine("Computation", "mettimeseries.dat");
-							
-							using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-							{
-								text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-								text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-								string dummy_year = "1990";
-								int year_increase=0;
-								int monthold = -1;
+                            //read mettimeseries.dat
+                            newpath = Path.Combine("Computation", "mettimeseries.dat");
+                            
+                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                            {
+                                text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                string dummy_year = "1990";
+                                int year_increase=0;
+                                int monthold = -1;
 
-								//consider, if meteopgt.all represents a time series or a statistics
-								int dispersionsituations = 0;
-								if (mydata.Checkbox19 == true || transient == true)
-									dispersionsituations = numbwet + 1;
-								else
-									dispersionsituations = wrmet.Count;
-								
-								int count_dispsit_in_mettime = 0;
+                                //consider, if meteopgt.all represents a time series or a statistics
+                                int dispersionsituations = 0;
+                                if (mydata.Checkbox19 == true || transient == true)
+                                    dispersionsituations = numbwet + 1;
+                                else
+                                    dispersionsituations = wrmet.Count;
+                                
+                                int count_dispsit_in_mettime = 0;
 
-								while (text2[0] != "")
-								{
-									count_dispsit_in_mettime++;
-									if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
-										break;
+                                while (!string.IsNullOrEmpty(text2[0]))
+                                {
+                                    count_dispsit_in_mettime++;
+                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
+                                        break;
 
-									month = text3[1];
-									day = text3[0];
-									hour = text2[1];
-									if (hour == "24")
-										hourplus = 1;
-									wgmettime = text2[2];
-									wrmettime = text2[3];
-									akmettime = text2[4];
+                                    month = text3[1];
+                                    day = text3[0];
+                                    hour = text2[1];
+                                    if (hour == "24")
+                                        hourplus = 1;
+                                    wgmettime = text2[2];
+                                    wrmettime = text2[3];
+                                    akmettime = text2[4];
 
-									//artificially increase year by one
-									if (Convert.ToInt32(month) < monthold)
-										year_increase += 1;
-									monthold = Convert.ToInt32(text3[1]);
+                                    //artificially increase year by one
+                                    if (Convert.ToInt32(month) < monthold)
+                                        year_increase += 1;
+                                    monthold = Convert.ToInt32(text3[1]);
 
-									int corr_situation = 0;
-									
-									if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
-									{
-										//search in file meteopgt.all for the corresponding dispersion situation
-										for (int n = 0; n < dispersionsituations; n++)
-										{
-											if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
-											{
-												//take care if not all dispersion situations have been computed
-												if (n >= numbwet)
-												{
-													//write results
-													//dummy = "";
-													//recwrite.WriteLine(dummy);
-												}
-												else
-												{
-													corr_situation = n;
-													break;
-												}
-											}
-										}
-									}
-									else // transient mode: situation = line number of mettimeseries 
-									{
-										corr_situation = count_dispsit_in_mettime;
-									}
-									
-									if (corr_situation > 0)
-									{
-										int n  = corr_situation;
-										SetText("Day.Month: " + day + "." + month);
-										
-										int std = Convert.ToInt32(hour);
-										int mon = Convert.ToInt32(month) - 1;
+                                    int corr_situation = 0;
+                                    
+                                    if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
+                                    {
+                                        //search in file meteopgt.all for the corresponding dispersion situation
+                                        for (int n = 0; n < dispersionsituations; n++)
+                                        {
+                                            if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                            {
+                                                //take care if not all dispersion situations have been computed
+                                                if (n >= numbwet)
+                                                {
+                                                    //write results
+                                                    //dummy = "";
+                                                    //recwrite.WriteLine(dummy);
+                                                }
+                                                else
+                                                {
+                                                    corr_situation = n;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    else // transient mode: situation = line number of mettimeseries 
+                                    {
+                                        corr_situation = count_dispsit_in_mettime;
+                                    }
+                                    
+                                    if (corr_situation > 0)
+                                    {
+                                        int n  = corr_situation;
+                                        SetText("Day.Month: " + day + "." + month);
+                                        
+                                        int std = Convert.ToInt32(hour);
+                                        int mon = Convert.ToInt32(month) - 1;
 
-										//write results
-										dummy = "";
-										dummy_year = Convert.ToString(1990 + year_increase);
-										dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
-										//compute wind speed and direction
-										windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
-										if (GRAL_v[k,n] == 0)
-											winddirection_GRAL = 90;
-										else
-											winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
-										if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
-											winddirection_GRAL = 180 - winddirection_GRAL;
-										if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
-											winddirection_GRAL = 180 + winddirection_GRAL;
-										if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
-											winddirection_GRAL = 360 - winddirection_GRAL;
+                                        //write results
+                                        dummy = "";
+                                        dummy_year = Convert.ToString(1990 + year_increase);
+                                        dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
+                                        //compute wind speed and direction
+                                        windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
+                                        if (GRAL_v[k,n] == 0)
+                                            winddirection_GRAL = 90;
+                                        else
+                                            winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
+                                        if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
+                                            winddirection_GRAL = 180 - winddirection_GRAL;
+                                        if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
+                                            winddirection_GRAL = 180 + winddirection_GRAL;
+                                        if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
+                                            winddirection_GRAL = 360 - winddirection_GRAL;
 
-										dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
+                                        dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
 
-										if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
-										{
-											if (GRAL_SC[k, n] > 0) // if this situation is not available yet
-											{
-												dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
-											}
-											else
-											{
-												dummy = dummy + "," + Convert.ToString(akmettime);
-											}
-										}
-										else
-										{
-											dummy = dummy + "," + Convert.ToString(akmettime);
-										}
-										
-										recwrite.WriteLine(dummy);
-										//consider, if meteopgt.all represents a time series or a statistics
+                                        if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
+                                        {
+                                            if (GRAL_SC[k, n] > 0) // if this situation is not available yet
+                                            {
+                                                dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
+                                            }
+                                            else
+                                            {
+                                                dummy = dummy + "," + Convert.ToString(akmettime);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            dummy = dummy + "," + Convert.ToString(akmettime);
+                                        }
+                                        
+                                        recwrite.WriteLine(dummy);
+                                        //consider, if meteopgt.all represents a time series or a statistics
 //										if (mydata.Checkbox19 == true || transient == true)
 //											break;
-									}
-									try
-									{
-										text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-										text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-									}
-									catch
-									{
-										break;
-									}
-								}
-							} // using read
-						} // using recwrite
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error writing GRAL-Metfiles");
-					return;
-				}
-				
-			}
-			else
-			{
-				//MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-		}
-		
-		private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
+                                    }
+                                    try
+                                    {
+                                        text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                        text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                    }
+                                    catch
+                                    {
+                                        break;
+                                    }
+                                }
+                            } // using read
+                        } // using recwrite
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error writing GRAL-Metfiles");
+                    return;
+                }
+                
+            }
+            else
+            {
+                //MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        
+        private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
-		{
-			string[] text7 = new string[1];
-			numbwet = 1;
+        {
+            numbwet = 1;
             int ParamOffset = 2; // old file format
             int headerLineNumber = 0;
 
-			try // 11.9.2017 Kuntner -> new File format?
-			{
-				using(StreamReader read1 = new StreamReader(GRAL_metfile))
-				{
+            try // 11.9.2017 Kuntner -> new File format?
+            {
+                using(StreamReader read1 = new StreamReader(GRAL_metfile))
+                {
                     string header = read1.ReadLine().Trim();
                     if (header.Equals("U,V,SC"))
-					{
-						local_SCL = true;
+                    {
+                        local_SCL = true;
                         ParamOffset = 3; // U,V,SC
                         headerLineNumber = 1;
-					}
+                    }
                     else if (header.StartsWith("U,V,SC,BLH"))
                     {
                         local_SCL = true;
@@ -732,17 +732,17 @@ namespace GralBackgroundworkers
                     }
                     if (header.EndsWith("+")) // Additional header lines for name and coordinates of receptors
                     {
-                        headerLineNumber = 5;
+                        headerLineNumber = 6;
                     }
                 }
-			}
-			catch{}
-				
-			using (StreamReader read = new StreamReader(GRAL_metfile))
-			{
-				try
-				{
-					if (headerLineNumber > 0) // Read header lines
+            }
+            catch{}
+                
+            using (StreamReader read = new StreamReader(GRAL_metfile))
+            {
+                 try
+                {
+                    if (headerLineNumber > 0) // Read header lines
                     {
                         ReceptorHeader = new string[headerLineNumber + 1];
 
@@ -760,39 +760,43 @@ namespace GralBackgroundworkers
                             }
                         }
                     }
-					
+                    
                     // read entire file
-					while (read.EndOfStream == false)
-					{
-						text7 = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-						int count = 0;
-						for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-						{
-							GRAL_u[numbrec, numbwet] = Convert.ToDouble(text7[count], ic);
-							GRAL_v[numbrec, numbwet] = Convert.ToDouble(text7[count + 1], ic);
-							if (local_SCL) // 11.9.2017 Kuntner -> new File format
-							{
-								GRAL_SC[numbrec, numbwet] = Convert.ToInt32(text7[count + 2], ic);
-								count += ParamOffset;
-							}
-							else
-							{
-								count += ParamOffset;
-							}
-						}
-						numbwet++;
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
-					return false;
-				}
-			}
-			
-			Computation_Completed = true; // set flag, that computation was successful
-			return true;
-		} // Read_GRAL_Meteozeitreihe
-		
-	}
+                    while (read.EndOfStream == false)
+                    {
+                        string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        int count = 0;
+                        for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                        {
+                            //check if this situation has been computed, otherwise this line is 0
+                            if (columns.Length > count + 2)
+                            {
+                                GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
+                                GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);
+                                if (local_SCL) // 11.9.2017 Kuntner -> new File format
+                                {
+                                    GRAL_SC[numbrec, numbwet] = Convert.ToInt32(columns[count + 2], ic);
+                                    count += ParamOffset;
+                                }
+                                else
+                                {
+                                    count += ParamOffset;
+                                }
+                            }
+                        }
+                        numbwet++;
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
+                    return false;
+                }
+            }
+            
+            Computation_Completed = true; // set flag, that computation was successful
+            return true;
+        } // Read_GRAL_Meteozeitreihe
+        
+    }
 }

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -18,14 +18,14 @@
  * 
  * To change this template use Tools | Options | Coding | Edit Standard Headers.
  */
-using System;
-using System.IO;
-using System.Collections.Generic;
 using GralIO;
+using System;
+using System.Collections.Generic;
+using System.IO;
 
 namespace GralBackgroundworkers
 {
-    public partial class ProgressFormBackgroundworker
+	public partial class ProgressFormBackgroundworker
 	{
     	private string decsep;
     	private List<double> xrec = new List<double>();
@@ -128,7 +128,7 @@ namespace GralBackgroundworkers
 			}
 			if (mettimefilelength == 0) // File-lenght must > 0
 			{
-				BackgroundThreadMessageBox ("Can´t read mettimeseries.txt");
+				BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
 				return; // leave method
 			}
 			//mettimefilelength--;
@@ -202,7 +202,7 @@ namespace GralBackgroundworkers
 					}
 					catch(Exception ex)
 					{
-						BackgroundThreadMessageBox (ex.Message + " Can´t read emissions_timeseries.txt - evaluation stopped");
+						BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
 						return;
 					}
 				} // read value from emissions_timeseries.txt
@@ -261,7 +261,7 @@ namespace GralBackgroundworkers
 				}
 				catch
 				{
-					BackgroundThreadMessageBox ("Can´t read Receptor.dat");
+					BackgroundThreadMessageBox ("Error reading Receptor.dat");
 					return;
 				}
 				
@@ -286,7 +286,7 @@ namespace GralBackgroundworkers
 					}
 					catch
 					{
-						BackgroundThreadMessageBox ("Can´t read meteopgt.all");
+						BackgroundThreadMessageBox ("Error reading meteopgt.all");
 						return;
 					}
 				}
@@ -305,33 +305,38 @@ namespace GralBackgroundworkers
 			if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
 			{
 				zeitflag = true;
-				StreamReader read = new StreamReader(receptorfile);
+				
 				try
 				{
-					while (read.EndOfStream == false)
-					{
-						text5 = read.ReadLine().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-						int count = 0;
-						// read all conc data of all computed source-groups
-						for (int numbsource = 0; numbsource < maxcomputedsourcegroup; numbsource++)
-						{
-							int sg_number = Convert.ToInt32(computed_sourcegroups[numbsource]) - 1; // Source-Group Number of computed sourcegroups
-							
-							for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-							{
-							    conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
-								count = count + 1;
-							}
-						}
-						numbwet = numbwet + 1;
-					}
-				}
-				catch
+                    using (StreamReader read = new StreamReader(receptorfile))
+                    {
+                        while (read.EndOfStream == false)
+                        {
+                            text5 = read.ReadLine().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                            int count = 0;
+                            // read all conc data of all computed source-groups
+                            for (int numbsource = 0; numbsource < maxcomputedsourcegroup; numbsource++)
+                            {
+                                int sg_number = Convert.ToInt32(computed_sourcegroups[numbsource]) - 1; // Source-Group Number of computed sourcegroups
+
+                                for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                                {
+                                    conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
+                                    count++;
+                                }
+                            }
+                            numbwet++;
+                        }
+                    }
+                }
+                catch
 				{
-					BackgroundThreadMessageBox ("Can´t read zeitreihe.dat");
+					BackgroundThreadMessageBox ("Error reading zeitreihe.dat. Is this file available?" + Environment.NewLine +
+												"Has the number of receptors or source groups changed?");
 					return;
 				}
-				read.Close();
+				
+				
 			}
 			
 			//read all wind speeds from file GRAL_Meteozeitreihe.dat
@@ -374,7 +379,7 @@ namespace GralBackgroundworkers
 							catch{}
 						}
 
-						//write results to file receptor_timeseries.dat
+						//write results to file receptor_timeseries.txt
 						using (StreamWriter recwrite = new StreamWriter(file))
 						{
 							//write header line
@@ -411,7 +416,7 @@ namespace GralBackgroundworkers
 							while (text2[0] != "")
 							{
 								count_ws++;
-								count_dispsit_in_mettime = count_dispsit_in_mettime + 1;
+								count_dispsit_in_mettime += 1;
 								
 								if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
 									break;
@@ -486,7 +491,7 @@ namespace GralBackgroundworkers
 					}
 					catch
 					{
-						BackgroundThreadMessageBox ("Can´t write receptor_timeseries.txt");
+						BackgroundThreadMessageBox ("Error writing the file receptor_timeseries.txt");
 						return;
 					}
 				}
@@ -559,7 +564,7 @@ namespace GralBackgroundworkers
 
 									//artificially increase year by one
 									if (Convert.ToInt32(month) < monthold)
-										year_increase = year_increase + 1;
+										year_increase += 1;
 									monthold = Convert.ToInt32(text3[1]);
 
 									int corr_situation = 0;
@@ -655,7 +660,7 @@ namespace GralBackgroundworkers
 				}
 				catch
 				{
-					BackgroundThreadMessageBox ("Can´t write GRAL-Metfiles");
+					BackgroundThreadMessageBox ("Error writing GRAL-Metfiles");
 					return;
 				}
 				
@@ -703,11 +708,11 @@ namespace GralBackgroundworkers
 							if (local_SCL) // 11.9.2017 Kuntner -> new File format
 							{
 								GRAL_SC[numbrec, numbwet] = Convert.ToInt32(text7[count + 2].Replace(".", decsep));
-								count = count + 3;
+								count += 3;
 							}
 							else
 							{
-								count = count + 2;
+								count += 2;
 							}
 						}
 						numbwet++;
@@ -715,7 +720,7 @@ namespace GralBackgroundworkers
 				}
 				catch
 				{
-					BackgroundThreadMessageBox ("Can´t read GRAL_Meteozeitreihe.dat");
+					BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
 					return false;
 				}
 			}

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -704,7 +704,7 @@ namespace GralBackgroundworkers
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
         {
             numbwet = 1;
-            int ParamOffset = 2; // old file format
+            int columnOffset = 2; // old file format
             int headerLineNumber = 0;
 
             try // 11.9.2017 Kuntner -> new File format?
@@ -715,19 +715,19 @@ namespace GralBackgroundworkers
                     if (header.Equals("U,V,SC"))
                     {
                         local_SCL = true;
-                        ParamOffset = 3; // U,V,SC
+                        columnOffset = 3; // U,V,SC
                         headerLineNumber = 1;
                     }
                     else if (header.StartsWith("U,V,SC,BLH"))
                     {
                         local_SCL = true;
-                        ParamOffset = 4; // U,V,SC,BLH
+                        columnOffset = 4; // U,V,SC,BLH
                         headerLineNumber = 1;
                     }
                     else if (header.StartsWith("U,V,BLH"))
                     {
                         local_SCL = false;
-                        ParamOffset = 3; //U,V,BLH
+                        columnOffset = 3; //U,V,BLH
                         headerLineNumber = 1;
                     }
                     if (header.EndsWith("+")) // Additional header lines for name and coordinates of receptors
@@ -765,23 +765,21 @@ namespace GralBackgroundworkers
                     while (read.EndOfStream == false)
                     {
                         string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        int numberOfReceptors = (int)(columns.Length / columnOffset);
                         int count = 0;
-                        for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                        
+                        for (int numbrec = 0; numbrec < numberOfReceptors; numbrec++)
                         {
                             //check if this situation has been computed, otherwise this line is 0
-                            if (columns.Length > count + 2)
+                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= numberOfReceptors)
                             {
                                 GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
                                 GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);
                                 if (local_SCL) // 11.9.2017 Kuntner -> new File format
                                 {
                                     GRAL_SC[numbrec, numbwet] = Convert.ToInt32(columns[count + 2], ic);
-                                    count += ParamOffset;
                                 }
-                                else
-                                {
-                                    count += ParamOffset;
-                                }
+                                count += columnOffset;
                             }
                         }
                         numbwet++;

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -675,15 +675,22 @@ namespace GralBackgroundworkers
 		{
 			string[] text7 = new string[1];
 			numbwet = 1;
-			
+            int ParamOffset = 2; // old file format
 			try // 11.9.2017 Kuntner -> new File format?
 			{
 				using(StreamReader read1 = new StreamReader(GRAL_metfile))
 				{
-					if (read1.ReadLine().Trim() == "U,V,SC")
+                    string header = read1.ReadLine().Trim();
+                    if (header.Equals("U,V,SC"))
 					{
 						local_SCL = true;
+                        ParamOffset = 3; // U,V,SC
 					}
+                    else if (header.Equals("U,V,SC,BLH"))
+                    {
+                        local_SCL = true;
+                        ParamOffset = 4; // U,V,SC,BLH
+                    }
 				}
 			}
 			catch{}
@@ -703,16 +710,16 @@ namespace GralBackgroundworkers
 						int count = 0;
 						for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
 						{
-							GRAL_u[numbrec, numbwet] = Convert.ToDouble(text7[count].Replace(".", decsep));
-							GRAL_v[numbrec, numbwet] = Convert.ToDouble(text7[count + 1].Replace(".", decsep));
+							GRAL_u[numbrec, numbwet] = Convert.ToDouble(text7[count], ic);
+							GRAL_v[numbrec, numbwet] = Convert.ToDouble(text7[count + 1], ic);
 							if (local_SCL) // 11.9.2017 Kuntner -> new File format
 							{
-								GRAL_SC[numbrec, numbwet] = Convert.ToInt32(text7[count + 2].Replace(".", decsep));
-								count += 3;
+								GRAL_SC[numbrec, numbwet] = Convert.ToInt32(text7[count + 2], ic);
+								count += ParamOffset;
 							}
 							else
 							{
-								count += 2;
+								count += ParamOffset;
 							}
 						}
 						numbwet++;

--- a/Source/Gral/GRALData/DrawingObject.cs
+++ b/Source/Gral/GRALData/DrawingObject.cs
@@ -457,6 +457,7 @@ namespace GralDomain
                 FillYesNo = true;
                 ShpPoints = new List<PointF>();
                 ItemInfo = new List<string>();
+                ContourLabelDist = 0;
             }
             else
             {

--- a/Source/Gral/GRALData/DrawingObject.cs
+++ b/Source/Gral/GRALData/DrawingObject.cs
@@ -213,6 +213,10 @@ namespace GralDomain
         /// list of polygons when importing shape files
         /// </summary>
         public List<GralShape.SHPPolygon> ShpPolygons { get; set; }
+        /// <summary>
+        /// list of strings for item infos
+        /// </summary>
+        public List<string> ItemInfo { get; set; }
 
         private bool disposed = false;
 
@@ -437,7 +441,7 @@ namespace GralDomain
                 ItemValues.Add(0);
                 LineColors.Add(Color.Black);
             }
-            else if (_name.StartsWith("CONCENTRATION VALUES"))
+            else if (_name.StartsWith("CONCENTRATION VALUES") || _name.StartsWith("ITEM INFO"))
             {
                 FillColors.Add(Color.Transparent);
                 ItemValues.Add(0);
@@ -451,6 +455,8 @@ namespace GralDomain
                 LineWidth = 4;
                 Fill = true;
                 FillYesNo = true;
+                ShpPoints = new List<PointF>();
+                ItemInfo = new List<string>();
             }
             else
             {
@@ -559,7 +565,6 @@ namespace GralDomain
             }
             disposed = true;
         }
-
 
         /// <summary>
         /// Class for the DrawObject countour geometry

--- a/Source/Gral/GRALData/PointD_3d.cs
+++ b/Source/Gral/GRALData/PointD_3d.cs
@@ -19,6 +19,7 @@
  * To change this template use Tools | Options | Coding | Edit Standard Headers.
  */
 using System;
+using System.Globalization;
 
 namespace GralData
 {
@@ -33,9 +34,35 @@ namespace GralData
 		
 		public PointD_3d(double x, double y, double z)
 		{
-			X = x; 
-			Y = y;
-			Z = z;
+			X = Math.Round(x, 1); 
+			Y = Math.Round(y, 1);
+			Z = Math.Round(z, 1);
+		}
+		public PointD_3d(string x, string y, string z, CultureInfo cul)
+		{
+			X = Math.Round(Convert.ToDouble(x, cul), 1);
+			Y = Math.Round(Convert.ToDouble(y, cul), 1);
+			Z = Math.Round(Convert.ToDouble(z, cul), 1);
+		}		
+		public GralDomain.PointD ToPointD()
+		{
+			return new GralDomain.PointD(X, Y);
+		}
+		public override bool Equals(object obj)
+		{
+			return obj is PointD_3d && this == (PointD_3d)obj;
+		}
+		public override int GetHashCode()
+		{
+			return X.GetHashCode() ^ Y.GetHashCode() ^ Z.GetHashCode();
+		}
+		public static bool operator ==(PointD_3d a, PointD_3d b)
+		{
+			return a.X == b.X && a.Y == b.Y && a.Z == b.Z;
+		}
+		public static bool operator !=(PointD_3d a, PointD_3d b)
+		{
+			return !(a == b);
 		}
 	}
 }

--- a/Source/Gral/GRALData/PointD_3d.cs
+++ b/Source/Gral/GRALData/PointD_3d.cs
@@ -48,6 +48,10 @@ namespace GralData
 		{
 			return new GralDomain.PointD(X, Y);
 		}
+		public System.Drawing.PointF ToPointF()
+		{
+			return new System.Drawing.PointF((float)X, (float)Y);
+		}
 		public override bool Equals(object obj)
 		{
 			return obj is PointD_3d && this == (PointD_3d)obj;

--- a/Source/Gral/GRALDomForms/Dispersionsituation.Designer.cs
+++ b/Source/Gral/GRALDomForms/Dispersionsituation.Designer.cs
@@ -34,6 +34,7 @@
             this.radioButton2 = new System.Windows.Forms.RadioButton();
             this.radioButton1 = new System.Windows.Forms.RadioButton();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
+            this.showSituations = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -67,19 +68,20 @@
             this.groupBox1.Controls.Add(this.radioButton1);
             this.groupBox1.Location = new System.Drawing.Point(13, 272);
             this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(327, 43);
+            this.groupBox1.Size = new System.Drawing.Size(183, 43);
             this.groupBox1.TabIndex = 2;
             this.groupBox1.TabStop = false;
             // 
             // radioButton2
             // 
-            this.radioButton2.Location = new System.Drawing.Point(236, 13);
+            this.radioButton2.Location = new System.Drawing.Point(108, 13);
             this.radioButton2.Name = "radioButton2";
-            this.radioButton2.Size = new System.Drawing.Size(85, 24);
+            this.radioButton2.Size = new System.Drawing.Size(69, 24);
             this.radioButton2.TabIndex = 0;
             this.radioButton2.TabStop = true;
             this.radioButton2.Text = "GRAL";
             this.radioButton2.UseVisualStyleBackColor = true;
+            this.radioButton2.CheckedChanged += new System.EventHandler(this.radioButton2_CheckedChanged);
             // 
             // radioButton1
             // 
@@ -90,6 +92,7 @@
             this.radioButton1.TabStop = true;
             this.radioButton1.Text = "GRAMM";
             this.radioButton1.UseVisualStyleBackColor = true;
+            this.radioButton1.CheckedChanged += new System.EventHandler(this.radioButton1_CheckedChanged);
             // 
             // dataGridView1
             // 
@@ -105,6 +108,18 @@
             this.dataGridView1.TabIndex = 3;
             this.dataGridView1.RowHeaderMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridView1RowHeaderMouseDoubleClick);
             // 
+            // showSituations
+            // 
+            this.showSituations.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.showSituations.AutoSize = true;
+            this.showSituations.Location = new System.Drawing.Point(214, 288);
+            this.showSituations.Name = "showSituations";
+            this.showSituations.Size = new System.Drawing.Size(113, 17);
+            this.showSituations.TabIndex = 4;
+            this.showSituations.Text = "Show all situations";
+            this.showSituations.UseVisualStyleBackColor = true;
+            this.showSituations.CheckedChanged += new System.EventHandler(this.showSituations_CheckedChanged);
+            // 
             // SelectDispersionSituation
             // 
             this.AcceptButton = this.button1;
@@ -113,6 +128,7 @@
             this.CancelButton = this.button2;
             this.ClientSize = new System.Drawing.Size(352, 353);
             this.ControlBox = false;
+            this.Controls.Add(this.showSituations);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.button2);
@@ -125,6 +141,7 @@
             this.groupBox1.ResumeLayout(false);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.ResumeLayout(false);
+            this.PerformLayout();
 
         }
         private System.Windows.Forms.DataGridView dataGridView1;
@@ -136,5 +153,6 @@
         #endregion
 
         public System.Windows.Forms.Button button1;
+        private System.Windows.Forms.CheckBox showSituations;
     }
 }

--- a/Source/Gral/GRALDomForms/Dispersionsituation.Designer.cs
+++ b/Source/Gral/GRALDomForms/Dispersionsituation.Designer.cs
@@ -35,6 +35,8 @@
             this.radioButton1 = new System.Windows.Forms.RadioButton();
             this.dataGridView1 = new System.Windows.Forms.DataGridView();
             this.showSituations = new System.Windows.Forms.CheckBox();
+            this.label1 = new System.Windows.Forms.Label();
+            this.textBox1 = new System.Windows.Forms.TextBox();
             this.groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.SuspendLayout();
@@ -42,7 +44,7 @@
             // button1
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.button1.Location = new System.Drawing.Point(12, 321);
+            this.button1.Location = new System.Drawing.Point(12, 365);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(75, 23);
             this.button1.TabIndex = 1;
@@ -54,7 +56,7 @@
             // 
             this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(265, 321);
+            this.button2.Location = new System.Drawing.Point(265, 365);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(75, 23);
             this.button2.TabIndex = 1;
@@ -64,9 +66,10 @@
             // 
             // groupBox1
             // 
+            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.groupBox1.Controls.Add(this.radioButton2);
             this.groupBox1.Controls.Add(this.radioButton1);
-            this.groupBox1.Location = new System.Drawing.Point(13, 272);
+            this.groupBox1.Location = new System.Drawing.Point(13, 316);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Size = new System.Drawing.Size(183, 43);
             this.groupBox1.TabIndex = 2;
@@ -112,7 +115,7 @@
             // 
             this.showSituations.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.showSituations.AutoSize = true;
-            this.showSituations.Location = new System.Drawing.Point(214, 288);
+            this.showSituations.Location = new System.Drawing.Point(214, 332);
             this.showSituations.Name = "showSituations";
             this.showSituations.Size = new System.Drawing.Size(113, 17);
             this.showSituations.TabIndex = 4;
@@ -120,14 +123,35 @@
             this.showSituations.UseVisualStyleBackColor = true;
             this.showSituations.CheckedChanged += new System.EventHandler(this.showSituations_CheckedChanged);
             // 
+            // label1
+            // 
+            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.label1.AutoSize = true;
+            this.label1.Location = new System.Drawing.Point(12, 272);
+            this.label1.Name = "label1";
+            this.label1.Size = new System.Drawing.Size(29, 13);
+            this.label1.TabIndex = 5;
+            this.label1.Text = "Path";
+            // 
+            // textBox1
+            // 
+            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.textBox1.Location = new System.Drawing.Point(15, 289);
+            this.textBox1.Name = "textBox1";
+            this.textBox1.ReadOnly = true;
+            this.textBox1.Size = new System.Drawing.Size(325, 20);
+            this.textBox1.TabIndex = 6;
+            // 
             // SelectDispersionSituation
             // 
             this.AcceptButton = this.button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.button2;
-            this.ClientSize = new System.Drawing.Size(352, 353);
+            this.ClientSize = new System.Drawing.Size(352, 397);
             this.ControlBox = false;
+            this.Controls.Add(this.textBox1);
+            this.Controls.Add(this.label1);
             this.Controls.Add(this.showSituations);
             this.Controls.Add(this.dataGridView1);
             this.Controls.Add(this.groupBox1);
@@ -154,5 +178,7 @@
 
         public System.Windows.Forms.Button button1;
         private System.Windows.Forms.CheckBox showSituations;
+        private System.Windows.Forms.Label label1;
+        private System.Windows.Forms.TextBox textBox1;
     }
 }

--- a/Source/Gral/GRALDomForms/Dispersionsituation.cs
+++ b/Source/Gral/GRALDomForms/Dispersionsituation.cs
@@ -127,21 +127,25 @@ namespace GralDomForms
             string decsep = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
 
             int selectentries = 0;
-            if (radioButton1.Checked && GrammPath != String.Empty)
+            if (radioButton1.Checked && !string.IsNullOrEmpty(GrammPath))
             {
                 selectentries = 1;
+                textBox1.Text = GrammPath;
             }
-            if (radioButton2.Checked && GFFPath != String.Empty)
+            if (radioButton2.Checked && !string.IsNullOrEmpty(GFFPath))
             {
                 selectentries = 2;
+                textBox1.Text = GFFPath;
             }
-            if (radioButton1.Checked && SCLPath != String.Empty)
+            if (radioButton1.Checked && !string.IsNullOrEmpty(SCLPath))
             {
                 selectentries = 3;
+                textBox1.Text = SCLPath;
             }
-            if (radioButton2.Checked && GRZPath != String.Empty)
+            if (radioButton2.Checked && !string.IsNullOrEmpty(GRZPath))
             {
                 selectentries = 4;
+                textBox1.Text = GRZPath;
             }
             
             //read file meteopgt.all
@@ -324,7 +328,8 @@ namespace GralDomForms
         void DispersionsituationResizeEnd (object sender, EventArgs e)
         {
             dataGridView1.Width = ClientSize.Width - 5;
-            dataGridView1.Height = Math.Max (30, ClientSize.Height - 75);
+            dataGridView1.Height = Math.Max (10, label1.Top - 5);
+            textBox1.Width = Math.Max(5, ClientSize.Width - textBox1.Left  - 15);
         }
 
         void button2_Click (object sender, EventArgs e) // Cancel

--- a/Source/Gral/GRALDomForms/Dispersionsituation.cs
+++ b/Source/Gral/GRALDomForms/Dispersionsituation.cs
@@ -21,264 +21,337 @@ using GralIO;
 
 namespace GralDomForms
 {
-	/// <summary>
+    /// <summary>
     /// Select a dispersion situation
     /// </summary>
     public partial class SelectDispersionSituation : Form
-	{
-		private GralDomain.Domain domain = null;
-		private Main form1 = null;
-		private DataTable _data;
-		public int selected_situation = 0;
-		public int selectGRAMM_GRAL = 0;
+    {
+        private readonly GralDomain.Domain domain = null;
+        private readonly Main form1 = null;
+        private DataTable _data;
+        public int selected_situation = 0;
+        public int selectGRAMM_GRAL = 0;
+        public string GrammPath = string.Empty;
+        public string SCLPath = string.Empty;
+        public string GRZPath = string.Empty;
+        public string GFFPath = string.Empty;
+        private bool transient = false;
 
-		public SelectDispersionSituation (GralDomain.Domain d, Main f)
-		{
-			InitializeComponent ();
-			domain = d;
-			form1 = f;
-			button1.DialogResult = DialogResult.OK;
-			button2.DialogResult = DialogResult.Cancel;
-		}
+        public SelectDispersionSituation (GralDomain.Domain d, Main f)
+        {
+            InitializeComponent ();
+            domain = d;
+            form1 = f;
+            button1.DialogResult = DialogResult.OK;
+            button2.DialogResult = DialogResult.Cancel;
+        }
 
-		private void Dispersionsituation_Load (object sender, EventArgs e)
-		{
-		    if (selectGRAMM_GRAL == 0)
-		    {
-		        groupBox1.Visible = false;
-		    }
-		    else if (selectGRAMM_GRAL == 1) // GRAMM
-		    {
-		        groupBox1.Visible = true;
-		        radioButton1.Checked = true;
-		    }
-		    else if (selectGRAMM_GRAL == 2) // GRAL only
-		    {
-		        groupBox1.Visible = true;
-		        radioButton1.Visible = false;
-		        radioButton2.Checked = true;
-		    }
+        private void Dispersionsituation_Load (object sender, EventArgs e)
+        {
+            if (selectGRAMM_GRAL == 0)
+            {
+                groupBox1.Visible = false;
+                if (GrammPath != string.Empty || SCLPath != string.Empty)
+                {
+                    radioButton1.Checked = true;
+                }
+                else if (GFFPath != string.Empty || GRZPath != string.Empty)
+                {
+                    radioButton2.Checked = true;
+                }
+            }
+            else if (selectGRAMM_GRAL == 1) // GRAMM
+            {
+                groupBox1.Visible = true;
+                radioButton1.Checked = true;
+            }
+            else if (selectGRAMM_GRAL == 2) // GRAL only
+            {
+                groupBox1.Visible = true;
+                radioButton1.Visible = false;
+                radioButton2.Checked = true;
+            }
 
             //in case of steady-state simulations meteopgt.all is used in transient simulations mettimeseries.dat
-			bool transient = false;
-			try 
-			{
-				InDatVariables data = new InDatVariables ();
-				InDatFileIO ReadInData = new InDatFileIO ();
-				data.InDatPath = Path.Combine (Main.ProjectName, "Computation", "in.dat");
-				ReadInData.Data = data;
-				if (ReadInData.ReadInDat () == true && form1.checkBox19.Checked == true) // Transient mode & no classification 
-				{
-					if (data.Transientflag == 0) 
-					{
-						transient = true;
-					}
-				}
-			} 
-			catch { }
-			
-			if (transient)
-			{
-			    //fill Listbox
-			    _data = new DataTable ();
-			    _data.Columns.Add ("Number", typeof (string));
-			    _data.Columns.Add ("Date", typeof (string));
-			    _data.Columns.Add ("Hour", typeof (string));
-			    _data.Columns.Add ("Wind speed", typeof (string));
-			    _data.Columns.Add ("Wind sector", typeof (string));
-			    _data.Columns.Add ("Stability class", typeof (string));
-			}
-			else
-			{
-			    //fill Listbox
-			    _data = new DataTable ();
-			    _data.Columns.Add ("Number", typeof (string));
-			    _data.Columns.Add ("Wind sector", typeof (string));
-			    _data.Columns.Add ("Wind speed", typeof (string));
-			    _data.Columns.Add ("Stability class", typeof (string));
-			    _data.Columns.Add ("Frequency [1/1000]", typeof (string));
-			}
+            
+            try 
+            {
+                InDatVariables data = new InDatVariables ();
+                InDatFileIO ReadInData = new InDatFileIO ();
+                data.InDatPath = Path.Combine (Main.ProjectName, "Computation", "in.dat");
+                ReadInData.Data = data;
+                if (ReadInData.ReadInDat () == true && form1.checkBox19.Checked == true) // Transient mode & no classification 
+                {
+                    if (data.Transientflag == 0) 
+                    {
+                        transient = true;
+                    }
+                }
+            } 
+            catch { }
+            
+            if (transient)
+            {
+                //fill Listbox
+                _data = new DataTable ();
+                _data.Columns.Add ("Number", typeof (string));
+                _data.Columns.Add ("Date", typeof (string));
+                _data.Columns.Add ("Hour", typeof (string));
+                _data.Columns.Add ("Wind speed", typeof (string));
+                _data.Columns.Add ("Wind sector", typeof (string));
+                _data.Columns.Add ("Stability class", typeof (string));
+            }
+            else
+            {
+                //fill Listbox
+                _data = new DataTable ();
+                _data.Columns.Add ("Number", typeof (string));
+                _data.Columns.Add ("Wind sector", typeof (string));
+                _data.Columns.Add ("Wind speed", typeof (string));
+                _data.Columns.Add ("Stability class", typeof (string));
+                _data.Columns.Add ("Frequency [1/1000]", typeof (string));
+            }
 
-			string decsep = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
-			//read file meteopgt.all
-			if (transient == false) 
-			{
-				string ggeom_file = Path.Combine (Main.ProjectName, @"Computation", "meteopgt.all");
-				if (File.Exists (ggeom_file) == false) {
-					MessageBox.Show (this, "Unable to open meteopgt.all", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-					Close ();
-				}
-				try {
-					using (StreamReader myreader = new StreamReader (ggeom_file)) {
-						string [] text = new string [5];
-						int count = 0;
-						text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						while (text [0] != "") 
-						{
-						    if (text.Length > 3)
-						    {
-						        count = count + 1;
+            AddGridViewEntries();
+        }
 
-						        DataRow workrow;
-						        workrow = _data.NewRow ();
-						        workrow [0] = count.ToString ();
-						        float direction = 0;
-						        if (float.TryParse (text [0].Replace (".", decsep), out direction)) 
-						        {
-						            workrow [1] = (direction * 10).ToString ();
-						        } 
-						        else 
-						        {
-						            workrow [1] = text [0];
-						        }
-						        workrow [2] = text [1].Replace (".", decsep);
-						        workrow [3] = text [2].Replace (".", decsep);
-						        workrow [4] = text [3].Replace (".", decsep);
-						        _data.Rows.Add (workrow);
-						    }
-						    try
-						    {
-						        text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						    }
-						    catch
-						    {
-						        break;
-						    }
-						}
-					}
-				}
-				catch { }
-			}
-			else
-			{
-				string ggeom_file = Path.Combine (Main.ProjectName, @"Computation", "mettimeseries.dat");
-				if (File.Exists (ggeom_file) == false) {
-					MessageBox.Show (this, "Unable to open mettimeseries.dat", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-					Close ();
-				}
-				try {
-					using (StreamReader myreader = new StreamReader (ggeom_file)) {
-						string [] text = new string [5];
-						int count = 0;
-						text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						while (text [0] != "")
-						{
-						    if (text.Length > 3)
-						    {
-						        count = count + 1;
-						        DataRow workrow;
-						        workrow = _data.NewRow ();
-						        workrow [0] = count.ToString ();
+        private void AddGridViewEntries()
+        {
+            dataGridView1.SelectionChanged -= new System.EventHandler(DataGridView1SelectionChanged);
+            dataGridView1.DataSource = null;
+            if (_data != null)
+            {
+                _data.Clear();
+            }
 
-						        float direction = 0;
-						        if (float.TryParse (text [3].Replace (".", decsep), out direction)) 
-						        {
-						            workrow [4] = (direction * 10).ToString ();
-						        }
-						        else
-						        {
-						            workrow [4] = text [3];
-						        }
-						        workrow [1] = text [0];
-						        workrow [2] = text [1].Replace (".", decsep);
-						        workrow [3] = text [2].Replace (".", decsep);
-						        workrow [5] = text [4].Replace (".", decsep);
-						        _data.Rows.Add (workrow);
-						    }
-						    try
-						    {
-						        text = myreader.ReadLine ().Split (new char [] { ' ', ';', ',', '\t' });
-						    } 
-						    catch
-						    {
-						        break;
-						    }
-						}
-					}
-				} 
-				catch { }
-			}
-			DataView datasorted = new DataView ();
-			datasorted = new DataView (_data); // create DataView from DataTable
-			dataGridView1.DataSource = datasorted; // connect DataView to GridView
-			dataGridView1.ColumnHeadersHeight = 26;
-			dataGridView1.Columns.Cast<DataGridViewColumn> ().ToList ().ForEach (f => f.SortMode = DataGridViewColumnSortMode.NotSortable);
-			dataGridView1.ColumnHeadersDefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+            string decsep = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
 
-			dataGridView1.Columns [0].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
-			dataGridView1.Columns [0].Width = 45;
-			for (int i = 1; i < 5; i++) {
-				dataGridView1.Columns [i].Width = 60;
-				dataGridView1.Columns [i].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
-			}
-			dataGridView1.SelectionChanged += new System.EventHandler (DataGridView1SelectionChanged);
-		}
+            int selectentries = 0;
+            if (radioButton1.Checked && GrammPath != String.Empty)
+            {
+                selectentries = 1;
+            }
+            if (radioButton2.Checked && GFFPath != String.Empty)
+            {
+                selectentries = 2;
+            }
+            if (radioButton1.Checked && SCLPath != String.Empty)
+            {
+                selectentries = 3;
+            }
+            if (radioButton2.Checked && GRZPath != String.Empty)
+            {
+                selectentries = 4;
+            }
+            
+            //read file meteopgt.all
+            if (transient == false)
+            {
+                string ggeom_file = Path.Combine(Main.ProjectName, @"Computation", "meteopgt.all");
+                if (File.Exists(ggeom_file) == false)
+                {
+                    MessageBox.Show(this, "Unable to open meteopgt.all", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                    Close();
+                }
+                try
+                {
+                    using (StreamReader myreader = new StreamReader(ggeom_file))
+                    {
+                        string[] text = new string[5];
+                        int count = 0;
+                        text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
+                        text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
+                        text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
 
-		private void button1_Click (object sender, EventArgs e)
-		{
-			try {
+                        while (text[0] != "")
+                        {
+                            if (text.Length > 3)
+                            {
+                                count = count + 1;
+
+                                // select existing situations
+                                if (showSituations.Checked || selectentries == 0 ||
+                                                          (selectentries == 1 && File.Exists(Path.Combine(GrammPath, Convert.ToString(count).PadLeft(5, '0') + ".wnd"))) ||
+                                                          (selectentries == 2 && File.Exists(Path.Combine(GFFPath, Convert.ToString(count).PadLeft(5, '0') + ".gff"))) ||
+                                                          (selectentries == 3 && File.Exists(Path.Combine(SCLPath, Convert.ToString(count).PadLeft(5, '0') + ".scl"))) ||
+                                                          (selectentries == 4 && File.Exists(Path.Combine(GRZPath, Convert.ToString(count).PadLeft(5, '0') + ".grz"))))
+                                {
+                                    DataRow workrow;
+                                    workrow = _data.NewRow();
+                                    workrow[0] = count.ToString();
+                                    float direction = 0;
+                                    if (float.TryParse(text[0].Replace(".", decsep), out direction))
+                                    {
+                                        workrow[1] = (direction * 10).ToString();
+                                    }
+                                    else
+                                    {
+                                        workrow[1] = text[0];
+                                    }
+                                    workrow[2] = text[1].Replace(".", decsep);
+                                    workrow[3] = text[2].Replace(".", decsep);
+                                    workrow[4] = text[3].Replace(".", decsep);
+                                    _data.Rows.Add(workrow);
+                                }
+                            }
+                            try
+                            {
+                                text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
+                            }
+                            catch
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch { }
+            }
+            else
+            {
+                string ggeom_file = Path.Combine(Main.ProjectName, @"Computation", "mettimeseries.dat");
+                if (File.Exists(ggeom_file) == false)
+                {
+                    MessageBox.Show(this, "Unable to open mettimeseries.dat", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                    Close();
+                }
+                try
+                {
+                    using (StreamReader myreader = new StreamReader(ggeom_file))
+                    {
+                        string[] text = new string[5];
+                        int count = 0;
+                        text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
+                        while (text[0] != "")
+                        {
+                            if (text.Length > 3)
+                            {
+                                count = count + 1;
+
+                                // select existing situations
+                                if (showSituations.Checked || selectentries == 0 || 
+                                                          (selectentries == 1 && File.Exists(Path.Combine(GrammPath, Convert.ToString(count).PadLeft(5, '0') + ".wnd"))) ||
+                                                          (selectentries == 2 && File.Exists(Path.Combine(GFFPath, Convert.ToString(count).PadLeft(5, '0') + ".gff"))) ||
+                                                          (selectentries == 3 && File.Exists(Path.Combine(SCLPath, Convert.ToString(count).PadLeft(5, '0') + ".scl"))) ||
+                                                          (selectentries == 4 && File.Exists(Path.Combine(GRZPath, Convert.ToString(count).PadLeft(5, '0') + ".grz"))))
+                                {
+                                    DataRow workrow;
+                                    workrow = _data.NewRow();
+                                    workrow[0] = count.ToString();
+
+                                    float direction = 0;
+                                    if (float.TryParse(text[3].Replace(".", decsep), out direction))
+                                    {
+                                        workrow[4] = (direction * 10).ToString();
+                                    }
+                                    else
+                                    {
+                                        workrow[4] = text[3];
+                                    }
+                                    workrow[1] = text[0];
+                                    workrow[2] = text[1].Replace(".", decsep);
+                                    workrow[3] = text[2].Replace(".", decsep);
+                                    workrow[5] = text[4].Replace(".", decsep);
+                                    _data.Rows.Add(workrow);
+                                }
+                            }
+                            try
+                            {
+                                text = myreader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' });
+                            }
+                            catch
+                            {
+                                break;
+                            }
+                        }
+                    }
+                }
+                catch { }
+            }
+            
+            if (_data != null && _data.Rows.Count > 0)
+            {
+                DataView datasorted = new DataView();
+                datasorted = new DataView(_data); // create DataView from DataTable
+                dataGridView1.DataSource = datasorted; // connect DataView to GridView
+                dataGridView1.ColumnHeadersHeight = 26;
+                dataGridView1.Columns.Cast<DataGridViewColumn>().ToList().ForEach(f => f.SortMode = DataGridViewColumnSortMode.NotSortable);
+                dataGridView1.ColumnHeadersDefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
+
+                dataGridView1.Columns[0].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+                dataGridView1.Columns[0].Width = 45;
+                for (int i = 1; i < 5; i++)
+                {
+                    dataGridView1.Columns[i].Width = 60;
+                    dataGridView1.Columns[i].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
+                }
+                dataGridView1.SelectionChanged += new System.EventHandler(DataGridView1SelectionChanged);
+            }
+        }
+
+        private void button1_Click (object sender, EventArgs e)
+        {
+            try {
 #if __MonoCS__
 #else
-				selected_situation = Convert.ToInt32 (dataGridView1.Rows [dataGridView1.SelectedCells [0].RowIndex].Cells [0].Value);
+                selected_situation = Convert.ToInt32 (dataGridView1.Rows [dataGridView1.SelectedCells [0].RowIndex].Cells [0].Value);
 #endif
-				if (radioButton1.Checked)
-					selectGRAMM_GRAL = 1;
-				else if (radioButton2.Checked)
-					selectGRAMM_GRAL = 2;
-				else
-				    selectGRAMM_GRAL = 0;
-				//this.Close();
-			} 
-			catch
-			{
-				MessageBox.Show (this, "No situation selected", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				//domain.dissit = 0;
-				selected_situation = 0;
-			}
+                if (radioButton1.Checked)
+                    selectGRAMM_GRAL = 1;
+                else if (radioButton2.Checked)
+                    selectGRAMM_GRAL = 2;
+                else
+                    selectGRAMM_GRAL = 0;
+                //this.Close();
+            } 
+            catch
+            {
+                MessageBox.Show (this, "No situation selected", "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                //domain.dissit = 0;
+                selected_situation = 0;
+            }
 #if __MonoCS__
 #else
-			dataGridView1.DataSource = null;
+            dataGridView1.DataSource = null;
 
-			dataGridView1.Rows.Clear();
-        	_data.Dispose();
-        	_data = null;
-        	dataGridView1.Dispose();
-#endif
-		}
-
-		void DispersionsituationResizeEnd (object sender, EventArgs e)
-		{
-			dataGridView1.Width = ClientSize.Width - 5;
-			dataGridView1.Height = Math.Max (30, ClientSize.Height - 75);
-		}
-
-		void button2_Click (object sender, EventArgs e) // Cancel
-		{
-			selected_situation = 0;
-#if __MonoCS__
-#else
-        	dataGridView1.DataSource = null;
-        	dataGridView1.Rows.Clear();
-        	_data.Dispose();
-        	_data = null;
-        	dataGridView1.Dispose();
+            dataGridView1.Rows.Clear();
+            _data.Dispose();
+            _data = null;
+            dataGridView1.Dispose();
 #endif
         }
 
-		// Change the selection of the datagridview for LINUX compatibility
-		void DataGridView1SelectionChanged (object sender, EventArgs e)
-		{
-			if (dataGridView1.SelectedRows.Count == 0) // no rows selected
-			{
-				//selected_situation = 0;
-			} 
-			else
-			{
-				selected_situation = dataGridView1.SelectedRows[0].Index + 1;
-			}         
-		}
+        void DispersionsituationResizeEnd (object sender, EventArgs e)
+        {
+            dataGridView1.Width = ClientSize.Width - 5;
+            dataGridView1.Height = Math.Max (30, ClientSize.Height - 75);
+        }
+
+        void button2_Click (object sender, EventArgs e) // Cancel
+        {
+            selected_situation = 0;
+#if __MonoCS__
+#else
+            dataGridView1.DataSource = null;
+            dataGridView1.Rows.Clear();
+            _data.Dispose();
+            _data = null;
+            dataGridView1.Dispose();
+#endif
+        }
+
+        // Change the selection of the datagridview for LINUX compatibility
+        void DataGridView1SelectionChanged (object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count == 0) // no rows selected
+            {
+                //selected_situation = 0;
+            } 
+            else
+            {
+                selected_situation = Convert.ToInt32(dataGridView1.SelectedRows[0].Cells[0].Value);
+            }         
+        }
 
         void DispersionsituationFormClosed(object sender, FormClosedEventArgs e)
         {
@@ -293,14 +366,28 @@ namespace GralDomForms
                 dataGridView1.Dispose();
             }
         }
-        
-       
+            
         void DataGridView1RowHeaderMouseDoubleClick(object sender, DataGridViewCellMouseEventArgs e)
         {
             selected_situation = dataGridView1.SelectedRows[0].Index + 1;
             button1_Click(null, null);
             DialogResult = DialogResult.OK;
             Close();
+        }
+
+        private void radioButton1_CheckedChanged(object sender, EventArgs e)
+        {
+            AddGridViewEntries();
+        }
+
+        private void radioButton2_CheckedChanged(object sender, EventArgs e)
+        {
+            //AddGridViewEntries();
+        }
+
+        private void showSituations_CheckedChanged(object sender, EventArgs e)
+        {
+            AddGridViewEntries();
         }
     }
 }

--- a/Source/Gral/GRALDomForms/MatchMultipleObservations.cs
+++ b/Source/Gral/GRALDomForms/MatchMultipleObservations.cs
@@ -714,7 +714,7 @@ namespace GralDomForms
             {
                 RemoveLine = -999;
                 dataGridView1.ClearSelection();
-                // send delegate - Message to domain Form, that match process should start
+                // send delegate - Message to domain Form, that wind data should be selected by the user
                 try
                 {
                     if (LoadWindData != null)

--- a/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.Designer.cs
+++ b/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.Designer.cs
@@ -160,6 +160,7 @@
             // 
             // listView1
             // 
+            this.listView1.HideSelection = false;
             this.listView1.Location = new System.Drawing.Point(28, 220);
             this.listView1.Name = "listView1";
             this.listView1.Size = new System.Drawing.Size(283, 134);

--- a/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.cs
+++ b/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.cs
@@ -74,15 +74,15 @@ namespace GralDomForms
 			int n1 = 0;
 			foreach(WindData wd in winddata)
 			{
-				MMOData.Date[n1] = wd.Date;
+				MMOData.GetDate()[n1] = wd.Date;
 				
 				if (n1 < index) // fill preview
 				{
 					//read met file finally
-					MMOData.Time[n1] = wd.Time;
-					MMOData.WindVel[n1] = wd.Vel;
-					MMOData.WindDir[n1] = wd.Dir;
-					MMOData.SC[n1] = wd.StabClass;
+					MMOData.GetTime()[n1] = wd.Time;
+					MMOData.GetWindVel()[n1] = wd.Vel;
+					MMOData.GetWindDir()[n1] = wd.Dir;
+					MMOData.GetSC()[n1] = wd.StabClass;
 					
 					ListViewItem item = new ListViewItem(wd.Date);
 					//if (zeile.GetLength(0) > 4)
@@ -106,8 +106,8 @@ namespace GralDomForms
           	//show month calender to select the desired time period of the time series
             try
             {
-                StartDate = MMOData.Date[0].Split(new char[] { '.', ':', '-' });
-                EndDate = MMOData.Date[FileLength1 - 1].Split(new char[] { '.', ':', '-' });
+                StartDate = MMOData.GetDate()[0].Split(new char[] { '.', ':', '-' });
+                EndDate = MMOData.GetDate()[FileLength1 - 1].Split(new char[] { '.', ':', '-' });
                 if (Convert.ToInt16(StartDate[2]) < 1900)
                 {
                     if (Convert.ToInt32(StartDate[2]) < 60)
@@ -193,27 +193,27 @@ namespace GralDomForms
 					    ((Convert.ToInt32(date[2]) * 10000 + Convert.ToInt16(date[1]) * 100 + Convert.ToInt16(date[0])) <= (Convert.ToInt32(EndDate[2]) * 10000 + Convert.ToInt16(EndDate[1]) * 100 + Convert.ToInt16(EndDate[0]))))
 					{
 						
-						MMOData.Date[length] = wd.Date;
-						MMOData.Time[length] = wd.Time;
-						MMOData.WindVel[length] = wd.Vel;
-						MMOData.WindDir[length] = wd.Dir;
-						MMOData.SC[length] = wd.StabClass;
-						MMOData.Hour[length] = wd.Hour;
+						MMOData.GetDate()[length] = wd.Date;
+						MMOData.GetTime()[length] = wd.Time;
+						MMOData.GetWindVel()[length] = wd.Vel;
+						MMOData.GetWindDir()[length] = wd.Dir;
+						MMOData.GetSC()[length] = wd.StabClass;
+						MMOData.GetHour()[length] = wd.Hour;
 						
 						//check for unplausible values
-						if(MMOData.WindVel[length]>55||MMOData.WindVel[length]<0)
+						if(MMOData.GetWindVel()[length]>55||MMOData.GetWindVel()[length]<0)
 						{
 							if (error_count < 4)
 								MessageBox.Show(this, "Wind speed implausible - check line number" + Convert.ToString(n1 + 1), "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
 							error_count++;
 						}
-						else if (MMOData.WindDir[length] > 360 || MMOData.WindDir[length] < 0)
+						else if (MMOData.GetWindDir()[length] > 360 || MMOData.GetWindDir()[length] < 0)
 						{
 							if (error_count < 4)
 								MessageBox.Show(this, "Wind direction implausible - check line number" + Convert.ToString(n1 + 1), "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
 							error_count++;
 						}
-						else if (MMOData.SC[length] > 7 || MMOData.SC[length] < 1)
+						else if (MMOData.GetSC()[length] > 7 || MMOData.GetSC()[length] < 1)
 						{
 							if (error_count < 4)
 								MessageBox.Show(this, "Stability class implausible - check line number" + Convert.ToString(n1 + 1), "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);

--- a/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.cs
+++ b/Source/Gral/GRALDomForms/MeteoInput_Matchlocalobs.cs
@@ -33,6 +33,7 @@ namespace GralDomForms
         public GralItemData.MatchMeteoData MMOData;
         public string[] StartDate = new string[3];
         public string[] EndDate = new string[3];
+        public double Anemometerheight;
 
         public MeteoInput_Matchlocalobs()
         {
@@ -274,6 +275,10 @@ namespace GralDomForms
         	if (Owner != null)
         		Location = new Point(Math.Max(0,Owner.Location.X + Owner.Width / 2 - Width / 2 - 100),
         		                    Math.Max(0, Owner.Location.Y + Owner.Height / 2 - Height / 2 -100));
+            if (Anemometerheight > 0)
+            {
+                numericUpDown1.Value = (decimal) Anemometerheight;
+            }
         }
 
         //select start date for met data input

--- a/Source/Gral/GRALDomForms/Search_Item.Designer.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.Designer.cs
@@ -51,6 +51,8 @@ namespace GralDomForms
             this.label1 = new System.Windows.Forms.Label();
             this.button2 = new System.Windows.Forms.Button();
             this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+            this.button3 = new System.Windows.Forms.Button();
+            this.button4 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
@@ -60,21 +62,22 @@ namespace GralDomForms
             this.dataGridView1.AllowUserToAddRows = false;
             this.dataGridView1.AllowUserToDeleteRows = false;
             this.dataGridView1.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.dataGridView1.Location = new System.Drawing.Point(9, 54);
+            this.dataGridView1.Location = new System.Drawing.Point(0, 54);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(2);
             this.dataGridView1.MinimumSize = new System.Drawing.Size(338, 81);
             this.dataGridView1.Name = "dataGridView1";
-            this.dataGridView1.ReadOnly = true;
             this.dataGridView1.RowTemplate.Height = 24;
-            this.dataGridView1.Size = new System.Drawing.Size(589, 271);
+            this.dataGridView1.Size = new System.Drawing.Size(721, 271);
             this.dataGridView1.TabIndex = 0;
             this.dataGridView1.ColumnHeaderMouseClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridView1ColumnHeaderMouseClick);
+            this.dataGridView1.DataError += new System.Windows.Forms.DataGridViewDataErrorEventHandler(this.dataGridView1_DataError);
             this.dataGridView1.RowHeaderMouseDoubleClick += new System.Windows.Forms.DataGridViewCellMouseEventHandler(this.DataGridView1RowHeaderMouseDoubleClick);
+            this.dataGridView1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.dataGridView1_KeyDown);
             // 
             // button1
             // 
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.button1.Location = new System.Drawing.Point(26, 356);
+            this.button1.Location = new System.Drawing.Point(10, 373);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(121, 27);
@@ -85,7 +88,7 @@ namespace GralDomForms
             // 
             // label2
             // 
-            this.label2.Location = new System.Drawing.Point(16, 13);
+            this.label2.Location = new System.Drawing.Point(16, 15);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(41, 19);
@@ -97,14 +100,14 @@ namespace GralDomForms
             this.textBox1.Location = new System.Drawing.Point(62, 12);
             this.textBox1.Margin = new System.Windows.Forms.Padding(2);
             this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(76, 20);
+            this.textBox1.Size = new System.Drawing.Size(134, 20);
             this.textBox1.TabIndex = 4;
             this.toolTip1.SetToolTip(this.textBox1, "Item name");
             this.textBox1.TextChanged += new System.EventHandler(this.TextBox1TextChanged);
             // 
             // label3
             // 
-            this.label3.Location = new System.Drawing.Point(158, 13);
+            this.label3.Location = new System.Drawing.Point(235, 15);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(42, 19);
@@ -113,7 +116,7 @@ namespace GralDomForms
             // 
             // textBox2
             // 
-            this.textBox2.Location = new System.Drawing.Point(204, 12);
+            this.textBox2.Location = new System.Drawing.Point(281, 12);
             this.textBox2.Margin = new System.Windows.Forms.Padding(2);
             this.textBox2.Name = "textBox2";
             this.textBox2.Size = new System.Drawing.Size(76, 20);
@@ -123,7 +126,7 @@ namespace GralDomForms
             // 
             // label4
             // 
-            this.label4.Location = new System.Drawing.Point(309, 13);
+            this.label4.Location = new System.Drawing.Point(412, 15);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(52, 19);
@@ -132,7 +135,7 @@ namespace GralDomForms
             // 
             // textBox3
             // 
-            this.textBox3.Location = new System.Drawing.Point(366, 12);
+            this.textBox3.Location = new System.Drawing.Point(469, 12);
             this.textBox3.Margin = new System.Windows.Forms.Padding(2);
             this.textBox3.Name = "textBox3";
             this.textBox3.Size = new System.Drawing.Size(76, 20);
@@ -154,14 +157,14 @@ namespace GralDomForms
             this.groupBox1.Margin = new System.Windows.Forms.Padding(2);
             this.groupBox1.Name = "groupBox1";
             this.groupBox1.Padding = new System.Windows.Forms.Padding(2);
-            this.groupBox1.Size = new System.Drawing.Size(589, 40);
+            this.groupBox1.Size = new System.Drawing.Size(721, 40);
             this.groupBox1.TabIndex = 5;
             this.groupBox1.TabStop = false;
             this.groupBox1.Text = "Filter";
             // 
             // textBox4
             // 
-            this.textBox4.Location = new System.Drawing.Point(509, 12);
+            this.textBox4.Location = new System.Drawing.Point(629, 12);
             this.textBox4.Margin = new System.Windows.Forms.Padding(2);
             this.textBox4.Name = "textBox4";
             this.textBox4.Size = new System.Drawing.Size(76, 20);
@@ -170,7 +173,7 @@ namespace GralDomForms
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(478, 13);
+            this.label1.Location = new System.Drawing.Point(598, 15);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(27, 19);
@@ -179,9 +182,9 @@ namespace GralDomForms
             // 
             // button2
             // 
-            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(447, 356);
+            this.button2.Location = new System.Drawing.Point(609, 373);
             this.button2.Margin = new System.Windows.Forms.Padding(2);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(121, 27);
@@ -190,23 +193,52 @@ namespace GralDomForms
             this.button2.UseVisualStyleBackColor = true;
             this.button2.Click += new System.EventHandler(this.Button2Click);
             // 
+            // button3
+            // 
+            this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.button3.Location = new System.Drawing.Point(206, 373);
+            this.button3.Margin = new System.Windows.Forms.Padding(2);
+            this.button3.Name = "button3";
+            this.button3.Size = new System.Drawing.Size(129, 27);
+            this.button3.TabIndex = 8;
+            this.button3.Text = "&Save the changes";
+            this.button3.UseVisualStyleBackColor = true;
+            this.button3.Click += new System.EventHandler(this.button3_Click);
+            // 
+            // button4
+            // 
+            this.button4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
+            this.button4.Location = new System.Drawing.Point(408, 373);
+            this.button4.Margin = new System.Windows.Forms.Padding(2);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(121, 27);
+            this.button4.TabIndex = 10;
+            this.button4.Text = "&Delete Items";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
             // Search_Item
             // 
             this.AcceptButton = this.button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.CancelButton = this.button2;
-            this.ClientSize = new System.Drawing.Size(607, 392);
+            this.ClientSize = new System.Drawing.Size(741, 411);
+            this.Controls.Add(this.button4);
             this.Controls.Add(this.groupBox1);
             this.Controls.Add(this.button2);
+            this.Controls.Add(this.button3);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.dataGridView1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Margin = new System.Windows.Forms.Padding(2);
+            this.MinimumSize = new System.Drawing.Size(700, 450);
             this.Name = "Search_Item";
-            this.Text = "GRAL GUI Search & filter items";
+            this.Text = "GRAL GUI Search, filter and edit items";
+            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.Search_Item_FormClosed);
             this.Load += new System.EventHandler(this.Search_ItemLoad);
             this.ResizeEnd += new System.EventHandler(this.Search_ItemResizeEnd);
+            this.Resize += new System.EventHandler(this.Search_Item_Resize);
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).EndInit();
             this.groupBox1.ResumeLayout(false);
             this.groupBox1.PerformLayout();
@@ -226,5 +258,7 @@ namespace GralDomForms
 		private System.Windows.Forms.Label label2;
 		private System.Windows.Forms.Button button1;
 		private System.Windows.Forms.DataGridView dataGridView1;
-	}
+        private System.Windows.Forms.Button button3;
+        private System.Windows.Forms.Button button4;
+    }
 }

--- a/Source/Gral/GRALDomForms/Search_Item.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.cs
@@ -45,8 +45,22 @@ namespace GralDomForms
 		
 		private bool[] _visible = new bool[100];
 		public bool[] Items_visible{set {_visible = value;} get {return _visible;} }
-		
-		public Search_Item()
+        public Size FormSize;
+
+        public GralItemForms.EditPointSources EditPSSearch;
+        public GralItemForms.EditAreaSources EditASSearch;
+        public GralItemForms.EditLinesources EditLSSearch;
+        public GralItemForms.EditBuildings EditBSearch;
+        public GralItemForms.EditPortalSources EditPortalsSearch;
+        public GralItemForms.EditReceptors EditRSearch;
+        public GralItemForms.EditWalls EditWallSearch;
+        public GralItemForms.EditVegetation EditVegetationSearch;
+
+        public bool Locked = false;
+
+        private DataGridViewCellStyle ChangedCellStyle;
+
+        public Search_Item()
 		{
 			//
 			// The InitializeComponent() call is required for Windows Forms designer support.
@@ -59,8 +73,7 @@ namespace GralDomForms
 		}
 		
 		void Search_ItemLoad(object sender, EventArgs e)
-		{
-			
+		{		
 			datasorted = new DataView(_data); // create DataView from DataTable
 			dataGridView1.DataSource = datasorted; // connect DataView to GridView
 			dataGridView1.ColumnHeadersHeight = 26;
@@ -80,47 +93,293 @@ namespace GralDomForms
 			dataGridView1.Columns["Diameter"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
 			dataGridView1.Columns["Exit_velocity"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
 			dataGridView1.Columns["Temperature"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
-			#endif
-
-			for (int i = 1; i < 11; i++)
+            dataGridView1.Columns["ER_SG"].Name = DataGridViewContentAlignment.MiddleRight.ToString();
+#endif
+            if (Locked == false)
+            {
+                dataGridView1.Columns[0].ReadOnly = true;
+                dataGridView1.Columns[2].ReadOnly = true;
+                dataGridView1.Columns[9].ReadOnly = true;
+                button3.Enabled = true;
+                button4.Enabled = true;
+            }
+            else
+            {
+                for (int i = 0; i < dataGridView1.Columns.Count; i++)
+                {
+                    dataGridView1.Columns[i].ReadOnly = true;
+                }
+                button3.Enabled = false;
+                button4.Enabled = false;
+            }
+            for (int i = 1; i < 11; i++)
 			{
 				dataGridView1.Columns["ER Nr. " + Convert.ToString(i)].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleRight;
 				#if __MonoCS__
 				#else
 				dataGridView1.Columns["ER Nr. " + Convert.ToString(i)].Name = DataGridViewContentAlignment.MiddleRight.ToString();
-				#endif
-			}
+#endif
+                dataGridView1.Columns["Poll. " + Convert.ToString(i)].ReadOnly = true;
+            }
 			dataGridView1.Columns["Source_group"].DefaultCellStyle.Alignment = DataGridViewContentAlignment.MiddleCenter;
 			#if __MonoCS__
 			#else
 			dataGridView1.Columns["Source_group"].Name = DataGridViewContentAlignment.MiddleCenter.ToString();
-			#endif
-			for (int i = 0; i < _data.Columns.Count; i++)
-				dataGridView1.Columns[i].Visible = _visible[i];
-		}
-		
-		void Button1Click(object sender, EventArgs e) //OK
-		{
-			int selectedRowCount =
-				dataGridView1.Rows.GetRowCount(DataGridViewElementStates.Selected);
-			
-			if (selectedRowCount > 0) // a line selected?
-			{
-				int index = dataGridView1.SelectedRows[0].Index;
-				_selected_item = Convert.ToInt32(dataGridView1[0, index].Value);
-				_selected_type = Convert.ToString(dataGridView1[2, index].Value);
-    		}
-			
-			Close();
-		}
-		
-		void Button2Click(object sender, EventArgs e) // Cancel
-		{
-			_selected_item = 0;
-			Close();
-		}
-		
-		void TextBox1TextChanged(object sender, EventArgs e)
+#endif
+            for (int i = 0; i < _data.Columns.Count; i++)
+            {
+                dataGridView1.Columns[i].Visible = _visible[i];
+            }
+            ChangedCellStyle = new DataGridViewCellStyle();
+            ChangedCellStyle.Font = new Font(dataGridView1.Font, FontStyle.Bold);
+            ChangedCellStyle.BackColor = Color.Beige;
+            dataGridView1.CellValueChanged += new DataGridViewCellEventHandler(dataGridView1_CellValueChanged);
+            Search_ItemResizeEnd(null, null);
+        }
+
+        void Button1Click(object sender, EventArgs e) //OK
+        {
+            int selectedRowCount =
+                dataGridView1.Rows.GetRowCount(DataGridViewElementStates.Selected);
+
+            if (selectedRowCount > 0) // a line selected?
+            {
+                int index = dataGridView1.SelectedRows[0].Index;
+                _selected_item = Convert.ToInt32(dataGridView1[0, index].Value);
+                _selected_type = Convert.ToString(dataGridView1[2, index].Value);
+            }
+            Close();
+        }
+
+        private void button3_Click(object sender, EventArgs e)
+        {
+            if (Locked == false)
+            {
+                for (int i = dataGridView1.RowCount - 1; i >= 0; i--)
+                {
+                    int index = dataGridView1.Rows[i].Index;
+                    int selected_item = Convert.ToInt32(dataGridView1[0, index].Value) - 1;
+                    string selected_type = Convert.ToString(dataGridView1[2, index].Value);
+
+                    if (selected_type == "Point source" && EditPSSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.PointSourceData _dta in EditPSSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.Poll.SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    if (string.IsNullOrEmpty(_dta.VelocityTimeSeries))
+                                    {
+                                        _dta.Velocity = Convert.ToSingle(dataGridView1[6, index].Value);
+                                    }
+                                    if (string.IsNullOrEmpty(_dta.TemperatureTimeSeries))
+                                    {
+                                        _dta.Temperature = Convert.ToSingle(dataGridView1[7, index].Value);
+                                    }
+                                    _dta.Diameter = Convert.ToSingle(dataGridView1[8, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll.EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Line source" && EditLSSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.LineSourceData _dta in EditLSSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    int SGIndex = Convert.ToInt32(dataGridView1[9, index].Value);
+                                    _dta.Poll[SGIndex].SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll[SGIndex].EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Portal source" && EditPortalsSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.PortalsData _dta in EditPortalsSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    
+                                    if (string.IsNullOrEmpty(_dta.VelocityTimeSeries))
+                                    {
+                                        _dta.ExitVel = Convert.ToSingle(dataGridView1[6, index].Value);
+                                    }
+                                    if (string.IsNullOrEmpty(_dta.TemperatureTimeSeries))
+                                    {
+                                        _dta.DeltaT = Convert.ToSingle(dataGridView1[7, index].Value);
+                                    }
+                                    int SGIndex = Convert.ToInt32(dataGridView1[9, index].Value);
+                                    _dta.Poll[SGIndex].SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll[SGIndex].EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Area source" && EditASSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.AreaSourceData _dta in EditASSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    _dta.Poll.SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[4, index].Value);
+                                    for (int j = 0; j < 10; j++)
+                                    {
+                                        int _col = 10 + 2 * j;
+                                        // MessageBox.Show(dataGridView1.Columns.Count.ToString());
+                                        //MessageBox.Show(Convert.ToDouble(dataGridView1[_col, index].Value).ToString());
+                                        if (dataGridView1.Rows[i].Cells[_col].Value != DBNull.Value)
+                                        {
+                                            _dta.Poll.EmissionRate[j] = Convert.ToDouble(dataGridView1[_col, index].Value);
+                                        }
+                                    }
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+
+                    if (selected_type == "Receptor point" && EditRSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.ReceptorData _dta in EditRSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Building" && EditBSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.BuildingData _dta in EditBSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Wall" && EditWallSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.WallData _dta in EditWallSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                    if (selected_type == "Vegetation" && EditVegetationSearch != null)
+                    {
+                        int k = 0;
+                        foreach (GralItemData.VegetationData _dta in EditVegetationSearch.ItemData)
+                        {
+                            try
+                            {
+                                if (k == selected_item)
+                                {
+                                    _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
+                                    _dta.VerticalExt = Convert.ToSingle(dataGridView1[3, index].Value);
+                                }
+                            }
+                            catch { }
+                            k++;
+                        }
+                    }
+                }
+            }
+
+            _selected_item = -1; // marker that values should be saved
+            Close();
+        }
+
+        void Button2Click(object sender, EventArgs e) // Cancel
+        {
+            _selected_item = 0;
+            Close();
+        }
+
+        void TextBox1TextChanged(object sender, EventArgs e)
 		{
 			try
 			{
@@ -197,8 +456,16 @@ namespace GralDomForms
 
 		void Search_ItemResizeEnd(object sender, EventArgs e)
 		{
-			dataGridView1.Height = Math.Max(300, Height - 177);
-			dataGridView1.Width = Math.Max(400, Width - 50);
+            int h = Height - 60 - (Height - button1.Top);
+            if (h > 0)
+            {
+                dataGridView1.Height = h;
+            }
+            dataGridView1.Width = Math.Max(400, Width - SystemInformation.VerticalScrollBarWidth);
+            if (sender != null && WindowState != FormWindowState.Maximized && WindowState != FormWindowState.Minimized)
+            {
+                FormSize = this.Size;
+            }
 		}
 		
 		void DataGridView1RowHeaderMouseDoubleClick(object sender, DataGridViewCellMouseEventArgs e)
@@ -233,5 +500,190 @@ namespace GralDomForms
 			//MessageBox.Show(sender.ToString() + mi.Index.ToString());
 		}
 
-	}
+        private void dataGridView1_KeyDown(object sender, KeyEventArgs e)
+        {
+            if (e.KeyData == Keys.Delete && dataGridView1.SelectedRows.Count > 0 && Locked == false)
+            {
+                DeleteItems();
+            }
+            try
+            {
+                if (e.Modifiers == Keys.Control)
+                {
+                    switch (e.KeyCode)
+                    {
+                        case Keys.C:
+                            break;
+
+                        case Keys.V:
+                            PasteClipboard();
+                            break;
+                    }
+                }
+            }
+            catch
+            {
+
+            }
+        }
+
+        private void button4_Click(object sender, EventArgs e)
+        {
+            if (dataGridView1.SelectedRows.Count > 0 && Locked == false)
+            {
+                DeleteItems();
+            }
+        }
+
+        private void DeleteItems()
+        {
+            string _it = "items?";
+            if (dataGridView1.SelectedRows.Count == 1)
+            {
+                _it = "item?";
+            }
+            if (MessageBox.Show(this, "Delete " + dataGridView1.SelectedRows.Count.ToString() +
+                    " selected " + _it, "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+            {
+                for (int i = dataGridView1.RowCount - 1; i >= 0; i--)
+                {
+                    if (dataGridView1.SelectedRows.Contains(dataGridView1.Rows[i]))
+                    {
+                        int index = dataGridView1.Rows[i].Index;
+                        int selected_item = Convert.ToInt32(dataGridView1[0, index].Value) - 1;
+                        string selected_type = Convert.ToString(dataGridView1[2, index].Value);
+
+                        if (selected_type == "Point source" && EditPSSearch != null)
+                        {
+                            EditPSSearch.ItemDisplayNr = selected_item;
+                            EditPSSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Portal source" && EditPortalsSearch != null)
+                        {
+                            EditPortalsSearch.ItemDisplayNr = selected_item;
+                            EditPortalsSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Line source" && EditLSSearch != null)
+                        {
+                            EditLSSearch.ItemDisplayNr = selected_item;
+                            EditLSSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Area source" && EditASSearch != null)
+                        {
+                            EditASSearch.ItemDisplayNr = selected_item;
+                            EditASSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Building" && EditBSearch != null)
+                        {
+                            EditBSearch.ItemDisplayNr = selected_item;
+                            EditBSearch.RemoveOne(false, false);
+                        }
+                        if (selected_type == "Receptor point" && EditRSearch != null)
+                        {
+                            EditRSearch.ItemDisplayNr = selected_item;
+                            EditRSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Wall" && EditWallSearch != null)
+                        {
+                            EditWallSearch.ItemDisplayNr = selected_item;
+                            EditWallSearch.RemoveOne(false);
+                        }
+                        if (selected_type == "Vegetation" && EditVegetationSearch != null)
+                        {
+                            EditVegetationSearch.ItemDisplayNr = selected_item;
+                            EditVegetationSearch.RemoveOne(false);
+                        }
+
+                        _selected_item = -1; // marker, that changed items need to be written to disk
+                        Close();
+                    }
+                }
+            }
+        }
+
+        private void Search_Item_FormClosed(object sender, FormClosedEventArgs e)
+        {
+            _data = null;
+            Data = null;
+            ChangedCellStyle.Font.Dispose();
+            ChangedCellStyle = null;
+            dataGridView1.CellValueChanged -= new DataGridViewCellEventHandler(dataGridView1_CellValueChanged);         
+        }
+
+        private void dataGridView1_CellValueChanged(object sender, DataGridViewCellEventArgs e)
+        {
+            if (sender == dataGridView1)
+            {
+                dataGridView1.Rows[e.RowIndex].Cells[e.ColumnIndex].Style = ChangedCellStyle;
+            }
+        }
+
+        private void Search_Item_Resize(object sender, EventArgs e)
+        {
+            if (WindowState == FormWindowState.Maximized)
+            {
+                Search_ItemResizeEnd(null, null);
+            }
+            if (WindowState == FormWindowState.Normal)
+            {
+                Search_ItemResizeEnd(null, null);
+            }
+        }
+
+        void PasteClipboard()
+        {
+            try
+            {
+                string s = Clipboard.GetText();
+                string[] lines = s.Split('\n');
+
+                int iRow = dataGridView1.CurrentCell.RowIndex;
+                int iCol = dataGridView1.CurrentCell.ColumnIndex;
+                DataGridViewCell oCell;
+
+                foreach (string line in lines)
+                {
+                    if (iRow < dataGridView1.RowCount && line.Length > 0)
+                    {
+                        string[] sCells = line.Split('\t');
+                        for (int i = 0; i < sCells.GetLength(0); ++i)
+                        {
+                            double test = 0;
+                            if (double.TryParse(sCells[i], out test) == false)
+                            {
+                                sCells[i] = test.ToString("0.0");
+                            }
+                            if (iCol + i < dataGridView1.ColumnCount)
+                            {
+                                oCell = dataGridView1[iCol + i, iRow];
+                                oCell.Value = Convert.ChangeType(sCells[i].Replace("\r", ""), oCell.ValueType);
+                                oCell.Style = ChangedCellStyle;
+                            }
+                            else
+                            {
+                                break;
+                            }
+                        }
+                        iRow++;
+                    }
+                    else
+                    {
+                        break;
+                    }
+                }
+            }
+            catch (FormatException)
+            {
+                return;
+            }
+        }
+
+        private void dataGridView1_DataError(object sender, DataGridViewDataErrorEventArgs e)
+        {
+            DataGridViewCell ocell = dataGridView1[e.ColumnIndex, e.RowIndex];
+            MessageBox.Show(this, "Only numeric inputs allowed", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Warning);
+            ocell.Value = Convert.ChangeType(_data.Rows[e.RowIndex][e.ColumnIndex], ocell.ValueType);
+            e.Cancel = false;
+        }
+    }
 }

--- a/Source/Gral/GRALDomForms/Search_Item.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.cs
@@ -179,7 +179,7 @@ namespace GralDomForms
                                     }
                                     if (string.IsNullOrEmpty(_dta.TemperatureTimeSeries))
                                     {
-                                        _dta.Temperature = Convert.ToSingle(dataGridView1[7, index].Value);
+                                        _dta.Temperature = Convert.ToSingle(dataGridView1[7, index].Value) + 273F;
                                     }
                                     _dta.Diameter = Convert.ToSingle(dataGridView1[8, index].Value);
                                     for (int j = 0; j < 10; j++)

--- a/Source/Gral/GRALDomForms/Search_Item.cs
+++ b/Source/Gral/GRALDomForms/Search_Item.cs
@@ -210,6 +210,19 @@ namespace GralDomForms
                                 {
                                     _dta.Name = Convert.ToString(dataGridView1[1, index].Value);
                                     _dta.Height = Convert.ToSingle(dataGridView1[3, index].Value);
+                                    GralDomain.PointD[] pt = new GralDomain.PointD[_dta.Pt.Count];
+                                    for (int ik = 0; ik < _dta.Pt.Count; ik++)
+                                    {
+                                        pt[ik] = new GralDomain.PointD(_dta.Pt[ik].X, _dta.Pt[ik].Y);
+                                    }
+                                    _dta.Pt.Clear();
+                                    _dta.Pt.TrimExcess();
+                                    for (int ik = 0; ik < pt.Length; ik++)
+                                    {
+                                        _dta.Pt.Add(new GralData.PointD_3d(pt[ik].X, pt[ik].Y, _dta.Height));
+                                    }
+                                    _dta.Lines3D = false;
+
                                     _dta.VerticalExt = Convert.ToSingle(dataGridView1[4, index].Value);
                                     int SGIndex = Convert.ToInt32(dataGridView1[9, index].Value);
                                     _dta.Poll[SGIndex].SourceGroup = Convert.ToInt32(dataGridView1[5, index].Value);

--- a/Source/Gral/GRALDomain/Domain.Designer.cs
+++ b/Source/Gral/GRALDomain/Domain.Designer.cs
@@ -135,6 +135,9 @@
             this.moveMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.arrowCursorToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem18 = new System.Windows.Forms.ToolStripMenuItem();
+            this.shownCellHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuEntryCellHeightsGramm = new System.Windows.Forms.ToolStripMenuItem();
+            this.MenuEntryCellHeightsGral = new System.Windows.Forms.ToolStripMenuItem();
             this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
             this.sectionViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.dViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -1550,6 +1553,7 @@
             this.moveMapToolStripMenuItem,
             this.arrowCursorToolStripMenuItem1,
             this.toolStripMenuItem18,
+            this.shownCellHeightToolStripMenuItem,
             this.toolStripMenuItem5,
             this.sectionViewToolStripMenuItem,
             this.dViewToolStripMenuItem,
@@ -1637,6 +1641,29 @@
             this.toolStripMenuItem18.Size = new System.Drawing.Size(205, 22);
             this.toolStripMenuItem18.Text = "Show &length label info";
             this.toolStripMenuItem18.Click += new System.EventHandler(this.ToolStripMenuItem18Click);
+            // 
+            // shownCellHeightToolStripMenuItem
+            // 
+            this.shownCellHeightToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+            this.MenuEntryCellHeightsGramm,
+            this.MenuEntryCellHeightsGral});
+            this.shownCellHeightToolStripMenuItem.Name = "shownCellHeightToolStripMenuItem";
+            this.shownCellHeightToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.shownCellHeightToolStripMenuItem.Text = "Show cell heights for";
+            // 
+            // MenuEntryCellHeightsGramm
+            // 
+            this.MenuEntryCellHeightsGramm.Name = "MenuEntryCellHeightsGramm";
+            this.MenuEntryCellHeightsGramm.Size = new System.Drawing.Size(180, 22);
+            this.MenuEntryCellHeightsGramm.Text = "GRAMM grid";
+            this.MenuEntryCellHeightsGramm.Click += new System.EventHandler(this.MenuCellHeightsGramm);
+            // 
+            // MenuEntryCellHeightsGral
+            // 
+            this.MenuEntryCellHeightsGral.Name = "MenuEntryCellHeightsGral";
+            this.MenuEntryCellHeightsGral.Size = new System.Drawing.Size(180, 22);
+            this.MenuEntryCellHeightsGral.Text = "GRAL grid";
+            this.MenuEntryCellHeightsGral.Click += new System.EventHandler(this.MenuCellHeightsGral);
             // 
             // toolStripMenuItem5
             // 
@@ -2015,7 +2042,7 @@
             // 
             this.pointSourcesToolStripMenuItem1.Name = "pointSourcesToolStripMenuItem1";
             this.pointSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F1)));
-            this.pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.pointSourcesToolStripMenuItem1.Text = "Point sources";
             this.pointSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button8_Click);
             // 
@@ -2023,7 +2050,7 @@
             // 
             this.areaSourcesToolStripMenuItem1.Name = "areaSourcesToolStripMenuItem1";
             this.areaSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F2)));
-            this.areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.areaSourcesToolStripMenuItem1.Text = "Area sources";
             this.areaSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button10_Click);
             // 
@@ -2031,7 +2058,7 @@
             // 
             this.lineSourcesToolStripMenuItem1.Name = "lineSourcesToolStripMenuItem1";
             this.lineSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F3)));
-            this.lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.lineSourcesToolStripMenuItem1.Text = "Line sources";
             this.lineSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button12_Click);
             // 
@@ -2039,7 +2066,7 @@
             // 
             this.tunnelPortalsToolStripMenuItem1.Name = "tunnelPortalsToolStripMenuItem1";
             this.tunnelPortalsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F4)));
-            this.tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.tunnelPortalsToolStripMenuItem1.Text = "Tunnel portals";
             this.tunnelPortalsToolStripMenuItem1.Click += new System.EventHandler(this.Button14_Click);
             // 
@@ -2047,7 +2074,7 @@
             // 
             this.buildingsToolStripMenuItem1.Name = "buildingsToolStripMenuItem1";
             this.buildingsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F5)));
-            this.buildingsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.buildingsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.buildingsToolStripMenuItem1.Text = "Buildings";
             this.buildingsToolStripMenuItem1.Click += new System.EventHandler(this.Button16_Click);
             // 
@@ -2055,7 +2082,7 @@
             // 
             this.receptorPointsToolStripMenuItem1.Name = "receptorPointsToolStripMenuItem1";
             this.receptorPointsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F6)));
-            this.receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.receptorPointsToolStripMenuItem1.Text = "Receptor points";
             this.receptorPointsToolStripMenuItem1.Click += new System.EventHandler(this.Button23_Click);
             // 
@@ -2063,7 +2090,7 @@
             // 
             this.wallsToolStripMenuItem1.Name = "wallsToolStripMenuItem1";
             this.wallsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7)));
-            this.wallsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.wallsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.wallsToolStripMenuItem1.Text = "Walls";
             this.wallsToolStripMenuItem1.Click += new System.EventHandler(this.Button49Click);
             // 
@@ -2071,20 +2098,20 @@
             // 
             this.VegetationtToolStripMenuItem1.Name = "VegetationtToolStripMenuItem1";
             this.VegetationtToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F10)));
-            this.VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
+            this.VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
             this.VegetationtToolStripMenuItem1.Text = "Vegetation";
             this.VegetationtToolStripMenuItem1.Click += new System.EventHandler(this.Button50Click);
             // 
             // toolStripMenuItem17
             // 
             this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-            this.toolStripMenuItem17.Size = new System.Drawing.Size(200, 6);
+            this.toolStripMenuItem17.Size = new System.Drawing.Size(202, 6);
             // 
             // searchItemToolStripMenuItem
             // 
             this.searchItemToolStripMenuItem.Name = "searchItemToolStripMenuItem";
             this.searchItemToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.searchItemToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
+            this.searchItemToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
             this.searchItemToolStripMenuItem.Text = "Search items";
             this.searchItemToolStripMenuItem.Click += new System.EventHandler(this.SearchItemToolStripMenuItemClick);
             // 
@@ -2105,7 +2132,7 @@
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.ShortcutKeyDisplayString = "T";
             this.toolsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.T)));
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 21);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 21);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // measureLenghtToolStripMenuItem
@@ -2375,7 +2402,7 @@
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.ShortcutKeyDisplayString = "E";
             this.exportToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.X)));
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(53, 21);
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(52, 21);
             this.exportToolStripMenuItem.Text = "E&xport";
             // 
             // saveMapToDiscToolStripMenuItem
@@ -2788,5 +2815,8 @@
         private System.Windows.Forms.ToolStripMenuItem contourLinesToolStripMenuItem;
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.TextBox textBox3;
+        private System.Windows.Forms.ToolStripMenuItem shownCellHeightToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem MenuEntryCellHeightsGramm;
+        private System.Windows.Forms.ToolStripMenuItem MenuEntryCellHeightsGral;
     }
 }

--- a/Source/Gral/GRALDomain/Domain.Designer.cs
+++ b/Source/Gral/GRALDomain/Domain.Designer.cs
@@ -298,8 +298,8 @@
             this.button21.Size = new System.Drawing.Size(26, 25);
             this.button21.TabIndex = 13;
             this.button21.Text = "[m²]";
-            this.toolTip1.SetToolTip(this.button21, "Measure areas:\r\nLeft click:\r\nSet vertices of the polygon.\r\n\r\nRight click:\r\nClosin" +
-        "g the polygon.");
+            this.toolTip1.SetToolTip(this.button21, "Measure areas:\r\nLeft click:\r\nSet vertices of the polygon.\r\n\r\nRight click:\r\nClose " +
+        "the polygon.");
             this.button21.UseVisualStyleBackColor = true;
             this.button21.Visible = false;
             this.button21.Click += new System.EventHandler(this.Button21_Click);
@@ -342,7 +342,7 @@
             this.button18.Name = "button18";
             this.button18.Size = new System.Drawing.Size(26, 25);
             this.button18.TabIndex = 10;
-            this.toolTip1.SetToolTip(this.button18, "Define position (cemtre)\r\nof north arrow.");
+            this.toolTip1.SetToolTip(this.button18, "Define position (center)\r\nof north arrow.");
             this.button18.UseVisualStyleBackColor = true;
             this.button18.Visible = false;
             this.button18.Click += new System.EventHandler(this.Button18_Click);
@@ -372,7 +372,7 @@
             this.button7.Name = "button7";
             this.button7.Size = new System.Drawing.Size(26, 25);
             this.button7.TabIndex = 8;
-            this.toolTip1.SetToolTip(this.button7, "Zoom in");
+            this.toolTip1.SetToolTip(this.button7, "Zoom in by rectangle");
             this.button7.UseVisualStyleBackColor = true;
             this.button7.Click += new System.EventHandler(this.Button7_Click);
             // 
@@ -615,7 +615,7 @@
             this.button30.Size = new System.Drawing.Size(26, 25);
             this.button30.TabIndex = 40;
             this.toolTip1.SetToolTip(this.button30, "Compute wind statistics at\r\na specific point.\r\nWindroses etc. can be viewed\r\nin t" +
-        "he menu \"");
+        "he menu tab \"Meteorology\"");
             this.button30.UseVisualStyleBackColor = true;
             this.button30.Click += new System.EventHandler(this.Button30_Click);
             // 
@@ -864,9 +864,9 @@
             this.button43.Name = "button43";
             this.button43.Size = new System.Drawing.Size(26, 25);
             this.button43.TabIndex = 47;
-            this.toolTip1.SetToolTip(this.button43, "Re-order wind fields to match\r\nnewly observed wind and stability data\r\n at any lo" +
-        "cation.\r\nLeft click on the map to define\r\nthe position of the new meteorological" +
-        "\r\nmeasurements.");
+            this.toolTip1.SetToolTip(this.button43, "Match-to-Observation:\r\nReorder wind fields to match\r\nnewly observed wind and stab" +
+        "ility data\r\nat any location.\r\nLeft click on the map to define\r\nthe position of t" +
+        "he new meteorological\r\nmeasurements.");
             this.button43.UseVisualStyleBackColor = true;
             this.button43.Click += new System.EventHandler(this.Button43_Click);
             // 
@@ -1635,7 +1635,7 @@
             this.toolStripMenuItem18.CheckState = System.Windows.Forms.CheckState.Checked;
             this.toolStripMenuItem18.Name = "toolStripMenuItem18";
             this.toolStripMenuItem18.Size = new System.Drawing.Size(205, 22);
-            this.toolStripMenuItem18.Text = "Show &lenght label info";
+            this.toolStripMenuItem18.Text = "Show &length label info";
             this.toolStripMenuItem18.Click += new System.EventHandler(this.ToolStripMenuItem18Click);
             // 
             // toolStripMenuItem5
@@ -2015,7 +2015,7 @@
             // 
             this.pointSourcesToolStripMenuItem1.Name = "pointSourcesToolStripMenuItem1";
             this.pointSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F1)));
-            this.pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.pointSourcesToolStripMenuItem1.Text = "Point sources";
             this.pointSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button8_Click);
             // 
@@ -2023,7 +2023,7 @@
             // 
             this.areaSourcesToolStripMenuItem1.Name = "areaSourcesToolStripMenuItem1";
             this.areaSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F2)));
-            this.areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.areaSourcesToolStripMenuItem1.Text = "Area sources";
             this.areaSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button10_Click);
             // 
@@ -2031,7 +2031,7 @@
             // 
             this.lineSourcesToolStripMenuItem1.Name = "lineSourcesToolStripMenuItem1";
             this.lineSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F3)));
-            this.lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.lineSourcesToolStripMenuItem1.Text = "Line sources";
             this.lineSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button12_Click);
             // 
@@ -2039,7 +2039,7 @@
             // 
             this.tunnelPortalsToolStripMenuItem1.Name = "tunnelPortalsToolStripMenuItem1";
             this.tunnelPortalsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F4)));
-            this.tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.tunnelPortalsToolStripMenuItem1.Text = "Tunnel portals";
             this.tunnelPortalsToolStripMenuItem1.Click += new System.EventHandler(this.Button14_Click);
             // 
@@ -2047,7 +2047,7 @@
             // 
             this.buildingsToolStripMenuItem1.Name = "buildingsToolStripMenuItem1";
             this.buildingsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F5)));
-            this.buildingsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.buildingsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.buildingsToolStripMenuItem1.Text = "Buildings";
             this.buildingsToolStripMenuItem1.Click += new System.EventHandler(this.Button16_Click);
             // 
@@ -2055,7 +2055,7 @@
             // 
             this.receptorPointsToolStripMenuItem1.Name = "receptorPointsToolStripMenuItem1";
             this.receptorPointsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F6)));
-            this.receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.receptorPointsToolStripMenuItem1.Text = "Receptor points";
             this.receptorPointsToolStripMenuItem1.Click += new System.EventHandler(this.Button23_Click);
             // 
@@ -2063,7 +2063,7 @@
             // 
             this.wallsToolStripMenuItem1.Name = "wallsToolStripMenuItem1";
             this.wallsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7)));
-            this.wallsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.wallsToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.wallsToolStripMenuItem1.Text = "Walls";
             this.wallsToolStripMenuItem1.Click += new System.EventHandler(this.Button49Click);
             // 
@@ -2071,20 +2071,20 @@
             // 
             this.VegetationtToolStripMenuItem1.Name = "VegetationtToolStripMenuItem1";
             this.VegetationtToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F10)));
-            this.VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            this.VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(203, 22);
             this.VegetationtToolStripMenuItem1.Text = "Vegetation";
             this.VegetationtToolStripMenuItem1.Click += new System.EventHandler(this.Button50Click);
             // 
             // toolStripMenuItem17
             // 
             this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-            this.toolStripMenuItem17.Size = new System.Drawing.Size(202, 6);
+            this.toolStripMenuItem17.Size = new System.Drawing.Size(200, 6);
             // 
             // searchItemToolStripMenuItem
             // 
             this.searchItemToolStripMenuItem.Name = "searchItemToolStripMenuItem";
             this.searchItemToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.searchItemToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            this.searchItemToolStripMenuItem.Size = new System.Drawing.Size(203, 22);
             this.searchItemToolStripMenuItem.Text = "Search items";
             this.searchItemToolStripMenuItem.Click += new System.EventHandler(this.SearchItemToolStripMenuItemClick);
             // 
@@ -2105,14 +2105,14 @@
             this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
             this.toolsToolStripMenuItem.ShortcutKeyDisplayString = "T";
             this.toolsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.T)));
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(47, 21);
+            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 21);
             this.toolsToolStripMenuItem.Text = "&Tools";
             // 
             // measureLenghtToolStripMenuItem
             // 
             this.measureLenghtToolStripMenuItem.Name = "measureLenghtToolStripMenuItem";
             this.measureLenghtToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.measureLenghtToolStripMenuItem.Text = "Lenght measurement";
+            this.measureLenghtToolStripMenuItem.Text = "Length measurement";
             this.measureLenghtToolStripMenuItem.Click += new System.EventHandler(this.Button20_Click);
             // 
             // measureAreaToolStripMenuItem
@@ -2375,7 +2375,7 @@
             this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
             this.exportToolStripMenuItem.ShortcutKeyDisplayString = "E";
             this.exportToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.X)));
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(52, 21);
+            this.exportToolStripMenuItem.Size = new System.Drawing.Size(53, 21);
             this.exportToolStripMenuItem.Text = "E&xport";
             // 
             // saveMapToDiscToolStripMenuItem

--- a/Source/Gral/GRALDomain/Domain.cs
+++ b/Source/Gral/GRALDomain/Domain.cs
@@ -543,7 +543,10 @@ namespace GralDomain
                                     }
                                 }
                                 ReDrawContours = true;
-                                Contours(_drobj.ContourFilename, _drobj);
+                                if (File.Exists(_drobj.ContourFilename))
+                                {
+                                    Contours(_drobj.ContourFilename, _drobj);
+                                }
                             }
                             catch
                             {
@@ -583,7 +586,10 @@ namespace GralDomain
                                         }
                                     }
                                 }
-                                LoadVectors(_drobj.ContourFilename, _drobj);
+                                if (File.Exists(_drobj.ContourFilename))
+                                {
+                                    LoadVectors(_drobj.ContourFilename, _drobj);
+                                }
                             }
                             catch
                             {

--- a/Source/Gral/GRALDomain/Domain.cs
+++ b/Source/Gral/GRALDomain/Domain.cs
@@ -31,8 +31,8 @@ namespace GralDomain
     
     public partial class Domain : Form
     {
-        private string decsep;                                                // global decimal separator of the system
-        private Gral.Main MainForm = null;
+        private readonly string decsep;                                                // global decimal separator of the system
+        private readonly Gral.Main MainForm = null;
         private string MapFileName;
         private string ImageFileName;
         /// <summary>
@@ -62,7 +62,7 @@ namespace GralDomain
         /// <summary>
         /// Copied object container 
         /// </summary>
-        private CopyObjects CopiedItem = new CopyObjects();        
+        private readonly CopyObjects CopiedItem = new CopyObjects();        
         /// <summary>
         /// form for georeferencing bitmap file using one reference point and a map scale
         /// </summary>
@@ -138,7 +138,7 @@ namespace GralDomain
         private int RubberRedrawAllowed = 0;
         
         private PointF FirstPointLenght;				  // Lenght measurement
-        private ToolTip ToolTipMousePosition;			  // Tooltip for picturebox1
+        private readonly ToolTip ToolTipMousePosition;	  // Tooltip for picturebox1
         /// <summary>
         ///  x,y corner points of an area/line source in pixel for intermediate drawing during editing
         /// </summary> 
@@ -146,12 +146,12 @@ namespace GralDomain
         /// <summary>
         /// [0] = 1st point for lenght label [1] = Point for Rubberline
         /// </summary> 
-        private Point[] RubberLineCoors = new Point[2]; 	       
+        private readonly Point[] RubberLineCoors = new Point[2]; 	       
         
         private Bitmap NorthArrowBitmap;                       // Icon for north arrow
         private Bitmap PictureBoxBitmap;					   // Bitmap for the picture box
-        private NorthArrowData NorthArrow = new NorthArrowData(); // Data for the north arrow
-        private MapScaleData MapScale = new MapScaleData();       //Data for the MapScale
+        private readonly NorthArrowData NorthArrow = new NorthArrowData(); // Data for the north arrow
+        private readonly MapScaleData MapScale = new MapScaleData();       //Data for the MapScale
 
         /// <summary>
         /// Map transformation X when zooming and shifting
@@ -196,7 +196,7 @@ namespace GralDomain
         /// <summary>
         /// Online or Domain mode?
         /// </summary>
-        private bool GRAMMOnline;             
+        private readonly bool GRAMMOnline;             
         
         /// <summary>
         /// Objectmanager form: it is possible to close the objectmanager if domain is closed
@@ -205,7 +205,7 @@ namespace GralDomain
         /// <summary>
         /// List of all selectet Items of one type to delete all selected items
         /// </summary>
-        private List<int> SelectedItems = new List<int>();        
+        private readonly List<int> SelectedItems = new List<int>();        
         private string ConcFilename = "";						  // filename for concentration files
         private float [,] CellHeights = new float[1,1];           // Cell heights
         /// <summary>
@@ -215,7 +215,7 @@ namespace GralDomain
         /// <summary>
         /// variables needed for the routine to import newly observed meteo data
         /// </summary>
-        private MatchMeteoData MMOData =  new MatchMeteoData();
+        private readonly MatchMeteoData MMOData =  new MatchMeteoData();
         /// <summary>
         /// form for matching GRAMM wind fields with multiple observations
         /// </summary>
@@ -224,7 +224,7 @@ namespace GralDomain
         public VerticalProfileConcentration VerticalProfileForm;
         public DomainformClosed DomainClosed;
         
-        private ShowFirstItem ShowFirst = new ShowFirstItem();	          // contains info about the first visible item form
+        private readonly ShowFirstItem ShowFirst = new ShowFirstItem();	          // contains info about the first visible item form
         /// <summary>
         /// Visible Columns in the search datagridview
         /// </summary>
@@ -247,20 +247,18 @@ namespace GralDomain
         /// <summary>
         /// Size & Position of Geo-Referenced Map
         /// </summary>
-        private MapSizes MapSize = new MapSizes();                         
+        private readonly MapSizes MapSize = new MapSizes();                         
                 
         private bool GRAL_Locked = false;
         private bool GRAMM_Locked = false;
         
         private MessageWindow MessageInfoForm;
         
-        private VerticalWindProfile ProfileConcentration = new VerticalWindProfile();
-        
-        private ToolTip InfoBoxTip = new ToolTip();
+        private readonly VerticalWindProfile ProfileConcentration = new VerticalWindProfile();
+       
+        private readonly ForceDomainRedraw DomainRedrawDelegate;
 
-        private ForceDomainRedraw DomainRedrawDelegate;
-
-        private ForceItemFormHide DomainItemFormHide;
+        private readonly ForceItemFormHide DomainItemFormHide;
 
         /// <summary>
         ///Cancel Token for all created await tasks
@@ -491,7 +489,6 @@ namespace GralDomain
                     CellHeightsType = 1;
                 }
             }
-            InfoBoxTip.AutomaticDelay = 0;
         }
         
 		/// <summary>
@@ -2213,6 +2210,14 @@ namespace GralDomain
             {
                 disp.StartPosition = FormStartPosition.Manual;
                 disp.Location = GetScreenPositionForNewDialog();
+
+                string grammpath = Path.Combine(Gral.Main.ProjectName, @"Computation");
+                if (MainForm.GRAMMwindfield != null) // try GRAMMPATH
+                {
+                    grammpath = MainForm.GRAMMwindfield;
+                }
+                disp.SCLPath = grammpath;
+
                 if (disp.ShowDialog() == DialogResult.OK) // Situation selected!
                 {
                     int sel = disp.selected_situation;
@@ -2382,16 +2387,32 @@ namespace GralDomain
                         if (windfieldfiles == false)
                         {
                             disp.selectGRAMM_GRAL = 0; // default: no selection
+                            string grammpath = Path.Combine(Gral.Main.ProjectName, @"Computation");
+                            if (MainForm.GRAMMwindfield != null) // try GRAMMPATH
+                            {
+                                grammpath = MainForm.GRAMMwindfield;
+                            }
+                            disp.GrammPath = grammpath;
+                            disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
                         }
                         else
                         {
                             disp.selectGRAMM_GRAL = 1; // default: select GRAMM
+                            string grammpath = Path.Combine(Gral.Main.ProjectName, @"Computation");
+                            if (MainForm.GRAMMwindfield != null) // try GRAMMPATH
+                            {
+                                grammpath = MainForm.GRAMMwindfield;
+                            }
+                            disp.GrammPath = grammpath;
+                            disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
                         }
                     }
-                    else
+                    else if(Gral.Main.ProjectName != null)
                     {
                         disp.selectGRAMM_GRAL = 2; // select GRAL
+                        disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
                     }
+
                     disp.StartPosition = FormStartPosition.Manual;
                     disp.Location = GetScreenPositionForNewDialog();
                     if (disp.ShowDialog() == DialogResult.OK)
@@ -2766,7 +2787,11 @@ namespace GralDomain
             if (temp != 0) // compressed files?
             {
                 //select dispersion situation
-                SelectDispersionSituation disp = new SelectDispersionSituation(this, MainForm);
+                SelectDispersionSituation disp = new SelectDispersionSituation(this, MainForm)
+                {
+                    selectGRAMM_GRAL = 2,
+                    GRZPath = files
+                };
                 disp.StartPosition = FormStartPosition.Manual;
                 disp.Location = GetScreenPositionForNewDialog();
                 if (disp.ShowDialog() == DialogResult.OK && disp.selected_situation > 0) // unzip the *.con files from this situation

--- a/Source/Gral/GRALDomain/Domain.cs
+++ b/Source/Gral/GRALDomain/Domain.cs
@@ -230,6 +230,10 @@ namespace GralDomain
         /// </summary>
         private bool[] SearchDatagridviewVisible = new bool[100];
         /// <summary>
+        /// Size of the search form
+        /// </summary>
+        private Size SearchFormSize = new Size(760, 450);
+        /// <summary>
         /// Show the lenght label?
         /// </summary>
         private bool ShowLenghtLabel = true;
@@ -3626,7 +3630,54 @@ namespace GralDomain
             
             Picturebox1_Paint();
         }
-        
+
+        void WriteAllItemsToDisk(object sender, EventArgs e)
+        {
+            if (EditAS.ItemData.Count > 0)
+            {
+                EditAndSaveAreaSourceData(sender, e);
+                EditAS.FillValues();
+            }
+
+            if (EditLS.ItemData.Count > 0)
+            {
+                EditAndSaveLineSourceData(sender, e);
+                EditLS.FillValues();
+            }
+            if (EditPS.ItemData.Count > 0)
+            {
+                EditAndSavePointSourceData(sender, e);
+                EditPS.FillValues();
+            }
+            if (EditPortals.ItemData.Count > 0)
+            {
+                EditAndSavePortalSourceData(sender, e);
+                EditPortals.FillValues();
+            }
+            if (EditB.ItemData.Count > 0)
+            {
+                EditAndSaveBuildingsData(sender, e);
+                EditB.FillValues();
+            }
+            if (EditR.ItemData.Count > 0)
+            {
+                EditAndSaveReceptorData(sender, e);
+                EditR.FillValues();
+            }
+            if (EditWall.ItemData.Count > 0)
+            {
+                EditAndSaveWallData(sender, e);
+                EditWall.FillValues();
+            }
+            if (EditVegetation.ItemData.Count > 0)
+            {
+                EditAndSaveVegetationData(sender, e);
+                EditVegetation.FillValues();
+            }
+            
+            Picturebox1_Paint();
+        }
+
         void CrossCursorToolStripMenuItemClick(object sender, EventArgs e)
         {
             Cursor = Cursors.Cross;

--- a/Source/Gral/GRALDomain/Domain.resx
+++ b/Source/Gral/GRALDomain/Domain.resx
@@ -10872,6 +10872,9 @@
   <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 54</value>
   </metadata>
+  <metadata name="toolStrip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 54</value>
+  </metadata>
   <data name="toolStripButton3.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACkAAAAYCAYAAABnRtT+AAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8

--- a/Source/Gral/GRALDomain/Domain_CloseForm.cs
+++ b/Source/Gral/GRALDomain/Domain_CloseForm.cs
@@ -118,7 +118,7 @@ namespace GralDomain
             
             
             MMO = null;
-            MMOData.WindVel =null; MMOData.WindDir = null; MMOData.SC = null; MMOData.Date = null; MMOData.Time = null; MMOData.Hour = null;
+            MMOData.SetWindVel(null); MMOData.SetWindDir(null); MMOData.SetSC(null); MMOData.SetDate(null); MMOData.SetTime(null); MMOData.SetHour(null);
             
             if (NorthArrowBitmap != null)
                 NorthArrowBitmap.Dispose();
@@ -239,7 +239,6 @@ namespace GralDomain
             }
             ItemOptions.Clear();
             ItemOptions.TrimExcess();
-            InfoBoxTip.Dispose();
             Application.DoEvents();
             
             try

--- a/Source/Gral/GRALDomain/Domain_LoadWindDataMatchProcess.cs
+++ b/Source/Gral/GRALDomain/Domain_LoadWindDataMatchProcess.cs
@@ -149,7 +149,7 @@ namespace GralDomain
                     {
                         MMO.dataGridView1.Rows[zeilenindex].Cells[1].Value = Convert.ToInt32(x0);
                         MMO.dataGridView1.Rows[zeilenindex].Cells[2].Value = Convert.ToInt32(y0);
-                        MMO.dataGridView1.Rows[zeilenindex].Cells[3].Value = Convert.ToInt32(Anemometerheight);
+                        MMO.dataGridView1.Rows[zeilenindex].Cells[3].Value = Convert.ToInt32((int) (Anemometerheight));
                     }
 
                     MeteoInput_Matchlocalobs FormatMetFile = new MeteoInput_Matchlocalobs()
@@ -158,6 +158,7 @@ namespace GralDomain
                         MetFile1 = metfile,
                         FileLength1 = MMOData.FileLenght,
                         DecSep1 = decsep,
+                        Anemometerheight = Anemometerheight,
                         Owner = this
                     };
                     if (FormatMetFile.ShowDialog() == DialogResult.OK)

--- a/Source/Gral/GRALDomain/Domain_LoadWindDataMatchProcess.cs
+++ b/Source/Gral/GRALDomain/Domain_LoadWindDataMatchProcess.cs
@@ -186,12 +186,12 @@ namespace GralDomain
                     
                     for (int length = 0; length < MMOData.FileLenght; length++)
                     {
-                        MMO.stunde[MMOdatagridindex][length] = MMOData.Hour[length];
-                        MMO.wind_speeds[MMOdatagridindex][length] = MMOData.WindVel[length];
-                        MMO.wind_direction[MMOdatagridindex][length] = MMOData.WindDir[length];
-                        MMO.datum[MMOdatagridindex][length] = MMOData.Date[length];
-                        MMO.zeit[MMOdatagridindex][length] = MMOData.Time[length];
-                        MMO.stability[MMOdatagridindex][length] = MMOData.SC[length];
+                        MMO.stunde[MMOdatagridindex][length] = MMOData.GetHour()[length];
+                        MMO.wind_speeds[MMOdatagridindex][length] = MMOData.GetWindVel()[length];
+                        MMO.wind_direction[MMOdatagridindex][length] = MMOData.GetWindDir()[length];
+                        MMO.datum[MMOdatagridindex][length] = MMOData.GetDate()[length];
+                        MMO.zeit[MMOdatagridindex][length] = MMOData.GetTime()[length];
+                        MMO.stability[MMOdatagridindex][length] = MMOData.GetSC()[length];
                     }
                     
                     char temp = char.Parse(FormatMetFile.DecSepUser);

--- a/Source/Gral/GRALDomain/Domain_SearchItems.cs
+++ b/Source/Gral/GRALDomain/Domain_SearchItems.cs
@@ -35,6 +35,7 @@ namespace GralDomain
 		/// </summary>
 		void SearchItemToolStripMenuItemClick(object sender, EventArgs e)
 		{
+			HideWindows(0); // hide all edit forms
 			using (Search_Item search = new Search_Item())
 			{
 				DataTable data = new DataTable();

--- a/Source/Gral/GRALDomain/Domain_Vectors_LoadRasterMaps.cs
+++ b/Source/Gral/GRALDomain/Domain_Vectors_LoadRasterMaps.cs
@@ -256,11 +256,24 @@ namespace GralDomain
                     {
                         //select dispersion situation
                         SelectDispersionSituation disp = new SelectDispersionSituation(this, MainForm);
-                        DialogResult dr = new DialogResult();
+                        
+                        if (windfieldenable == 2)
+                        {
+                            disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
+                        }
+                        else if (windfieldenable > 2 || windfieldenable == 1)
+                        {
+                            disp.GrammPath = Path.GetDirectoryName(MainForm.GRAMMwindfield);
+                        }
+                        else
+                        {
+
+                        }
+
                         disp.StartPosition = FormStartPosition.Manual;
                         disp.Location = new Point(met_st.Right + 20, met_st.Top);
-                        dr = disp.ShowDialog();
-                        if (dr == DialogResult.OK)
+
+                        if (disp.ShowDialog() == DialogResult.OK)
                         {
                             int dissit = disp.selected_situation;
 

--- a/Source/Gral/GRALDomain/DrawMap/Domain_DrawItemInfos.cs
+++ b/Source/Gral/GRALDomain/DrawMap/Domain_DrawItemInfos.cs
@@ -1,0 +1,118 @@
+#region Copyright
+///<remarks>
+/// <GRAL Graphical User Interface GUI>
+/// Copyright (C) [2019]  [Dietmar Oettl, Markus Kuntner]
+/// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation version 3 of the License
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+/// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///</remarks>
+#endregion
+
+/*
+ * Created by SharpDevelop.
+ * User: U0178969
+ * Date: 01.02.2019
+ * Time: 12:53
+ * 
+ * To change this template use Tools | Options | Coding | Edit Standard Headers.
+ */
+using System;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+
+using GralItemData;
+
+namespace GralDomain
+{
+    public partial class Domain
+    {
+        /// <summary>
+        /// Draw concentration values 
+        /// </summary>
+        private void DrawItemInfo(Graphics g, DrawingObjects _drobj, double form1_west, double form1_north,
+                               double factor_x, double factor_y, Font LabelFont, Brush LabelBrush)
+        {
+            if (_drobj.ItemInfo == null)
+            {
+                return;
+            }
+
+            int pb1_height = picturebox1.Height;
+            int pb1_width  = picturebox1.Width;
+            float[] tabStops = {50.0f, 50.0f, 20.0f, 20f };
+
+            StringFormat StringFormat2 = new StringFormat
+            {
+                LineAlignment = StringAlignment.Far,
+                Alignment = StringAlignment.Near,
+            };
+            StringFormat2.SetTabStops(0.0F, tabStops);
+
+            Pen penrec;
+            if (_drobj.LineColors[0] == Color.Transparent || _drobj.LineColor == Color.Transparent)
+            {
+                penrec = new Pen (Color.Blue);
+                _drobj.LineColor = Color.Blue;
+            }
+            else
+                penrec = new Pen(_drobj.LineColors[0]);
+
+            Brush whitebrush = new SolidBrush(Color.White);
+            Pen framePen = new Pen(Color.Black);
+
+            int width = 2;
+            if (_drobj.LineWidth <= 1)
+                if (_drobj.LineWidth == 0)
+                    width = 2;
+                else
+                    width = Math.Max (1, Math.Min(200, Convert.ToInt32(1 / BmpScale / MapSize.SizeX))); // 4 m lenght
+                else
+                    width = Math.Max (1, Math.Min(200, Convert.ToInt32((double) _drobj.LineWidth / 8 * factor_x)));
+            
+            //width = 3;
+            penrec.Width = width;
+            width *= 2;
+            
+            bool draw_label = (_drobj.Label == 2 || _drobj.Label == 3) && LabelFont.Height > 2;
+
+            int i = 0;
+            foreach(string info in _drobj.ItemInfo)
+            {
+                try
+                {
+                    if (i < _drobj.ShpPoints.Count)
+                    {
+                        float x1 = (float)((_drobj.ShpPoints[i].X + _drobj.ContourLabelDist - form1_west) * factor_x + TransformX) ;
+                        float y1 = (float)((_drobj.ShpPoints[i].Y - _drobj.ContourLabelDist - form1_north) * factor_y + TransformY);
+                        if ((x1 < 0) || (y1 < 0) || (x1 > pb1_width) || (y1 > pb1_height))
+                        {
+                        }
+                        else
+                        {
+                            SizeF stringSize = g.MeasureString(info, LabelFont);
+                            stringSize.Height += 10;
+                            stringSize.Width += 10;
+                            RectangleF stringPos = new RectangleF(x1, y1 - width, stringSize.Width, stringSize.Height);
+                            if (_drobj.FillYesNo)
+                            {
+                                g.FillRectangle(whitebrush, stringPos);
+                                g.DrawRectangle(framePen, stringPos.Left, stringPos.Top, stringPos.Width, stringPos.Height);
+                            }
+
+                            stringPos.Location = new PointF(stringPos.Left + 5, stringPos.Top - 5);
+                            g.DrawString(info, LabelFont, LabelBrush, stringPos, StringFormat2);
+                        }
+                    }
+                }
+                catch { }
+                i++;
+            }
+
+            framePen.Dispose();
+            whitebrush.Dispose();
+            penrec.Dispose();
+        }
+    }
+}

--- a/Source/Gral/GRALDomain/DrawMap/Domain_DrawItemInfos.cs
+++ b/Source/Gral/GRALDomain/DrawMap/Domain_DrawItemInfos.cs
@@ -12,9 +12,9 @@
 
 /*
  * Created by SharpDevelop.
- * User: U0178969
- * Date: 01.02.2019
- * Time: 12:53
+ * User: Markus
+ * Date: 16.01.2020
+ * Time: 18:50
  * 
  * To change this template use Tools | Options | Coding | Edit Standard Headers.
  */

--- a/Source/Gral/GRALDomain/DrawMap/Domain_DrawLineSources.cs
+++ b/Source/Gral/GRALDomain/DrawMap/Domain_DrawLineSources.cs
@@ -170,7 +170,7 @@ namespace GralDomain
                     width = Math.Max(width, _drobj.LineWidth);
                     Pen mypen = new Pen(Color2Transparent(200, Color.Green), width);
                     
-                    List <PointD> _pts = _ls.Pt;
+                    List <GralData.PointD_3d> _pts = _ls.Pt;
                     
                     x1 = (_pts[0].X - form1_west) * factor_x + TransformX;
                     y1 = (_pts[0].Y - form1_north) * factor_y + TransformY;

--- a/Source/Gral/GRALDomain/DrawMap/Domain_DrawRubberLines.cs
+++ b/Source/Gral/GRALDomain/DrawMap/Domain_DrawRubberLines.cs
@@ -202,7 +202,7 @@ namespace GralDomain
                         double y0 = y - CopiedItem.LineSource.Pt[0].Y;
                         
                         int i = 0;
-                        foreach(PointD _pt in CopiedItem.LineSource.Pt)
+                        foreach(GralData.PointD_3d _pt in CopiedItem.LineSource.Pt)
                         {
                             int x1 = (int)((x0 + _pt.X - form1_west) * factor_x + TransformX);
                             int y1 = (int)((y0 + _pt.Y - form1_north) * factor_y + TransformY);

--- a/Source/Gral/GRALDomain/DrawMap/Domain_Draw_Map.cs
+++ b/Source/Gral/GRALDomain/DrawMap/Domain_Draw_Map.cs
@@ -219,7 +219,13 @@ namespace GralDomain
                 {
                     DrawConcentrationValues(g, _drobj, form1_west, form1_north, factor_x, factor_y, LabelFont, LabelBrush);
                 }
-                
+
+                // draw info boxes
+                if ((obname == "ITEM INFO" && (_drobj.Show == true)))
+                {
+                    DrawItemInfo(g, _drobj, form1_west, form1_north, factor_x, factor_y, LabelFont, LabelBrush);
+                }
+
                 // draw Bitmap - Coordinate Raster
                 if ((obname.Substring(0, 3) == "BM:") && (_drobj.Show == true))
                 {

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxKeyDown.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxKeyDown.cs
@@ -521,10 +521,10 @@ namespace GralDomain
                 {
                     return;
                 }
-                PointD pt0 = CopiedItem.LineSource.Pt[0];
+                GralData.PointD_3d pt0 = CopiedItem.LineSource.Pt[0];
                 for (int i = 1; i < CopiedItem.LineSource.Pt.Count; i++)
                 {
-                    PointD pt = CopiedItem.LineSource.Pt[i];
+                    GralData.PointD_3d pt = CopiedItem.LineSource.Pt[i];
                     CopiedItem.LineSource.Pt[i] = Rotate(dir, pt, pt0);
                 }
             }
@@ -547,6 +547,31 @@ namespace GralDomain
         private PointD Rotate(int Dir, PointD pt, PointD pt0)
         {
             PointD temp = new PointD();
+            double angleInRadians = 10 * (Math.PI / 180);
+            if (Dir == 1)
+            {
+                angleInRadians = -10 * (Math.PI / 180);
+            }
+
+            double cosTheta = Math.Cos(angleInRadians);
+            double sinTheta = Math.Sin(angleInRadians);
+
+            temp.X = cosTheta * (pt.X - pt0.X) -
+                   sinTheta * (pt.Y - pt0.Y) + pt0.X;
+            temp.Y = sinTheta * (pt.X - pt0.X) +
+                    cosTheta * (pt.Y - pt0.Y) + pt0.Y;
+            return temp;
+        }
+        /// <summary>
+        /// Rotate the PointD_3D pt around point pt0 in 10 degree steps
+        /// </summary>
+        /// <param name="Dir">0: counterclockwise, 1: clockwise</param>
+        /// <param name="pt"></param>
+        /// <param name="pt0"></param>
+        /// <returns>Rotated PointD struct</returns>
+        private GralData.PointD_3d Rotate(int Dir, GralData.PointD_3d pt, GralData.PointD_3d pt0)
+        {
+            GralData.PointD_3d temp = new GralData.PointD_3d();
             double angleInRadians = 10 * (Math.PI / 180);
             if (Dir == 1)
             {

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDown.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDown.cs
@@ -128,6 +128,18 @@ namespace GralDomain
         {
             return new PointD(pt1.X - (pt1.X - pt2.X) / 2, pt1.Y - (pt1.Y - pt2.Y)/ 2);
         }
+        /// <summary>
+        /// Returns the point in the middle between pt1 and pt2
+        /// </summary>
+        /// <param name="pt1"></param>
+        /// <param name="pt2"></param>
+        /// <returns></returns>
+        GralData.PointD_3d GetPointBetween(GralData.PointD_3d pt1, GralData.PointD_3d pt2)
+        {
+            return new GralData.PointD_3d(pt1.X - (pt1.X - pt2.X) / 2, 
+                                          pt1.Y - (pt1.Y - pt2.Y) / 2,
+                                          pt1.Z - (pt1.Z - pt2.Z) / 2);
+        }
 
         // Section Form sends a closed message!
         void section_Form_Section_Closed(object sender, EventArgs e)

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDownLeft.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDownLeft.cs
@@ -383,15 +383,15 @@ namespace GralDomain
                                 double height = _psdata.Height;
 
                                 // show info in a Tooltip
-                                string infotext = "Name: " + _psdata.Name + "\n";
+                                string infotext = "'" + _psdata.Name + "'\n";
                                 if (height >= 0)
-                                    infotext += "Stack height [m]: " + height.ToString() + "\n";
+                                    infotext += "Height (rel) [m]: " + Math.Round(height, 1).ToString() + "\n";
                                 else
-                                    infotext += "Stack height (abs) [m]: " + Math.Abs(height).ToString() + "\n";
+                                    infotext += "Height (abs) [m]: " + Math.Abs(Math.Round(height,1)).ToString() + "\n";
 
-                                infotext += "Exit velocity [m/s]: " + _psdata.Velocity.ToString() + "\n";
-                                infotext += "Exit temperature [K]: " + _psdata.Temperature.ToString() + "\n";
-                                infotext += "Diameter [m]: " + _psdata.Diameter.ToString() + "\n";
+                                infotext += "Exit velocity [m/s]:  " + Math.Round(_psdata.Velocity, 1).ToString() + "\n";
+                                infotext += "Exit temperature [K]: " + Math.Round(_psdata.Temperature, 1).ToString() + "\n";
+                                infotext += "Diameter [m]: " + Math.Round(_psdata.Diameter, 2).ToString() + "\n";
                                 infotext += "Source group: " + Convert.ToString(_psdata.Poll.SourceGroup) + "\n";
                                 for (int r = 0; r < 10; r++)
                                 {
@@ -405,7 +405,16 @@ namespace GralDomain
                                 for (int r = 0; r < Gral.Main.PollutantList.Count; r++)
                                 {
                                     if (emission[r] > 0)
-                                        infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h or MOU/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                    {
+                                        if (Gral.Main.PollutantList[r] != "Odour")
+                                        {
+                                            infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                        }
+                                        else
+                                        {
+                                            infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[MOU/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                        }
+                                    }
                                 }
 
                                 AddItemInfoToDrawingObject(infotext, _psdata.Pt.X, _psdata.Pt.Y);
@@ -442,8 +451,8 @@ namespace GralDomain
                                 EditR.FillValues();
 
                                 //Ausgabe der Info in Infobox
-                                string infotext = "Name: " + _rd.Name + "\n";
-                                infotext += "Receptor height [m]: " + Math.Round(_rd.Height, 1).ToString();
+                                string infotext = "'" + _rd.Name + "'\n";
+                                infotext += "Height [m]: " + Math.Round(_rd.Height, 1).ToString();
 
                                 AddItemInfoToDrawingObject(infotext, _rd.Pt.X, _rd.Pt.Y);
 
@@ -506,13 +515,13 @@ namespace GralDomain
 
                                             //Ausgabe der Info in Infobox
 
-                                            string infotext = "Name: " + _as.Name + "\n";
+                                            string infotext = "'" + _as.Name + "'\n";
                                             if (height >= 0)
-                                                infotext += "Mean height [m]: " + height.ToString() + "\n";
+                                                infotext += "Mean height (rel) [m]:  " + Math.Round(height, 1).ToString() + "\n";
                                             else
-                                                infotext += "Mean height (abs) [m]: " + Math.Abs(height).ToString() + "\n";
+                                                infotext += "Mean height (abs) [m]:  " + Math.Abs(Math.Round(height, 1)).ToString() + "\n";
 
-                                            infotext += "Vertical extension [m]: " + _as.VerticalExt.ToString() + "\n";
+                                            infotext +=     "Vertical extension [m]: " + Math.Round(_as.VerticalExt, 1).ToString() + "\n";
                                             infotext += @"Area [m" + Gral.Main.SquareString + "]: " + Math.Round(_as.Area, 1).ToString() + "\n";
                                             infotext += "Source group: " + _as.Poll.SourceGroup + "\n";
                                             for (int r = 0; r < 10; r++)
@@ -527,7 +536,16 @@ namespace GralDomain
                                             for (int r = 0; r < Gral.Main.PollutantList.Count; r++)
                                             {
                                                 if (emission[r] > 0)
-                                                    infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h or OU/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                                {
+                                                    if (Gral.Main.PollutantList[r] != "Odour")
+                                                    {
+                                                        infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                                    }
+                                                    else
+                                                    {
+                                                        infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[OU/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                                    }
+                                                }
                                             }
 
                                             AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
@@ -573,9 +591,9 @@ namespace GralDomain
                                 double height = _vdata.VerticalExt;
 
                                 //Ausgabe der Info in Infobox
-                                string infotext = "Name: " + _vdata.Name + "\n";
-                                infotext += "Height [m]: " + Math.Abs(height) + "\n";
-                                infotext += @"Area [m" + Gral.Main.SquareString + "]: " + _vdata.Area + "\n";
+                                string infotext = "'" + _vdata.Name + "'\n";
+                                infotext += "Height (rel) [m]: " + Math.Abs(Math.Round(height, 1)) + "\n";
+                                infotext += @"Area [m" + Gral.Main.SquareString + "]: " + Math.Round(_vdata.Area) + "\n";
                                 AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                 stop = true;
                                 break;
@@ -615,11 +633,11 @@ namespace GralDomain
                                 double height = _bd.Height;
 
                                 //Ausgabe der Info in Infobox
-                                string infotext = "Name: " + _bd.Name + "\n";
+                                string infotext = "'" + _bd.Name + "'\n";
                                 if (height >= 0)
-                                    infotext += "Height [m]: " + _bd.Height.ToString() + "\n";
+                                    infotext += "Height (rel) [m]: " + Math.Round(_bd.Height, 1).ToString() + "\n";
                                 else
-                                    infotext += "Height (abs) [m]: " + St_F.DblToIvarTxt(Math.Abs(height)) + "\n";
+                                    infotext += "Height (abs) [m]: " + St_F.DblToIvarTxt(Math.Abs(Math.Round(height, 1))) + "\n";
 
                                 infotext += "Lower bound [m]: " + _bd.LowerBound + "\n";
                                 infotext += @"Area [m" + Gral.Main.SquareString + "]: " + Math.Round(_bd.Area, 1).ToString() + "\n";
@@ -676,28 +694,30 @@ namespace GralDomain
                                     stop = true;
 
                                     //Ausgabe der Info in Infobox
-                                    string infotext = "Name: " + _ls.Name + "\n";
+                                    string infotext = "'" + _ls.Name + "'\n";
                                     if (_ls.Height >= 0)
                                     {
-                                        infotext += "Height (rel): " + Math.Abs(_ls.Height).ToString() + "\n";
+                                        infotext += "Height (rel) [m]: \t" + Math.Abs(Math.Round(_ls.Height, 1)).ToString() + "\n";
                                     }
                                     else
                                     {
-                                        infotext += "Height (abs): " + Math.Abs(_ls.Height).ToString() + "\n";
+                                        infotext += "Height (abs) [m]: \t" + Math.Abs(Math.Round(_ls.Height, 1)).ToString() + "\n";
                                     }
-                                    infotext += "Vert. extension: " + _ls.VerticalExt.ToString() + "\n";
-                                    infotext += "Width: " + _ls.Width.ToString() + "\n";
+                                    infotext += "Vert. extension [m]: \t" + Math.Round(_ls.VerticalExt, 1).ToString() + "\n";
+                                    infotext += "Width [m]: \t" + Math.Round(_ls.Width, 1).ToString() + "\n";
 
-                                    infotext += "Veh/Day: " + _ls.Nemo.AvDailyTraffic.ToString() + "\n";
-                                    infotext += "Heavy Duty Veh [%]: " + _ls.Nemo.ShareHDV.ToString() + "\n";
-                                    infotext += "Slope [%]: " + _ls.Nemo.Slope.ToString() + "\n";
-                                    infotext += "Reference Year: " + _ls.Nemo.BaseYear.ToString() + "\n";
+                                    if (_ls.Nemo.AvDailyTraffic > 0)
+                                    {
+                                        infotext += "Veh/Day:            " + _ls.Nemo.AvDailyTraffic.ToString() + "\n";
+                                        infotext += "Heavy Duty Veh [%]: " + _ls.Nemo.ShareHDV.ToString() + "\n";
+                                        infotext += "Slope [%]:          " + _ls.Nemo.Slope.ToString() + "\n";
+                                        infotext += "Reference Year:     " + _ls.Nemo.BaseYear.ToString() + "\n";
+                                        infotext += "Traffic Situation:  " + EditLS.GetSelectedListBox1Item() + "\n";
+                                    }
 
                                     length = St_F.CalcLenght(_ls.Pt);
-
-                                    infotext += "Length [km]: " + Convert.ToString(Math.Round(length, 1)) + "\n";
-                                    infotext += "Traffic Situation: " + EditLS.GetSelectedListBox1Item() + "\n";
-
+                                    infotext += "Length [km]: \t" + Convert.ToString(Math.Round(length / 1000, 3)) + "\n";
+                                    
                                     foreach (PollutantsData _poll in _ls.Poll)
                                     {
                                         for (int r = 0; r < 10; r++)
@@ -713,7 +733,16 @@ namespace GralDomain
                                     for (int r = 0; r < Gral.Main.PollutantList.Count; r++)
                                     {
                                         if (emission[r] > 0)
-                                            infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h/km]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                        {
+                                            if (Gral.Main.PollutantList[r] != "Odour")
+                                            {
+                                                infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h/km]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                            }
+                                            else
+                                            {
+                                                infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[OU/h/km]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                            }
+                                        }       
                                     }
                                     AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                     
@@ -753,17 +782,18 @@ namespace GralDomain
                                 EditPortals.FillValues();
 
                                 //Ausgabe der Info in Infobox
-                                string infotext = "Name: " + _po.Name + "\n";
+                                string infotext = "'" + _po.Name + "'\n";
                                 if (_po.BaseHeight >= 0)
                                 {
-                                    infotext += "Base height (rel): " + Math.Abs(_po.BaseHeight).ToString() + "\n";
+                                    infotext += "Base height (rel)[m]: " + Math.Abs(Math.Round(_po.BaseHeight, 1)).ToString() + "\n";
                                 }
                                 else
                                 {
-                                    infotext += "Base height (abs): " + Math.Abs(_po.BaseHeight).ToString() + "\n";
+                                    infotext += "Base height (abs)[m]: " + Math.Abs(Math.Round(_po.BaseHeight, 1)).ToString() + "\n";
                                 }
-                                infotext += "Height [m]: " + _po.Height.ToString() + "\n";
-                                infotext += "Section [m²]: " + _po.Crosssection.ToString() + "\n";
+                                infotext += "Height [m]: " + Math.Round(_po.Height, 1).ToString() + "\n";
+                                int crosssection = Convert.ToInt32(_po.Height * Math.Sqrt(Math.Pow(_po.Pt1.X - _po.Pt2.X, 2) + Math.Pow(_po.Pt1.Y - _po.Pt2.Y, 2)));
+                                infotext += "Section [m²]: " + crosssection.ToString() + "\n";
                                 if (_po.Direction.Contains("1"))
                                 {
                                     infotext += "Bidirectional \n";
@@ -788,7 +818,16 @@ namespace GralDomain
                                 for (int r = 0; r < Gral.Main.PollutantList.Count; r++)
                                 {
                                     if (emission[r] > 0)
-                                        infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                    {
+                                        if (Gral.Main.PollutantList[r] != "Odour")
+                                        {
+                                            infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                        }
+                                        else
+                                        {
+                                            infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[OU/h]: \t" + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
+                                        }
+                                    }               
                                 }
                                 AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                 stop = true;
@@ -840,7 +879,7 @@ namespace GralDomain
                                     EditWall.FillValues();
                                     stop = true;
                                   
-                                    AddItemInfoToDrawingObject("Name: " + _wd.Name, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
+                                    AddItemInfoToDrawingObject("'" + _wd.Name + "'", (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
 
                                     break;
                                 }

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDownLeft.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainPictureboxMouseDownLeft.cs
@@ -408,15 +408,13 @@ namespace GralDomain
                                         infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h or MOU/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
                                 }
 
-                                InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
-
+                                AddItemInfoToDrawingObject(infotext, _psdata.Pt.X, _psdata.Pt.Y);
+                                
                                 stop = true;
                                 break;
                             }
                             i = i + 1;
                         }
-
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -446,14 +444,14 @@ namespace GralDomain
                                 //Ausgabe der Info in Infobox
                                 string infotext = "Name: " + _rd.Name + "\n";
                                 infotext += "Receptor height [m]: " + Math.Round(_rd.Height, 1).ToString();
-                                InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
+
+                                AddItemInfoToDrawingObject(infotext, _rd.Pt.X, _rd.Pt.Y);
 
                                 stop = true;
                                 break;
                             }
                             i++;
                         }
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -531,15 +529,16 @@ namespace GralDomain
                                                 if (emission[r] > 0)
                                                     infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h or OU/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
                                             }
-                                            InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
 
+                                            AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
+                                            
                                         }
                                     }
                                     i = i + 1;
                                 }
                             }
                         }
-                        Picturebox1_Paint(); // 
+                        
                         Focus();
                     }
                     break;
@@ -577,13 +576,12 @@ namespace GralDomain
                                 string infotext = "Name: " + _vdata.Name + "\n";
                                 infotext += "Height [m]: " + Math.Abs(height) + "\n";
                                 infotext += @"Area [m" + Gral.Main.SquareString + "]: " + _vdata.Area + "\n";
-                                InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
+                                AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                 stop = true;
                                 break;
                             }
                             i = i + 1;
                         }
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -625,13 +623,12 @@ namespace GralDomain
 
                                 infotext += "Lower bound [m]: " + _bd.LowerBound + "\n";
                                 infotext += @"Area [m" + Gral.Main.SquareString + "]: " + Math.Round(_bd.Area, 1).ToString() + "\n";
-                                InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
+                                AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                 stop = true;
                                 break;
                             }
                             i = i + 1;
                         }
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -718,14 +715,13 @@ namespace GralDomain
                                         if (emission[r] > 0)
                                             infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h/km]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
                                     }
-                                    InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
-
+                                    AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
+                                    
                                     break;
                                 }
                             }
                             i = i + 1;
                         }
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -794,14 +790,12 @@ namespace GralDomain
                                     if (emission[r] > 0)
                                         infotext += Convert.ToString(Gral.Main.PollutantList[r]) + "[kg/h]: " + Convert.ToString(Math.Round(emission[r], 4)) + "\n";
                                 }
-                                InfoBoxTip.Show(infotext, this, e.X, e.Y, 8000);
-
+                                AddItemInfoToDrawingObject(infotext, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
                                 stop = true;
                                 break;
                             }
                             i = i + 1;
                         }
-                        Picturebox1_Paint(); // 
                         Focus();
                     }
                     break;
@@ -845,9 +839,8 @@ namespace GralDomain
                                     SelectedItems.Add(i);
                                     EditWall.FillValues();
                                     stop = true;
-
-                                    //Ausgabe der Info in Infobox
-                                    InfoBoxTip.Show("Name: " + _wd.Name, this, e.X, e.Y, 8000);
+                                  
+                                    AddItemInfoToDrawingObject("Name: " + _wd.Name, (float)St_F.TxtToDbl(textBox1.Text, false), (float)St_F.TxtToDbl(textBox2.Text, false));
 
                                     break;
                                 }
@@ -1252,6 +1245,28 @@ namespace GralDomain
                     SetNewEdgepointVegetation();
                     break;
             }
+        }
+
+
+        /// <summary>
+        /// Add the string a to ItemOptions 
+        /// </summary>
+        /// <param name="info"></param>
+        private void AddItemInfoToDrawingObject(string info, double x1, double y1)
+        {
+            int index = CheckForExistingDrawingObject("ITEM INFO");
+            DrawingObjects _drobj = ItemOptions[index];
+            if (_drobj.ShpPoints == null)
+            {
+                _drobj.ShpPoints = new List<PointF>();
+            }
+            if (_drobj.ItemInfo == null)
+            {
+                _drobj.ItemInfo = new List<string>();
+            }
+            _drobj.ShpPoints.Add(new PointF((float) x1, (float) y1));
+            _drobj.ItemInfo.Add(info);
+            Picturebox1_Paint();
         }
     }
 }

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickLine.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickLine.cs
@@ -110,7 +110,9 @@ namespace GralDomain
 				
 				for(int i = 0; i < CopiedItem.LineSource.Pt.Count; i++)
 				{
-					CopiedItem.LineSource.Pt[i] = new PointD(x  - x0 + CopiedItem.LineSource.Pt[i].X, y - y0 + CopiedItem.LineSource.Pt[i].Y);
+					CopiedItem.LineSource.Pt[i] = new GralData.PointD_3d(x  - x0 + CopiedItem.LineSource.Pt[i].X, 
+																		 y - y0 + CopiedItem.LineSource.Pt[i].Y,
+																		 CopiedItem.LineSource.Pt[i].Z);
 				}
 				
 				LineSourceData Temp = new LineSourceData(CopiedItem.LineSource);
@@ -161,13 +163,14 @@ namespace GralDomain
 				int j = 0;
 				int indexmin = 0;
 				double min = 100000000;
-				foreach(PointD _pt in EditLS.ItemData[i].Pt)
+				foreach(GralData.PointD_3d _pt in EditLS.ItemData[i].Pt)
 				{
 					double dx = pt.X - _pt.X;
 					double dy = pt.Y - _pt.Y;
-					if (Math.Sqrt(dx*dx+dy*dy) < min) // search min
+					
+					if (Math.Sqrt(dx * dx + dy * dy) < min) // search min
 					{
-						min = Math.Sqrt(dx*dx+dy*dy);
+						min = Math.Sqrt(dx * dx + dy * dy);
 						indexmin = j;
 					}
 					j++;
@@ -181,11 +184,13 @@ namespace GralDomain
 					}
 					EditLS.ItemData[i].Pt.Insert(indexmin + 1, GetPointBetween(EditLS.ItemData[i].Pt[indexmin], EditLS.ItemData[i].Pt[indexnext]));
 				}
+
 				int count = 0;
-				foreach(PointD _pt in EditLS.ItemData[i].Pt)
+				foreach(GralData.PointD_3d _pt in EditLS.ItemData[i].Pt)
 				{
 					EditLS.CornerLineX[count] = _pt.X;
 					EditLS.CornerLineY[count] = _pt.Y;
+					EditLS.CornerLineZ[count] = _pt.Z;
 					count++;
 				}
 				EditLS.SetNumberOfVerticesText(EditLS.ItemData[i].Pt.Count.ToString());
@@ -208,13 +213,13 @@ namespace GralDomain
 				int j = 0;
 				int indexmin = 0;
 				double min = 100000000;
-				foreach(PointD _pt in EditLS.ItemData[i].Pt)
+				foreach(GralData.PointD_3d _pt in EditLS.ItemData[i].Pt)
 				{
 					double dx = pt.X - _pt.X;
 					double dy = pt.Y - _pt.Y;
-					if (Math.Sqrt(dx*dx+dy*dy) < min) // search min
+					if (Math.Sqrt(dx * dx + dy * dy) < min) // search min
 					{
-						min = Math.Sqrt(dx*dx+dy*dy);
+						min = Math.Sqrt(dx * dx + dy * dy);
 						indexmin = j;
 					}
 					j++;
@@ -224,10 +229,11 @@ namespace GralDomain
 					EditLS.ItemData[i].Pt.RemoveAt(indexmin);
 				}
 				int count = 0;
-				foreach(PointD _pt in EditLS.ItemData[i].Pt)
+				foreach(GralData.PointD_3d _pt in EditLS.ItemData[i].Pt)
 				{
 					EditLS.CornerLineX[count] = _pt.X;
 					EditLS.CornerLineY[count] = _pt.Y;
+					EditLS.CornerLineZ[count] = _pt.Z;
 					count++;
 				}
 				EditLS.SetNumberOfVerticesText(EditLS.ItemData[i].Pt.Count.ToString());

--- a/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickReceptor.cs
+++ b/Source/Gral/GRALDomain/PictureboxMouseAndKeys/DomainRightClickReceptor.cs
@@ -92,7 +92,7 @@ namespace GralDomain
 			}
 			if (mi.Index == 2) // Delete Receptor
 			{
-				EditR.RemoveOne();
+				EditR.RemoveOne(true);
 				EditAndSaveReceptorData(null, null); // save changes
 				Picturebox1_Paint();
 				if (EditR.ItemData.Count > 0)

--- a/Source/Gral/GRALDomainImportFiles/Domain_Import_PointSources.cs
+++ b/Source/Gral/GRALDomainImportFiles/Domain_Import_PointSources.cs
@@ -95,14 +95,14 @@ namespace GralDomain
                                         }
                                         if (text1.Length > 16)
                                         {
-                                            _psdata.Dep[0].Frac_2_5 = Convert.ToInt32(text1[11]);
-                                            _psdata.Dep[0].Frac_10 = Convert.ToInt32(text1[12]);
-                                            _psdata.Dep[0].DM_30 = Convert.ToInt32(text1[13]);
-                                            _psdata.Dep[0].Density = Convert.ToDouble(text1[14], ic);
-                                            _psdata.Dep[0].V_Dep1 = Convert.ToDouble(text1[15], ic);
-                                            _psdata.Dep[0].V_Dep2 = Convert.ToDouble(text1[16], ic);
-                                            _psdata.Dep[0].V_Dep3 = Convert.ToDouble(text1[17], ic);
-                                            _psdata.Dep[0].Conc = Convert.ToInt32(text1[18], ic);
+                                            _psdata.GetDep()[0].Frac_2_5 = Convert.ToInt32(text1[11]);
+                                            _psdata.GetDep()[0].Frac_10 = Convert.ToInt32(text1[12]);
+                                            _psdata.GetDep()[0].DM_30 = Convert.ToInt32(text1[13]);
+                                            _psdata.GetDep()[0].Density = Convert.ToDouble(text1[14], ic);
+                                            _psdata.GetDep()[0].V_Dep1 = Convert.ToDouble(text1[15], ic);
+                                            _psdata.GetDep()[0].V_Dep2 = Convert.ToDouble(text1[16], ic);
+                                            _psdata.GetDep()[0].V_Dep3 = Convert.ToDouble(text1[17], ic);
+                                            _psdata.GetDep()[0].Conc = Convert.ToInt32(text1[18], ic);
                                         }
                                         EditPS.ItemData.Add(_psdata);
                                     }

--- a/Source/Gral/GRALItemData/ItemDataAreaSource.cs
+++ b/Source/Gral/GRALItemData/ItemDataAreaSource.cs
@@ -39,8 +39,17 @@ namespace GralItemData
 		public float RasterSize	{ get; set;}
 		public List<GralDomain.PointD> Pt  { get; set;}
 		public PollutantsData Poll	{ get; set;}
-		public Deposition[] Dep	{ get; set;}
-		
+
+		private Deposition[] dep;
+		public Deposition[] GetDep()
+		{
+			return dep;
+		}
+		public void SetDep(Deposition[] value)
+		{
+			dep = value;
+		}
+
 		private static CultureInfo ic = CultureInfo.InvariantCulture;
 		
 		/// <summary>
@@ -50,14 +59,14 @@ namespace GralItemData
 		{
 			Name = "AS";
 			Poll = new PollutantsData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			VerticalExt = 3;
 			Pt = new List<PointD>();
 			
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(); // initialize Deposition array
-				Dep[i].init();
+				GetDep()[i] = new Deposition(); // initialize Deposition array
+				GetDep()[i].init();
 			}
 		}
 		
@@ -70,7 +79,7 @@ namespace GralItemData
 			int version = 0;
 			string[] text = new string[1];
 			text = sourcedata.Split(new char[] { ',' });
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Pt = new List<PointD>();
 			
 			try
@@ -116,8 +125,8 @@ namespace GralItemData
 						{
 							for (int i = 0; i < 10; i++)
 							{
-								Dep[i] = new Deposition(); // initialize Deposition array
-								Dep[i].String_to_Val(depostart + i * 10, text);
+								GetDep()[i] = new Deposition(); // initialize Deposition array
+								GetDep()[i].String_to_Val(depostart + i * 10, text);
 							}
 						}
 						catch{}
@@ -126,8 +135,8 @@ namespace GralItemData
 					{
 						for (int i = 0; i < 10; i++)
 						{
-							Dep[i] = new Deposition(); // initialize Deposition array
-							Dep[i].init();
+							GetDep()[i] = new Deposition(); // initialize Deposition array
+							GetDep()[i].init();
 						}
 					}
 				}
@@ -140,15 +149,15 @@ namespace GralItemData
 			{
 				Name = String.Empty;
 				Poll = new PollutantsData();
-				Dep = new Deposition[10];
+				SetDep(new Deposition[10]);
 				Height = 0;
 				VerticalExt = 3;
 				Pt = new List<PointD>();
 				
 				for (int i = 0; i < 10; i++)
 				{
-					Dep[i] = new Deposition(); // initialize Deposition array
-					Dep[i].init();
+					GetDep()[i] = new Deposition(); // initialize Deposition array
+					GetDep()[i].init();
 				}
 			}
 		}
@@ -171,7 +180,7 @@ namespace GralItemData
 			}
 			
 			Poll = new PollutantsData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			
 			Poll.SourceGroup = other.Poll.SourceGroup;
 			for (int i = 0; i < 10; i++)
@@ -179,11 +188,11 @@ namespace GralItemData
 				Poll.EmissionRate[i] = other.Poll.EmissionRate[i];
 				Poll.Pollutant[i] = other.Poll.Pollutant[i];
 			}
-			
-			Dep = new Deposition[10];
+
+			SetDep(new Deposition[10]);
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(other.Dep[i]); // initialize Deposition array
+				GetDep()[i] = new Deposition(other.GetDep()[i]); // initialize Deposition array
 			}
 		}
 		
@@ -219,7 +228,7 @@ namespace GralItemData
 			dummy += ",Dep@_,";
 			for (int i = 0; i < 10; i++)
 			{
-				dummy += Dep[i].ToString() + ",";
+				dummy += GetDep()[i].ToString() + ",";
 			}
 			
 			return dummy;

--- a/Source/Gral/GRALItemData/ItemDataLineSource.cs
+++ b/Source/Gral/GRALItemData/ItemDataLineSource.cs
@@ -41,8 +41,17 @@ namespace GralItemData
 		public List<GralData.PointD_3d> Pt  { get; set;}
 		public List <PollutantsData> Poll	{ get; set;}
 		public NemoData Nemo		{ get; set;}
-		public Deposition[] Dep	{ get; set;}
-		
+
+		private Deposition[] dep;
+		public Deposition[] GetDep()
+		{
+			return dep;
+		}
+		public void SetDep(Deposition[] value)
+		{
+			dep = value;
+		}
+
 		private static CultureInfo ic = CultureInfo.InvariantCulture;
 		
 		/// <summary>
@@ -57,13 +66,13 @@ namespace GralItemData
 			Lines3D = false;
 			Poll = new List<PollutantsData>();
 			Nemo = new NemoData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Pt = new List<GralData.PointD_3d>();
 			
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(); // initialize Deposition array
-				Dep[i].init();
+				GetDep()[i] = new Deposition(); // initialize Deposition array
+				GetDep()[i].init();
 			}
 		}
 		
@@ -76,7 +85,7 @@ namespace GralItemData
 			int version = 0;
 			string[] text = new string[1];
 			text = sourcedata.Split(new char[] { ',' });
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Nemo = new NemoData();
 			Pt = new List<GralData.PointD_3d> ();
 			
@@ -152,8 +161,8 @@ namespace GralItemData
 						{
 							for (int i = 0; i < 10; i++)
 							{
-								Dep[i] = new Deposition(); // initialize Deposition array
-								Dep[i].String_to_Val(depostart + i * 10, text);
+								GetDep()[i] = new Deposition(); // initialize Deposition array
+								GetDep()[i].String_to_Val(depostart + i * 10, text);
 							}
 						}
 						catch{}
@@ -162,8 +171,8 @@ namespace GralItemData
 					{
 						for (int i = 0; i < 10; i++)
 						{
-							Dep[i] = new Deposition(); // initialize Deposition array
-							Dep[i].init();
+							GetDep()[i] = new Deposition(); // initialize Deposition array
+							GetDep()[i].init();
 						}
 					}
 										
@@ -200,14 +209,14 @@ namespace GralItemData
 				
 				Poll = new List<PollutantsData>();
 				Nemo = new NemoData();
-				Dep = new Deposition[10];
+				SetDep(new Deposition[10]);
 				Lines3D = false;
 				Pt = new List<GralData.PointD_3d>();
 				
 				for (int i = 0; i < 10; i++)
 				{
-					Dep[i] = new Deposition(); // initialize Deposition array
-					Dep[i].init();
+					GetDep()[i] = new Deposition(); // initialize Deposition array
+					GetDep()[i].init();
 				}
 			}
 		}
@@ -242,10 +251,10 @@ namespace GralItemData
 			}
 						
 			Nemo = new NemoData(other.Nemo);
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(other.Dep[i]); // initialize Deposition array
+				GetDep()[i] = new Deposition(other.GetDep()[i]); // initialize Deposition array
 			}
 		}
 		
@@ -308,7 +317,7 @@ namespace GralItemData
 			dummy += ",Dep@_,";
 			for (int i = 0; i < 10; i++)
 			{
-				dummy += Dep[i].ToString() + ",";
+				dummy += GetDep()[i].ToString() + ",";
 			}
 			
 			dummy += St_F.DblToIvarTxt(Math.Round(VerticalExt, 1)) + ",";

--- a/Source/Gral/GRALItemData/ItemDataLineSource.cs
+++ b/Source/Gral/GRALItemData/ItemDataLineSource.cs
@@ -37,7 +37,8 @@ namespace GralItemData
 		public float Height		{ get; set;}
 		public float VerticalExt{ get; set;}
 		public float Width   	{ get; set;}
-		public List<GralDomain.PointD> Pt  { get; set;}
+		public bool  Lines3D    { get; set;}
+		public List<GralData.PointD_3d> Pt  { get; set;}
 		public List <PollutantsData> Poll	{ get; set;}
 		public NemoData Nemo		{ get; set;}
 		public Deposition[] Dep	{ get; set;}
@@ -53,10 +54,11 @@ namespace GralItemData
 			Section = "1";
 			VerticalExt = 3;
 			Width = 7;
+			Lines3D = false;
 			Poll = new List<PollutantsData>();
 			Nemo = new NemoData();
 			Dep = new Deposition[10];
-			Pt = new List<PointD>();
+			Pt = new List<GralData.PointD_3d>();
 			
 			for (int i = 0; i < 10; i++)
 			{
@@ -76,7 +78,7 @@ namespace GralItemData
 			text = sourcedata.Split(new char[] { ',' });
 			Dep = new Deposition[10];
 			Nemo = new NemoData();
-			Pt = new List<PointD>();
+			Pt = new List<GralData.PointD_3d> ();
 			
 			try
 			{
@@ -113,6 +115,15 @@ namespace GralItemData
 							Poll.Add(_poll);
 						}
 					}
+
+					if (version > 1)
+					{
+						int _3dLines = Convert.ToInt32(text[index++]);
+						if (_3dLines == 1)
+						{
+							Lines3D = true;
+						}
+					}
 					
 					int vertices_number = Convert.ToInt32(text[index++]); // number of vertices
 					
@@ -120,7 +131,12 @@ namespace GralItemData
 					{
 						double x = St_F.TxtToDbl(text[index++], false);
 						double y = St_F.TxtToDbl(text[index++], false);
-						Pt.Add(new PointD(x, y));
+						double z = Height;
+						if (version > 1)
+						{
+							z = St_F.TxtToDbl(text[index++], false);
+						}
+						Pt.Add(new GralData.PointD_3d(x, y, z));
 					}
 					
 					int depostart = text.Length;
@@ -185,7 +201,8 @@ namespace GralItemData
 				Poll = new List<PollutantsData>();
 				Nemo = new NemoData();
 				Dep = new Deposition[10];
-				Pt = new List<PointD>();
+				Lines3D = false;
+				Pt = new List<GralData.PointD_3d>();
 				
 				for (int i = 0; i < 10; i++)
 				{
@@ -205,8 +222,8 @@ namespace GralItemData
 			Height = other.Height;
 			Section = other.Section;
 			Width = other.Width;
-			Pt = new List<PointD>();
-			foreach (PointD _pt in other.Pt)
+			Pt = new List<GralData.PointD_3d>();
+			foreach (GralData.PointD_3d _pt in other.Pt)
 			{
 				Pt.Add(_pt);
 			}
@@ -235,7 +252,8 @@ namespace GralItemData
 		/// <summary>
 		/// Convert object data to a string as used in the item file
 		/// </summary>
-		public override string ToString()
+		/// <param name="version">0 and 1: return 2D line format, 2: write 3D format</param>
+		public string ToString(int version)
 		{
 			if (Name == null || Name == String.Empty)
 			{
@@ -258,12 +276,33 @@ namespace GralItemData
 						St_F.DblToIvarTxt(_poll.EmissionRate[i]) + ",";
 				}
 			}
-			
-			
-			dummy += Pt.Count.ToString();
-			foreach(PointD _pt in Pt)
+
+			if (version > 1)
 			{
-				dummy += "," + Math.Round(_pt.X, 1).ToString(ic) + "," + Math.Round(_pt.Y, 1).ToString(ic);
+				if (Lines3D)
+				{
+					dummy += "1,";
+				}
+				else
+				{
+					dummy += "0,";
+				}
+			}
+
+			dummy += Pt.Count.ToString();
+			if (version > 1)
+			{
+				foreach (GralData.PointD_3d _pt in Pt)
+				{
+					dummy += "," + Math.Round(_pt.X, 1).ToString(ic) + "," + Math.Round(_pt.Y, 1).ToString(ic) + "," + Math.Round(_pt.Z, 1).ToString(ic);
+				}
+			}
+			else
+			{
+				foreach (GralData.PointD_3d _pt in Pt)
+				{
+					dummy += "," + Math.Round(_pt.X, 1).ToString(ic) + "," + Math.Round(_pt.Y, 1).ToString(ic);
+				}
 			}
 			
 			dummy += ",Dep@_,";

--- a/Source/Gral/GRALItemData/ItemDataPointSource.cs
+++ b/Source/Gral/GRALItemData/ItemDataPointSource.cs
@@ -38,7 +38,17 @@ namespace GralItemData
 		public float Diameter	{ get; set;}
 		public GralDomain.PointD Pt 		{ get; set;}
 		public PollutantsData Poll	{ get; set;}
-		public Deposition[] Dep	{ get; set;}
+
+		private Deposition[] dep;
+		public Deposition[] GetDep()
+		{
+			return dep;
+		}
+		public void SetDep(Deposition[] value)
+		{
+			dep = value;
+		}
+
 		public string VelocityTimeSeries		{ get; set;}
 		public string TemperatureTimeSeries	{ get; set;}
 		
@@ -51,7 +61,7 @@ namespace GralItemData
 		{
 			Name = "PS";
 			Poll = new PollutantsData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Temperature = 20;
 			Diameter = 0.2F;
 			Height = 10;
@@ -59,8 +69,8 @@ namespace GralItemData
 			
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(); // initialize Deposition array
-				Dep[i].init();
+				GetDep()[i] = new Deposition(); // initialize Deposition array
+				GetDep()[i].init();
 			}
 		}
 		
@@ -73,7 +83,7 @@ namespace GralItemData
 			int version = 0;
 			string[] text = new string[1];
 			text = sourcedata.Split(new char[] { ',' });
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Pt = new PointD(0, 0);
 			
 			try
@@ -116,8 +126,8 @@ namespace GralItemData
 							{
 								for (int i = 0; i < 10; i++)
 								{
-									Dep[i] = new Deposition(); // initialize Deposition array
-									Dep[i].String_to_Val(depostart + i * 10, text);
+									GetDep()[i] = new Deposition(); // initialize Deposition array
+									GetDep()[i].String_to_Val(depostart + i * 10, text);
 								}
 							}
 							catch{}
@@ -126,8 +136,8 @@ namespace GralItemData
 						{
 							for (int i = 0; i < 10; i++)
 							{
-								Dep[i] = new Deposition(); // initialize Deposition array
-								Dep[i].init();
+								GetDep()[i] = new Deposition(); // initialize Deposition array
+								GetDep()[i].init();
 							}
 						}
 					}
@@ -160,7 +170,7 @@ namespace GralItemData
 			{
 				Name = String.Empty;
 				Poll = new PollutantsData();
-				Dep = new Deposition[10];
+				SetDep(new Deposition[10]);
 				Temperature = 20;
 				Diameter = 0.2F;
 				Height = 10;
@@ -168,8 +178,8 @@ namespace GralItemData
 				
 				for (int i = 0; i < 10; i++)
 				{
-					Dep[i] = new Deposition(); // initialize Deposition array
-					Dep[i].init();
+					GetDep()[i] = new Deposition(); // initialize Deposition array
+					GetDep()[i].init();
 				}
 			}
 		}
@@ -188,7 +198,7 @@ namespace GralItemData
 			Pt = other.Pt;
 			
 			Poll = new PollutantsData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			
 			Poll.SourceGroup = other.Poll.SourceGroup;
 			for (int i = 0; i < 10; i++)
@@ -196,11 +206,11 @@ namespace GralItemData
 				Poll.EmissionRate[i] = other.Poll.EmissionRate[i];
 				Poll.Pollutant[i] = other.Poll.Pollutant[i];
 			}
-			
-			Dep = new Deposition[10];
+
+			SetDep(new Deposition[10]);
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(other.Dep[i]); // initialize Deposition array
+				GetDep()[i] = new Deposition(other.GetDep()[i]); // initialize Deposition array
 			}
 			
 			if (other.TemperatureTimeSeries != null)
@@ -240,7 +250,7 @@ namespace GralItemData
 			dummy += "Dep@_,";
 			for (int i = 0; i < 10; i++)
 			{
-				dummy += Dep[i].ToString() + ",";
+				dummy += GetDep()[i].ToString() + ",";
 			}
 			
 			if (string.IsNullOrEmpty(VelocityTimeSeries) == false)

--- a/Source/Gral/GRALItemData/ItemDataPortalSource.cs
+++ b/Source/Gral/GRALItemData/ItemDataPortalSource.cs
@@ -45,8 +45,17 @@ namespace GralItemData
 		public List <PollutantsData> Poll	{ get; set;}
 		
 		public NemoData Nemo		{ get; set;}
-		public Deposition[] Dep	{ get; set;}
-		
+
+		private Deposition[] dep;
+		public Deposition[] GetDep()
+		{
+			return dep;
+		}
+		public void SetDep(Deposition[] value)
+		{
+			dep = value;
+		}
+
 		public string VelocityTimeSeries		{ get; set;}
 		public string TemperatureTimeSeries	{ get; set;}
 		
@@ -62,15 +71,15 @@ namespace GralItemData
 			
 			Poll = new List<PollutantsData>();
 			Nemo = new NemoData();
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Pt1 = new PointD(0, 0);
 			Pt2 = new PointD(0, 0);
 			BaseHeight = 0;
 			
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(); // initialize Deposition array
-				Dep[i].init();
+				GetDep()[i] = new Deposition(); // initialize Deposition array
+				GetDep()[i].init();
 			}
 		}
 		
@@ -83,7 +92,7 @@ namespace GralItemData
 			int version = 0;
 			string[] text = new string[1];
 			text = sourcedata.Split(new char[] { ',' });
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			Nemo = new NemoData();
 			
 			try
@@ -146,8 +155,8 @@ namespace GralItemData
 						{
 							for (int i = 0; i < 10; i++)
 							{
-								Dep[i] = new Deposition(); // initialize Deposition array
-								Dep[i].String_to_Val(depostart + i * 10, text);
+								GetDep()[i] = new Deposition(); // initialize Deposition array
+								GetDep()[i].String_to_Val(depostart + i * 10, text);
 							}
 						}
 						catch{}
@@ -156,8 +165,8 @@ namespace GralItemData
 					{
 						for (int i = 0; i < 10; i++)
 						{
-							Dep[i] = new Deposition(); // initialize Deposition array
-							Dep[i].init();
+							GetDep()[i] = new Deposition(); // initialize Deposition array
+							GetDep()[i].init();
 						}
 					}
 					
@@ -207,13 +216,13 @@ namespace GralItemData
 				
 				Poll = new List<PollutantsData>();
 				Nemo = new NemoData();
-				Dep = new Deposition[10];
+				SetDep(new Deposition[10]);
 				Pt1 = new PointD();
 				Pt2 = new PointD();
 				for (int i = 0; i < 10; i++)
 				{
-					Dep[i] = new Deposition(); // initialize Deposition array
-					Dep[i].init();
+					GetDep()[i] = new Deposition(); // initialize Deposition array
+					GetDep()[i].init();
 				}
 			}
 		}
@@ -251,10 +260,10 @@ namespace GralItemData
 			}
 			
 			Nemo = new NemoData(other.Nemo);
-			Dep = new Deposition[10];
+			SetDep(new Deposition[10]);
 			for (int i = 0; i < 10; i++)
 			{
-				Dep[i] = new Deposition(other.Dep[i]); // initialize Deposition array
+				GetDep()[i] = new Deposition(other.GetDep()[i]); // initialize Deposition array
 			}
 			
 			if (other.TemperatureTimeSeries != null)
@@ -304,7 +313,7 @@ namespace GralItemData
 			dummy += "Dep@_,";
 			for (int i = 0; i < 10; i++)
 			{
-				dummy += Dep[i].ToString() + ",";
+				dummy += GetDep()[i].ToString() + ",";
 			}
 			 
 			dummy += St_F.DblToIvarTxt(Math.Round(BaseHeight, 1)) + ",";

--- a/Source/Gral/GRALItemData/ItemDataVegetation.cs
+++ b/Source/Gral/GRALItemData/ItemDataVegetation.cs
@@ -42,7 +42,7 @@ namespace GralItemData
 		public float Coverage	{ get; set;}
 		public List<GralDomain.PointD> Pt  { get; set;}
 		
-		private static CultureInfo ic = CultureInfo.InvariantCulture;
+		private static readonly CultureInfo ic = CultureInfo.InvariantCulture;
 		
 		/// <summary>
 		/// Create a new empty vegetation data object

--- a/Source/Gral/GRALItemData/ItemDataWall.cs
+++ b/Source/Gral/GRALItemData/ItemDataWall.cs
@@ -38,7 +38,7 @@ namespace GralItemData
 		public float Lenght 		{ get; set;}
 		public List<PointD_3d> Pt   { get; set;}
 		
-		private static CultureInfo ic = CultureInfo.InvariantCulture;
+		private static readonly CultureInfo ic = CultureInfo.InvariantCulture;
 		
 		/// <summary>
 		/// Create a new empty wall data object

--- a/Source/Gral/GRALItemData/MatchMeteoData.cs
+++ b/Source/Gral/GRALItemData/MatchMeteoData.cs
@@ -28,13 +28,67 @@ namespace GralItemData
 	public class MatchMeteoData
 	{
 		public int FileLenght     	{ get; set; }
-		public int[] Hour 			{ get; set; }
-        public double[] WindVel		{ get; set; }
-        public double[] WindDir		{ get; set; }
-        public int[] SC 			{ get; set; }
-        public string[] Date 		{ get; set; }
-        public string[] Time 		{ get; set; }
-        public string MetFileExt 	{ get; set; }
+
+		private int[] hour;
+		public int[] GetHour()
+		{
+			return hour;
+		}
+    	public void SetHour(int[] value)
+		{
+			hour = value;
+		}
+
+		private double[] windVel;
+		public double[] GetWindVel()
+		{
+			return windVel;
+		}
+		public void SetWindVel(double[] value)
+		{
+			windVel = value;
+		}
+
+		private double[] windDir;
+		public double[] GetWindDir()
+		{
+			return windDir;
+		}
+		public void SetWindDir(double[] value)
+		{
+			windDir = value;
+		}
+		private int[] sC;
+		public int[] GetSC()
+		{
+			return sC;
+		}
+		public void SetSC(int[] value)
+		{
+			sC = value;
+		}
+
+		private string[] date;
+		public string[] GetDate()
+		{
+			return date;
+		}
+		public void SetDate(string[] value)
+		{
+			date = value;
+		}
+
+		private string[] time;
+		public string[] GetTime()
+		{
+			return time;
+		}
+		public void SetTime(string[] value)
+		{
+			time = value;
+		}
+
+		public string MetFileExt 	{ get; set; }
         public char MetColumnSeperator { get; set; }
         public string MetDecSeperator  { get; set; }
         public double AnemometerHeight { get; set; }
@@ -48,12 +102,12 @@ namespace GralItemData
 		public MatchMeteoData()
 		{
 			FileLenght = 0;
-			Hour = new int[1000000];
-			WindVel = new double[1000000];
-			WindDir = new double[1000000];
-			SC = new int[1000000];
-			Date = new string[1000000];
-			Time = new string[1000000];
+			SetHour(new int[1000000]);
+			SetWindVel(new double[1000000]);
+			SetWindDir(new double[1000000]);
+			SetSC(new int[1000000]);
+			SetDate(new string[1000000]);
+			SetTime(new string[1000000]);
 			MetFileExt = string.Empty;
 			MetColumnSeperator = ',';
 			MetDecSeperator = ".";

--- a/Source/Gral/GRALItemForms/EditAreaSources.cs
+++ b/Source/Gral/GRALItemForms/EditAreaSources.cs
@@ -327,7 +327,7 @@ namespace GralItemForms
 					
 					for (int i = 0; i < 10; i++) // save deposition
 					{
-						_as.Dep[i] = new Deposition(dep[i]);
+						_as.GetDep()[i] = new Deposition(dep[i]);
 					}
 					
 					float height = (float) (numericUpDown1.Value);
@@ -423,7 +423,7 @@ namespace GralItemForms
 				
 				for (int i = 0; i < 10; i++)
 				{
-					dep[i] = _as.Dep[i];
+					dep[i] = _as.GetDep()[i];
 					
 					if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
 						but1[i].BackColor = Color.LightGreen; // mark that deposition is set

--- a/Source/Gral/GRALItemForms/EditLineSources.Designer.cs
+++ b/Source/Gral/GRALItemForms/EditLineSources.Designer.cs
@@ -74,6 +74,8 @@
             this.listBox2 = new System.Windows.Forms.ListBox();
             this.groupBox2 = new System.Windows.Forms.GroupBox();
             this.button9 = new System.Windows.Forms.Button();
+            this.checkBox2 = new System.Windows.Forms.CheckBox();
+            this.trackBar2 = new System.Windows.Forms.TrackBar();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.trackBar1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
@@ -86,6 +88,7 @@
             this.tabControl1.SuspendLayout();
             this.tabPage2.SuspendLayout();
             this.groupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)(this.trackBar2)).BeginInit();
             this.SuspendLayout();
             // 
             // label2
@@ -134,6 +137,7 @@
             this.numericUpDown1.TabIndex = 4;
             this.numericUpDown1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.toolTip1.SetToolTip(this.numericUpDown1, "Lowest height above ground level");
+            this.numericUpDown1.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
             // 
             // trackBar1
             // 
@@ -250,7 +254,7 @@
             // 
             // textBox2
             // 
-            this.textBox2.Location = new System.Drawing.Point(114, 228);
+            this.textBox2.Location = new System.Drawing.Point(115, 256);
             this.textBox2.Name = "textBox2";
             this.textBox2.ReadOnly = true;
             this.textBox2.Size = new System.Drawing.Size(84, 20);
@@ -259,6 +263,7 @@
             this.textBox2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.toolTip1.SetToolTip(this.textBox2, "Click to edit edge point table");
             this.textBox2.Click += new System.EventHandler(this.TextBox2Click);
+            this.textBox2.TextChanged += new System.EventHandler(this.textBox2_TextChanged);
             // 
             // button5
             // 
@@ -281,7 +286,7 @@
             0,
             0,
             65536});
-            this.numericUpDown3.Location = new System.Drawing.Point(84, 160);
+            this.numericUpDown3.Location = new System.Drawing.Point(85, 188);
             this.numericUpDown3.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -300,7 +305,7 @@
             // 
             // checkBox1
             // 
-            this.checkBox1.Location = new System.Drawing.Point(12, 136);
+            this.checkBox1.Location = new System.Drawing.Point(10, 140);
             this.checkBox1.Name = "checkBox1";
             this.checkBox1.Size = new System.Drawing.Size(104, 21);
             this.checkBox1.TabIndex = 5;
@@ -317,7 +322,7 @@
             0,
             0,
             65536});
-            this.numericUpDown2.Location = new System.Drawing.Point(84, 182);
+            this.numericUpDown2.Location = new System.Drawing.Point(85, 210);
             this.numericUpDown2.Maximum = new decimal(new int[] {
             1000,
             0,
@@ -363,7 +368,7 @@
             // 
             this.button8.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button8.BackgroundImage")));
             this.button8.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button8.Location = new System.Drawing.Point(84, 226);
+            this.button8.Location = new System.Drawing.Point(85, 254);
             this.button8.Name = "button8";
             this.button8.Size = new System.Drawing.Size(24, 24);
             this.button8.TabIndex = 8;
@@ -374,7 +379,7 @@
             // label1
             // 
             this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(2, 185);
+            this.label1.Location = new System.Drawing.Point(3, 213);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(52, 13);
             this.label1.TabIndex = 42;
@@ -383,7 +388,7 @@
             // label9
             // 
             this.label9.AutoSize = true;
-            this.label9.Location = new System.Drawing.Point(2, 164);
+            this.label9.Location = new System.Drawing.Point(3, 192);
             this.label9.Name = "label9";
             this.label9.Size = new System.Drawing.Size(67, 13);
             this.label9.TabIndex = 59;
@@ -392,7 +397,7 @@
             // label3
             // 
             this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(2, 232);
+            this.label3.Location = new System.Drawing.Point(3, 260);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(66, 13);
             this.label3.TabIndex = 44;
@@ -564,7 +569,7 @@
             // label13
             // 
             this.label13.AutoSize = true;
-            this.label13.Location = new System.Drawing.Point(2, 208);
+            this.label13.Location = new System.Drawing.Point(3, 236);
             this.label13.Name = "label13";
             this.label13.Size = new System.Drawing.Size(57, 13);
             this.label13.TabIndex = 42;
@@ -574,7 +579,7 @@
             // label15
             // 
             this.label15.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.label15.Location = new System.Drawing.Point(84, 205);
+            this.label15.Location = new System.Drawing.Point(85, 233);
             this.label15.Name = "label15";
             this.label15.Size = new System.Drawing.Size(113, 20);
             this.label15.TabIndex = 42;
@@ -585,7 +590,7 @@
             // 
             this.tabControl1.Controls.Add(this.tabPage1);
             this.tabControl1.Controls.Add(this.tabPage2);
-            this.tabControl1.Location = new System.Drawing.Point(2, 407);
+            this.tabControl1.Location = new System.Drawing.Point(3, 435);
             this.tabControl1.Name = "tabControl1";
             this.tabControl1.SelectedIndex = 0;
             this.tabControl1.Size = new System.Drawing.Size(200, 308);
@@ -628,7 +633,7 @@
             this.groupBox2.Controls.Add(this.listBox2);
             this.groupBox2.Controls.Add(this.button7);
             this.groupBox2.Controls.Add(this.button5);
-            this.groupBox2.Location = new System.Drawing.Point(5, 254);
+            this.groupBox2.Location = new System.Drawing.Point(6, 282);
             this.groupBox2.Name = "groupBox2";
             this.groupBox2.Size = new System.Drawing.Size(192, 115);
             this.groupBox2.TabIndex = 65;
@@ -637,7 +642,7 @@
             // 
             // button9
             // 
-            this.button9.Location = new System.Drawing.Point(51, 375);
+            this.button9.Location = new System.Drawing.Point(52, 403);
             this.button9.Name = "button9";
             this.button9.Size = new System.Drawing.Size(85, 24);
             this.button9.TabIndex = 77;
@@ -645,17 +650,43 @@
             this.button9.UseVisualStyleBackColor = true;
             this.button9.Click += new System.EventHandler(this.button9_Click);
             // 
+            // checkBox2
+            // 
+            this.checkBox2.Location = new System.Drawing.Point(134, 140);
+            this.checkBox2.Name = "checkBox2";
+            this.checkBox2.Size = new System.Drawing.Size(88, 21);
+            this.checkBox2.TabIndex = 5;
+            this.checkBox2.Text = "3D Line";
+            this.checkBox2.UseVisualStyleBackColor = true;
+            this.checkBox2.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
+            // 
+            // trackBar2
+            // 
+            this.trackBar2.AutoSize = false;
+            this.trackBar2.Enabled = false;
+            this.trackBar2.Location = new System.Drawing.Point(9, 163);
+            this.trackBar2.Maximum = 1;
+            this.trackBar2.Minimum = 1;
+            this.trackBar2.Name = "trackBar2";
+            this.trackBar2.Size = new System.Drawing.Size(190, 19);
+            this.trackBar2.TabIndex = 78;
+            this.toolTip1.SetToolTip(this.trackBar2, "Select edge points");
+            this.trackBar2.Value = 1;
+            this.trackBar2.Scroll += new System.EventHandler(this.trackBar2_Scroll);
+            // 
             // EditLinesources
             // 
             this.AcceptButton = this.button9;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(206, 718);
+            this.ClientSize = new System.Drawing.Size(206, 761);
+            this.Controls.Add(this.trackBar2);
             this.Controls.Add(this.button9);
             this.Controls.Add(this.button8);
             this.Controls.Add(this.groupBox2);
             this.Controls.Add(this.button6);
             this.Controls.Add(this.tabControl1);
+            this.Controls.Add(this.checkBox2);
             this.Controls.Add(this.checkBox1);
             this.Controls.Add(this.numericUpDown3);
             this.Controls.Add(this.label9);
@@ -700,6 +731,7 @@
             this.tabControl1.ResumeLayout(false);
             this.tabPage2.ResumeLayout(false);
             this.groupBox2.ResumeLayout(false);
+            ((System.ComponentModel.ISupportInitialize)(this.trackBar2)).EndInit();
             this.ResumeLayout(false);
             this.PerformLayout();
 
@@ -751,5 +783,7 @@
         private System.Windows.Forms.TextBox textBox4;
         private System.Windows.Forms.ListBox listBox1;
         private System.Windows.Forms.Button button9;
+        private System.Windows.Forms.CheckBox checkBox2;
+        private System.Windows.Forms.TrackBar trackBar2;
     }
 }

--- a/Source/Gral/GRALItemForms/EditLineSources.cs
+++ b/Source/Gral/GRALItemForms/EditLineSources.cs
@@ -25,76 +25,81 @@ using GralStaticFunctions;
 
 namespace GralItemForms
 {
-	public partial class EditLinesources : Form
-	{
-		private TextBox  [] lineemission = new TextBox [10];    //textboxes for emission strenght input of line sources
-		private ComboBox [] linepollutant = new ComboBox [10];  //Combobox for selecting pollutants of line sources
-		private Label [] labelpollutant = new Label [10];       //Labels for pollutant types
-		private Button [] but1 = new Button [10];               //Buttons for unit and deposition edit
-		/// <summary>
+    public partial class EditLinesources : Form
+    {
+        private TextBox[] lineemission = new TextBox[10];    //textboxes for emission strenght input of line sources
+        private ComboBox[] linepollutant = new ComboBox[10];  //Combobox for selecting pollutants of line sources
+        private Label[] labelpollutant = new Label[10];       //Labels for pollutant types
+        private Button[] but1 = new Button[10];               //Buttons for unit and deposition edit
+        /// <summary>
         /// Collection of all line source data
         /// </summary>
-		public List<LineSourceData> ItemData = new List<LineSourceData>(); 
-		private List<PollutantsData> SourceGroupEmission = new List<PollutantsData>(); // emission data for various source groups
-		/// <summary>
+        public List<LineSourceData> ItemData = new List<LineSourceData>();
+        private List<PollutantsData> SourceGroupEmission = new List<PollutantsData>(); // emission data for various source groups
+        /// <summary>
         /// Number of actual line source to be displayed
         /// </summary>
-		public int ItemDisplayNr;
+        public int ItemDisplayNr;
         /// <summary>
         /// Recent number of an edited corner point
         /// </summary>
         public int CornerLineSource = 0;
-		private const int MaxVertices = 20000;                              // max. number of edge points
+        private const int MaxVertices = 20000;                              // max. number of edge points
 
         /// <summary>
         /// X corner points of a line source in meters
         /// </summary>
-        public double [] CornerLineX = new double [MaxVertices];
+        public double[] CornerLineX = new double[MaxVertices];
         /// <summary>
         /// Y corner points of a portal source in meters
         /// </summary>
-        public double [] CornerLineY = new double [MaxVertices];
+        public double[] CornerLineY = new double[MaxVertices];
+        /// <summary>
+        /// Z corner points of a portal source in meters
+        /// </summary>
+        public double[] CornerLineZ = new double[MaxVertices];
         /// <summary>
         /// All souce group names
         /// </summary>
-        public List<string> SG_List = new List<string>();			        
-		
-		private Deposition [] dep = new Deposition [10];
-		CultureInfo ic = CultureInfo.InvariantCulture;
-		private int Dialog_Initial_Width = 0;
-		private int TabControl1_Height = 520;
-		private int Button1_Width = 50;
-		private int Button1_Height = 10;
-		private int TBWidth = 80;
-		private int TextBox_x0 = 0;
-		private int TrackBar_x0 = 0;
-		private int Numericupdown_x0 = 0;
-		private int listbox_x0 = 0;
-		private int TabControl_x0 = 0;
-		
-		// delegate to send a message, that redraw is needed!
-		public event ForceDomainRedraw LinesourceRedraw;
+        public List<string> SG_List = new List<string>();
+
+        private Deposition[] dep = new Deposition[10];
+        CultureInfo ic = CultureInfo.InvariantCulture;
+        private int vertices;                              //number of maximum corner points
+        private int Dialog_Initial_Width = 0;
+        private int TabControl1_Height = 520;
+        private int Button1_Width = 50;
+        private int Button1_Height = 10;
+        private int TBWidth = 80;
+        private int TextBox_x0 = 0;
+        private int TrackBar_x0 = 0;
+        private int Numericupdown_x0 = 0;
+        private int listbox_x0 = 0;
+        private int TabControl_x0 = 0;
+
+        // delegate to send a message, that redraw is needed!
+        public event ForceDomainRedraw LinesourceRedraw;
 
         public bool AllowClosing = false;
         //delegate to send a message, that user tries to close the form
         public event ForceItemFormHide ItemFormHide;
 
-        public EditLinesources ()
-		{
-			InitializeComponent ();
-			Domain.EditSourceShape = true;  // allow input of new vertices
-			//User defined column seperator and decimal seperator
-			
-			#if __MonoCS__
+        public EditLinesources()
+        {
+            InitializeComponent();
+            Domain.EditSourceShape = true;  // allow input of new vertices
+                                            //User defined column seperator and decimal seperator
+
+#if __MonoCS__
 			var allNumUpDowns = Main.GetAllControls<NumericUpDown> (this);
 			foreach (NumericUpDown nu in allNumUpDowns)
 			{
 				nu.TextAlign = HorizontalAlignment.Left;
 			}
-			#endif
+#endif
 
-			int y_act = groupBox1.Top + groupBox1.Height + 5;
-			int TBHeight = textBox2.Height;
+            int y_act = groupBox1.Top + groupBox1.Height + 5;
+            int TBHeight = textBox2.Height;
 
             // get width of button for unit
             Button bt_test = new Button
@@ -106,54 +111,54 @@ namespace GralItemForms
                 Text = "[MOU/h/km]"
             };
             Button1_Width = bt_test.Width;
-			Button1_Height = bt_test.Height;
-			bt_test.Dispose();
+            Button1_Height = bt_test.Height;
+            bt_test.Dispose();
 
-			y_act = 10;
-			for (int i = 0; i < 10; i++)
-			{
-				createTextbox(6, Convert.ToInt32(y_act) + Convert.ToInt32(i * (TBHeight + 7)), TBWidth, TBHeight, i);
-				dep [i] = new Deposition (); // initialize Deposition array
-				dep [i].init ();
-			}
-			
-			for (int nr = 0; nr < 10; nr++)
-			{
-				for (int i = 0; i < Main.PollutantList.Count; i++)
-				{
-					linepollutant[nr].Items.Add(Main.PollutantList[i]);
-				}
-			}
-			listBox1.Items.AddRange(Main.NemoTrafficSituations);
-			
-			textBox1.KeyPress += new KeyPressEventHandler (Comma1); //only point as decimal seperator is allowed
-		}
+            y_act = 10;
+            for (int i = 0; i < 10; i++)
+            {
+                createTextbox(6, Convert.ToInt32(y_act) + Convert.ToInt32(i * (TBHeight + 7)), TBWidth, TBHeight, i);
+                dep[i] = new Deposition(); // initialize Deposition array
+                dep[i].init();
+            }
 
-		private void Editlinesources_Load (object sender, EventArgs e)
-		{
-			tabControl1.Height = Math.Max(350, lineemission[9].Bottom + 5);
-			tabControl1.Width = Math.Max(259, but1[1].Right + 4);
-			Dialog_Initial_Width = ClientSize.Width;
-			TabControl1_Height = tabControl1.Height;
-			TrackBar_x0 = trackBar1.Left;
-			TextBox_x0 = textBox1.Left;
-			Numericupdown_x0 = numericUpDown1.Left;
-			listbox_x0 = listBox2.Left;
-			TabControl_x0 = tabControl1.Left;
-			
-			FillValues();
-			
-			ClientSize = new Size(Math.Max(textBox2.Right + 5, but1[1].Right + 5), tabControl1.Bottom + 5);
-			EditlinesourcesResizeEnd(null, null);
-			
-			#if __MonoCS__
+            for (int nr = 0; nr < 10; nr++)
+            {
+                for (int i = 0; i < Main.PollutantList.Count; i++)
+                {
+                    linepollutant[nr].Items.Add(Main.PollutantList[i]);
+                }
+            }
+            listBox1.Items.AddRange(Main.NemoTrafficSituations);
+
+            textBox1.KeyPress += new KeyPressEventHandler(Comma1); //only point as decimal seperator is allowed
+        }
+
+        private void Editlinesources_Load(object sender, EventArgs e)
+        {
+            tabControl1.Height = Math.Max(350, lineemission[9].Bottom + 5);
+            tabControl1.Width = Math.Max(259, but1[1].Right + 4);
+            Dialog_Initial_Width = ClientSize.Width;
+            TabControl1_Height = tabControl1.Height;
+            TrackBar_x0 = trackBar1.Left;
+            TextBox_x0 = textBox1.Left;
+            Numericupdown_x0 = numericUpDown1.Left;
+            listbox_x0 = listBox2.Left;
+            TabControl_x0 = tabControl1.Left;
+
+            FillValues();
+
+            ClientSize = new Size(Math.Max(textBox2.Right + 5, but1[1].Right + 5), tabControl1.Bottom + 5);
+            EditlinesourcesResizeEnd(null, null);
+
+#if __MonoCS__
 			listBox1.Height = 25;
 			trackBar1.Height = 12;
-			#endif
-		}
+#endif
+        }
 
-		private void createTextbox (int x0, int y0, int b, int h, int nr)
-		{
+        private void createTextbox(int x0, int y0, int b, int h, int nr)
+        {
             //list box for selcting pollutants
             linepollutant[nr] = new ComboBox
             {
@@ -164,7 +169,7 @@ namespace GralItemForms
                 DropDownHeight = Math.Max(textBox2.Height * 4, tabPage1.Height - y0)
             };
             tabPage1.Controls.Add(linepollutant[nr]);
-			linepollutant[nr].SelectedValueChanged += new System.EventHandler(Odour);
+            linepollutant[nr].SelectedValueChanged += new System.EventHandler(Odour);
 
             labelpollutant[nr] = new Label
             {
@@ -186,9 +191,9 @@ namespace GralItemForms
                 Text = "0"
             };
             lineemission[nr].TextChanged += new System.EventHandler(St_F.CheckInput);
-			lineemission[nr].KeyPress += new KeyPressEventHandler(St_F.NumericInput);
-			
-			tabPage1.Controls.Add(lineemission[nr]);
+            lineemission[nr].KeyPress += new KeyPressEventHandler(St_F.NumericInput);
+
+            tabPage1.Controls.Add(lineemission[nr]);
 
             //labels
             but1[nr] = new Button
@@ -200,892 +205,947 @@ namespace GralItemForms
                 Text = "[kg/h/km]"
             };
             tabPage1.Controls.Add(but1[nr]);
-			toolTip1.SetToolTip(but1[nr], "Click to set deposition - green: deposition set");
-			but1[nr].Click += new EventHandler(edit_deposition);
-		}
-		
-		private void listBox_DrawItem(object sender, DrawItemEventArgs e)
-		{
-			e.DrawBackground();
-			// Define the default color of the brush as black.
-			ListBox lb = sender as ListBox;
-			string poll = lb.Items[e.Index].ToString();
-			
-			// See if the item is selected.
-			if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
-			{
-				// Selected.
-				using (var brush = new SolidBrush(Color.RoyalBlue))
-				{
-					e.Graphics.FillRectangle(brush, e.Bounds);
-				}
-				
-				// Draw the current item text based on the current Font
-				// and the custom brush settings.
-				Brush myBrush = Brushes.White;
-				{
-					e.Graphics.DrawString(poll, e.Font, myBrush, e.Bounds, StringFormat.GenericDefault);
-				}
-			}
-			else
-			{
-				// Not selected.
-				using (var brush = new SolidBrush(Color.AntiqueWhite))
-				{
-					e.Graphics.FillRectangle(brush, e.Bounds);
-				}
-				// Draw the current item text based on the current Font
-				// and the custom brush settings.
-				Brush myBrush = Brushes.Black;
-				{
-					e.Graphics.DrawString(poll, e.Font, myBrush, e.Bounds, StringFormat.GenericDefault);
-				}
-			}
-			
-			// If the ListBox has focus, draw a focus rectangle around the selected item.
-			e.DrawFocusRectangle();
-		}
+            toolTip1.SetToolTip(but1[nr], "Click to set deposition - green: deposition set");
+            but1[nr].Click += new EventHandler(edit_deposition);
+        }
 
-		private void Odour(object sender, EventArgs args)
-		{
-			for (int nr = 0; nr < 10; nr++)
-			{
-				if (linepollutant[nr].SelectedIndex == 2)
-					but1[nr].Text = "[MOU/h/km]";
-				else
-					but1[nr].Text = "[kg/h/km]";
-			}
-		}
-		
-		private void Comma1(object sender, KeyPressEventArgs e)
-		{
-			//if (e.KeyChar == ',') e.KeyChar = '.';
-			int asc = (int)e.KeyChar; //get ASCII code
-		}
-		
-		//increase the number of line sources by one
-		private void button1_Click(object sender, EventArgs e)
-		{
-			if ((textBox1.Text != "") && (textBox2.Text != ""))
-			{
-				SaveArray();
-				for (int i = 0; i < 10; i++)
-					lineemission[i].Text = "0";
+        private void listBox_DrawItem(object sender, DrawItemEventArgs e)
+        {
+            e.DrawBackground();
+            // Define the default color of the brush as black.
+            ListBox lb = sender as ListBox;
+            string poll = lb.Items[e.Index].ToString();
 
-				trackBar1.Maximum = trackBar1.Maximum + 1;
-				trackBar1.Value = trackBar1.Maximum;
-				ItemDisplayNr = trackBar1.Maximum - 1;
-				Domain.EditSourceShape = true;  // allow input of new vertices
-				FillValues();
-			}
-		}
+            // See if the item is selected.
+            if ((e.State & DrawItemState.Selected) == DrawItemState.Selected)
+            {
+                // Selected.
+                using (var brush = new SolidBrush(Color.RoyalBlue))
+                {
+                    e.Graphics.FillRectangle(brush, e.Bounds);
+                }
 
-		//scroll between the line sources
-		private void trackBar1_Scroll(object sender, EventArgs e)
-		{
-			SaveArray();
-			ItemDisplayNr = trackBar1.Value - 1;
-			FillValues();
-			RedrawDomain(this, null);
-		}
+                // Draw the current item text based on the current Font
+                // and the custom brush settings.
+                Brush myBrush = Brushes.White;
+                {
+                    e.Graphics.DrawString(poll, e.Font, myBrush, e.Bounds, StringFormat.GenericDefault);
+                }
+            }
+            else
+            {
+                // Not selected.
+                using (var brush = new SolidBrush(Color.AntiqueWhite))
+                {
+                    e.Graphics.FillRectangle(brush, e.Bounds);
+                }
+                // Draw the current item text based on the current Font
+                // and the custom brush settings.
+                Brush myBrush = Brushes.Black;
+                {
+                    e.Graphics.DrawString(poll, e.Font, myBrush, e.Bounds, StringFormat.GenericDefault);
+                }
+            }
 
-		//save data in array list
-		/// <summary>
-    	/// Saves the recent dialog data in the item object and the item list
-    	/// </summary> 
-		public void SaveArray()
-		{
+            // If the ListBox has focus, draw a focus rectangle around the selected item.
+            e.DrawFocusRectangle();
+        }
+
+        private void Odour(object sender, EventArgs args)
+        {
+            for (int nr = 0; nr < 10; nr++)
+            {
+                if (linepollutant[nr].SelectedIndex == 2)
+                    but1[nr].Text = "[MOU/h/km]";
+                else
+                    but1[nr].Text = "[kg/h/km]";
+            }
+        }
+
+        private void Comma1(object sender, KeyPressEventArgs e)
+        {
+            //if (e.KeyChar == ',') e.KeyChar = '.';
+            int asc = (int)e.KeyChar; //get ASCII code
+        }
+
+        //increase the number of line sources by one
+        private void button1_Click(object sender, EventArgs e)
+        {
+            if ((textBox1.Text != "") && (textBox2.Text != ""))
+            {
+                SaveArray();
+                for (int i = 0; i < 10; i++)
+                    lineemission[i].Text = "0";
+
+                trackBar1.Maximum = trackBar1.Maximum + 1;
+                trackBar1.Value = trackBar1.Maximum;
+                ItemDisplayNr = trackBar1.Maximum - 1;
+                Domain.EditSourceShape = true;  // allow input of new vertices
+                FillValues();
+            }
+        }
+
+        //scroll between the line sources
+        private void trackBar1_Scroll(object sender, EventArgs e)
+        {
+            SaveArray();
+            ItemDisplayNr = trackBar1.Value - 1;
+            FillValues();
+            RedrawDomain(this, null);
+        }
+
+        //save data in array list
+        /// <summary>
+        /// Saves the recent dialog data in the item object and the item list
+        /// </summary> 
+        public void SaveArray()
+        {
             if (Main.Project_Locked)
             {
                 return;
             }
 
-			int number_of_vertices = 0;
-			Int32.TryParse (textBox2.Text, out number_of_vertices);
-			
+            int number_of_vertices = 0;
+            Int32.TryParse(textBox2.Text, out number_of_vertices);
+
             if (listBox2.Items.Count == 0) // no source group added
             {
-            	if (number_of_vertices > 1 && textBox1.Text.Length > 1)
-				{
-                	MessageBox.Show(this, "No source group added", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-            	}
+                if (number_of_vertices > 1 && textBox1.Text.Length > 1)
+                {
+                    MessageBox.Show(this, "No source group added", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
                 return;
             }
             if (number_of_vertices < 2)
-			{
-				MessageBox.Show(this, "Not at least 2 edge points digitized", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-				return;
-			}
-            
-            LineSourceData _ls; 
-			if (ItemDisplayNr >= ItemData.Count) // new item
-			{
-				_ls = new LineSourceData();
-			}
-			else // change existing item
-			{
-				_ls = ItemData[ItemDisplayNr];
-			}
-			
-			if (textBox2.Text != "" && number_of_vertices > 1)
-			{
-				if ((textBox1.Text != "") && (Convert.ToInt32(textBox2.Text) > 1))
-				{
-					if (textBox4.Text == "") // section
-						textBox4.Text = "1";
-					
-					_ls.Pt.Clear();
-					_ls.Pt.TrimExcess();
-					
-					// new lenght
-					PointD[] mypoint = new PointD[MaxVertices];
+            {
+                MessageBox.Show(this, "Not at least 2 edge points digitized", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                return;
+            }
 
-					for (int i = 0; i < number_of_vertices; i++)
-					{
-						_ls.Pt.Add(new PointD(CornerLineX[i], CornerLineY[i])); 
-					}
-					
-					double lenght = St_F.CalcLenght(_ls.Pt);
-					label15.Text = lenght.ToString(ic);
+            LineSourceData _ls;
+            if (ItemDisplayNr >= ItemData.Count) // new item
+            {
+                _ls = new LineSourceData();
+            }
+            else // change existing item
+            {
+                _ls = ItemData[ItemDisplayNr];
+            }
 
-					if (Convert.ToInt32(textBox2.Text) > 0) Domain.EditSourceShape = false;  // block input of new vertices
-					
-					// collect pollutants
-					_ls.Poll.Clear();
-					_ls.Poll.TrimExcess();
-					if (SourceGroupEmission.Count == 0) // a source group is available, but Save SG not pressed
-					{
-						UpdateNewSourcegroupEmission();
-					}
-					
-					foreach(PollutantsData _pd in SourceGroupEmission)
-					{
-						_ls.Poll.Add(_pd);
-					}
-					
-					for (int i = 0; i < 10; i++) // save deposition
-					{
-						_ls.Dep[i] = new Deposition(dep[i]);
-					}
-					
-					float height = Convert.ToSingle(numericUpDown1.Value);
-					if (checkBox1.Checked) // absolute height over sea
-					{
-						height *= (-1);
-					}
-					
-					listBox1.SelectedIndex = listBox1.TopIndex; // NEMO
-					_ls.Name = textBox1.Text;
-					_ls.Section = textBox4.Text;
-					_ls.Height = height;
-					_ls.Width = Convert.ToSingle(numericUpDown2.Value);
-					_ls.VerticalExt = Convert.ToSingle(numericUpDown3.Value);
-					_ls.Nemo.AvDailyTraffic = Convert.ToInt32(numericUpDown6.Value);
-					_ls.Nemo.ShareHDV = Convert.ToSingle(numericUpDown7.Value);
-					_ls.Nemo.Slope = Convert.ToSingle(numericUpDown4.Value);
-					_ls.Nemo.TrafficSit = listBox1.SelectedIndex;
-					_ls.Nemo.BaseYear = Convert.ToInt32(numericUpDown8.Value);
-					
-					if (ItemDisplayNr >= ItemData.Count) // new item
-                	{
-                		ItemData.Add(_ls);
-                	}
-                	else
-                	{
-                		ItemData[ItemDisplayNr] = _ls;
-                	}
-					
-					RedrawDomain(this, null);
-				}
-			}
-			else
-			{
-				if (textBox1.Text.Length > 0)
+            if (textBox2.Text != "" && number_of_vertices > 1)
+            {
+                if ((textBox1.Text != "") && (Convert.ToInt32(textBox2.Text) > 1))
                 {
-					MessageBox.Show (this, "Digitize edge points, please", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-				}
-			}
-			// enable Remove SG if SG_count > 1 && a selected entry
-			if (listBox2.Items.Count > 1 && listBox2.SelectedIndex >= 0)
-				button5.Enabled = true;
-			else
-				button5.Enabled = false;
-		}
+                    if (textBox4.Text == "") // section
+                        textBox4.Text = "1";
 
-		//fill actual values
-		/// <summary>
-    	/// Fills the dialog with data from the recent item object
-    	/// </summary> 
-		public void FillValues()
-		{
-			try
-			{
-				LineSourceData _ldata;
-				if (ItemDisplayNr < ItemData.Count)
-				{
-					_ldata = ItemData[ItemDisplayNr];
-				}
-				else
-				{
-					if (ItemData.Count > 0)
-					{
-						_ldata = new LineSourceData(ItemData[ItemData.Count - 1]);
-					}
-					else // 1st entry 
-					{
-						_ldata = new LineSourceData();
-						_ldata.Poll.Add(new PollutantsData(1));
-						
-						for (int i = 0; i < 10; i++)
-						{
-							if (linepollutant[i].SelectedIndex < 0)
-							{
-								linepollutant[i].SelectedIndex = 0;
-							}
-						}
-					}
-				}
-				
-				listBox2.Items.Clear(); // clear Source groups
-				
-				textBox1.Text = _ldata.Name;    // name
-				textBox4.Text = _ldata.Section; // section
-				textBox2.Text = _ldata.Pt.Count.ToString();
-				
-				decimal height = Convert.ToDecimal(Math.Round(_ldata.Height, 1));
-				
-				if (height >= 0) // height above ground
-					checkBox1.Checked = false;
-				else // height above sea
-					checkBox1.Checked = true;
-				
-				numericUpDown1.Value = St_F.ValueSpan(0, 7999, (double) Math.Abs(height));
-				numericUpDown3.Value = St_F.ValueSpan(0, 7999, (double) Math.Abs(_ldata.VerticalExt));
-				
-				numericUpDown2.Value = St_F.ValueSpan(0, 1000, _ldata.Width);
-				numericUpDown6.Value = St_F.ValueSpan(0, 1000000, _ldata.Nemo.AvDailyTraffic);
-				numericUpDown7.Value = St_F.ValueSpan(-0.1, 100, _ldata.Nemo.ShareHDV);
-				numericUpDown4.Value = St_F.ValueSpan(-10, 10, _ldata.Nemo.Slope);
-				listBox1.SelectedIndex = _ldata.Nemo.TrafficSit;
-				numericUpDown8.Value = St_F.ValueSpan(1990, 2200, _ldata.Nemo.BaseYear);
-				
-				SourceGroupEmission.Clear();
-				SourceGroupEmission.TrimExcess();
-				foreach(PollutantsData _poll in _ldata.Poll)
-				{
-					SourceGroupEmission.Add(new PollutantsData(_poll));
-					listBox2.Items.Add(SG_List[_poll.SourceGroup - 1]);
-				}
-				
-				if (listBox2.Items.Count > 0)
-				{
-					listBox2.SelectedIndex = 0;
-				}
-				ListBox2SelectedIndexChanged(null, null); // fill values
+                    _ls.Pt.Clear();
+                    _ls.Pt.TrimExcess();
 
-				// limit to the lenght of cornerlinex
-				for (int i = 0; i < Math.Min(_ldata.Pt.Count, CornerLineX.Length); i++)
-				{
-					CornerLineX[i] = _ldata.Pt[i].X;
-					CornerLineY[i] = _ldata.Pt[i].Y;
-				}
-				
-				if (_ldata.Pt.Count > 0) Domain.EditSourceShape = false;  // block input of new vertices
-				
-				// new lenght
-				double lenght = St_F.CalcLenght(_ldata.Pt);
-				label15.Text = St_F.DblToLocTxt(lenght);
-				
-				//compute PC speed
-				PC_speed();
-				
-				for (int i = 0; i < 10; i++)
-				{
-					dep[i] = _ldata.Dep[i];
-					
-					if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
-						but1[i].BackColor = Color.LightGreen; // mark that deposition is set
-					else
-						but1[i].BackColor = SystemColors.ButtonFace; // mark that deposition is reset
-				}
-				
-			}
-			catch//*(Exception ex)*//
-			{
-				//MessageBox.Show(ex.Message);
-				textBox1.Text = "Line Source";
-				
-				SourceGroupEmission.Clear();
-				SourceGroupEmission.TrimExcess();
-				
-				numericUpDown3.Value = 3; // old standard value = 3 m
-				
-				for (int i = 0; i < 10; i++)
-				{
-					linepollutant[i].SelectedIndex = 0;
-					lineemission[i].Text = "0";
-					but1[i].BackColor = SystemColors.ButtonFace;
-					dep[i].init();
-				}
-			}
-			
-			// enable Remove SG if SG_count > 1 && a selected entry
-			if (listBox2.Items.Count > 1 && listBox2.SelectedIndex >= 0)
-				button5.Enabled = true;
-			else
-				button5.Enabled = false;
-		}
-		
-		//remove actual line source data
-		private void button2_Click(object sender, EventArgs e)
-		{
-			RemoveOne(true);
-			RedrawDomain(this, null);
-		}
-		
-		/// <summary>
-    	/// Remove the recent item object from the item list
-    	/// </summary> 
-		public void RemoveOne(bool ask)
-		{
-			// if ask = false do not ask and delete immediality
-			if (ask == true)
-			{
+                    // new lenght
+                    GralData.PointD_3d[] mypoint = new GralData.PointD_3d[MaxVertices];
+
+                    float height = Convert.ToSingle(numericUpDown1.Value);
+                    int absHeight = 1;
+                    if (checkBox1.Checked) // absolute height over sea
+                    {
+                        height *= (-1);
+                        absHeight = -1;
+                    }
+
+                    if (checkBox2.Checked) // 3D Lines
+                    {
+                        for (int i = 0; i < number_of_vertices; i++)
+                        {
+                            _ls.Pt.Add(new GralData.PointD_3d(CornerLineX[i], CornerLineY[i], Math.Abs(CornerLineZ[i]) * absHeight));
+                        }
+                        _ls.Lines3D = true;
+                    }
+                    else
+                    {
+                        for (int i = 0; i < number_of_vertices; i++)
+                        {
+                            _ls.Pt.Add(new GralData.PointD_3d(CornerLineX[i], CornerLineY[i], height));
+                            CornerLineZ[i] = height;
+                        }
+                        _ls.Lines3D = false;
+                    }
+
+                    double lenght = St_F.CalcLenght(_ls.Pt);
+                    label15.Text = lenght.ToString(ic);
+
+                    if (Convert.ToInt32(textBox2.Text) > 0) Domain.EditSourceShape = false;  // block input of new vertices
+
+                    // collect pollutants
+                    _ls.Poll.Clear();
+                    _ls.Poll.TrimExcess();
+                    if (SourceGroupEmission.Count == 0) // a source group is available, but Save SG not pressed
+                    {
+                        UpdateNewSourcegroupEmission();
+                    }
+
+                    foreach (PollutantsData _pd in SourceGroupEmission)
+                    {
+                        _ls.Poll.Add(_pd);
+                    }
+
+                    for (int i = 0; i < 10; i++) // save deposition
+                    {
+                        _ls.Dep[i] = new Deposition(dep[i]);
+                    }
+
+
+
+                    listBox1.SelectedIndex = listBox1.TopIndex; // NEMO
+                    _ls.Name = textBox1.Text;
+                    _ls.Section = textBox4.Text;
+                    _ls.Height = height;
+                    _ls.Width = Convert.ToSingle(numericUpDown2.Value);
+                    _ls.VerticalExt = Convert.ToSingle(numericUpDown3.Value);
+                    _ls.Nemo.AvDailyTraffic = Convert.ToInt32(numericUpDown6.Value);
+                    _ls.Nemo.ShareHDV = Convert.ToSingle(numericUpDown7.Value);
+                    _ls.Nemo.Slope = Convert.ToSingle(numericUpDown4.Value);
+                    _ls.Nemo.TrafficSit = listBox1.SelectedIndex;
+                    _ls.Nemo.BaseYear = Convert.ToInt32(numericUpDown8.Value);
+
+                    if (ItemDisplayNr >= ItemData.Count) // new item
+                    {
+                        ItemData.Add(_ls);
+                    }
+                    else
+                    {
+                        ItemData[ItemDisplayNr] = _ls;
+                    }
+
+                    RedrawDomain(this, null);
+                }
+            }
+            else
+            {
+                if (textBox1.Text.Length > 0)
+                {
+                    MessageBox.Show(this, "Digitize edge points, please", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+            // enable Remove SG if SG_count > 1 && a selected entry
+            if (listBox2.Items.Count > 1 && listBox2.SelectedIndex >= 0)
+                button5.Enabled = true;
+            else
+                button5.Enabled = false;
+        }
+
+        //fill actual values
+        /// <summary>
+        /// Fills the dialog with data from the recent item object
+        /// </summary> 
+        public void FillValues()
+        {
+            try
+            {
+                LineSourceData _ldata;
+                if (ItemDisplayNr < ItemData.Count)
+                {
+                    _ldata = ItemData[ItemDisplayNr];
+                }
+                else
+                {
+                    if (ItemData.Count > 0)
+                    {
+                        _ldata = new LineSourceData(ItemData[ItemData.Count - 1]);
+                    }
+                    else // 1st entry 
+                    {
+                        _ldata = new LineSourceData();
+                        _ldata.Poll.Add(new PollutantsData(1));
+
+                        for (int i = 0; i < 10; i++)
+                        {
+                            if (linepollutant[i].SelectedIndex < 0)
+                            {
+                                linepollutant[i].SelectedIndex = 0;
+                            }
+                        }
+                    }
+                }
+
+                listBox2.Items.Clear(); // clear Source groups
+
+                textBox1.Text = _ldata.Name;    // name
+                textBox4.Text = _ldata.Section; // section
+                textBox2.Text = _ldata.Pt.Count.ToString();
+
+                double height = Math.Round(_ldata.Height, 1);
+                if (_ldata.Lines3D && _ldata.Pt != null && _ldata.Pt.Count > 0)
+                {
+                    height = _ldata.Pt[0].Z;
+                }
+
+                if (height >= 0) // height above ground
+                    checkBox1.Checked = false;
+                else // height above sea
+                    checkBox1.Checked = true;
+
+                numericUpDown1.Value = St_F.ValueSpan(0, 7999, (double)Math.Abs(height));
+                numericUpDown3.Value = St_F.ValueSpan(0, 7999, (double)Math.Abs(_ldata.VerticalExt));
+
+                numericUpDown2.Value = St_F.ValueSpan(0, 1000, _ldata.Width);
+                numericUpDown6.Value = St_F.ValueSpan(0, 1000000, _ldata.Nemo.AvDailyTraffic);
+                numericUpDown7.Value = St_F.ValueSpan(-0.1, 100, _ldata.Nemo.ShareHDV);
+                numericUpDown4.Value = St_F.ValueSpan(-10, 10, _ldata.Nemo.Slope);
+                listBox1.SelectedIndex = _ldata.Nemo.TrafficSit;
+                numericUpDown8.Value = St_F.ValueSpan(1990, 2200, _ldata.Nemo.BaseYear);
+
+                SourceGroupEmission.Clear();
+                SourceGroupEmission.TrimExcess();
+                foreach (PollutantsData _poll in _ldata.Poll)
+                {
+                    SourceGroupEmission.Add(new PollutantsData(_poll));
+                    listBox2.Items.Add(SG_List[_poll.SourceGroup - 1]);
+                }
+
+                if (listBox2.Items.Count > 0)
+                {
+                    listBox2.SelectedIndex = 0;
+                }
+                ListBox2SelectedIndexChanged(null, null); // fill values
+
+                // limit to the lenght of cornerlinex
+                for (int i = 0; i < Math.Min(_ldata.Pt.Count, CornerLineX.Length); i++)
+                {
+                    CornerLineX[i] = _ldata.Pt[i].X;
+                    CornerLineY[i] = _ldata.Pt[i].Y;
+                    CornerLineZ[i] = Math.Abs(_ldata.Pt[i].Z);
+                }
+
+                if (_ldata.Pt.Count > 0) Domain.EditSourceShape = false;  // block input of new vertices
+
+                // new lenght
+                double lenght = St_F.CalcLenght(_ldata.Pt);
+                label15.Text = St_F.DblToLocTxt(lenght);
+
+                //compute PC speed
+                PC_speed();
+
+                for (int i = 0; i < 10; i++)
+                {
+                    dep[i] = _ldata.Dep[i];
+
+                    if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
+                        but1[i].BackColor = Color.LightGreen; // mark that deposition is set
+                    else
+                        but1[i].BackColor = SystemColors.ButtonFace; // mark that deposition is reset
+                }
+
+                
+                trackBar2.Minimum = 1;
+                trackBar2.Maximum = _ldata.Pt.Count;
+                trackBar2.Value = 1;
+
+                if (_ldata.Lines3D)
+                {
+                    checkBox2.Checked = true;
+                    trackBar2.Enabled = true;
+                    numericUpDown1.Value = St_F.ValueSpan(0, 7999, (double)Math.Abs(CornerLineZ[0]));
+                }
+                else
+                {
+                    checkBox2.Checked = false;
+                    trackBar2.Enabled = false;
+                }
+            }
+            catch(Exception ex)
+            {
+                //MessageBox.Show(ex.Message);
+                textBox1.Text = "Line Source";
+
+                SourceGroupEmission.Clear();
+                SourceGroupEmission.TrimExcess();
+
+                numericUpDown3.Value = 3; // old standard value = 3 m
+
+                for (int i = 0; i < 10; i++)
+                {
+                    linepollutant[i].SelectedIndex = 0;
+                    lineemission[i].Text = "0";
+                    but1[i].BackColor = SystemColors.ButtonFace;
+                    dep[i].init();
+                }
+            }
+
+            // enable Remove SG if SG_count > 1 && a selected entry
+            if (listBox2.Items.Count > 1 && listBox2.SelectedIndex >= 0)
+                button5.Enabled = true;
+            else
+                button5.Enabled = false;
+        }
+
+        //remove actual line source data
+        private void button2_Click(object sender, EventArgs e)
+        {
+            RemoveOne(true);
+            RedrawDomain(this, null);
+        }
+
+        /// <summary>
+        /// Remove the recent item object from the item list
+        /// </summary> 
+        public void RemoveOne(bool ask)
+        {
+            // if ask = false do not ask and delete immediality
+            if (ask == true)
+            {
                 if (St_F.InputBoxYesNo("Attention", "Do you really want to delete this source?", St_F.GetScreenAtMousePosition() + 340, 400) == DialogResult.Yes)
                     ask = false;
-				else
-					ask = true; // Cancel -> do not delete!
-			}
-			if (ask == false)
-			{
-				textBox1.Text = "";
-				textBox4.Text = "1";
-				numericUpDown1.Value = 0;
-				numericUpDown2.Value = 7;
-				numericUpDown6.Value = 1000;
-				numericUpDown7.Value = Convert.ToDecimal(-0.1);
-				numericUpDown4.Value = 0;
-				for (int i = 0; i < 10; i++)
-					lineemission[i].Text = "0";
-				
-				if (ItemDisplayNr >= 0)
-				{
-					try
-					{
-						if (trackBar1.Maximum > 1)
-							trackBar1.Maximum = trackBar1.Maximum - 1;
-						trackBar1.Value = Math.Min(trackBar1.Maximum, trackBar1.Value);
-						
-						ItemData.RemoveAt(ItemDisplayNr);
-						
-						ItemDisplayNr = trackBar1.Value - 1;
-						FillValues();
-					}
-					catch
-					{
-					}
-				}
-			}
-		}
-
-		//remove all line sources
-		private void button3_Click(object sender, EventArgs e)
-		{
-			if (St_F.InputBox("Attention", "Delete all line sources??", this) == DialogResult.OK)
-			{
-				SourceGroupEmission.Clear();
-				SourceGroupEmission.TrimExcess();
-				
-				ItemData.Clear();
-				ItemData.TrimExcess(); 
-				
-				listBox2.Items.Clear();
-				
-				textBox1.Text = "";
-				textBox4.Text = "1";
-				numericUpDown1.Value = 0;
-				numericUpDown3.Value = 3;
-				numericUpDown2.Value = 7;
-				numericUpDown6.Value = 1000;
-				numericUpDown7.Value = Convert.ToDecimal(-0.1);
-				numericUpDown4.Value = 0;
-				for (int i = 0; i < 10; i++)
-				{
-					linepollutant[i].SelectedIndex = 0;
-					lineemission[i].Text = "0";
-					dep[i].init();
-					but1[i].BackColor = SystemColors.ButtonFace;
-				}
-				
-				trackBar1.Value = 1;
-				trackBar1.Maximum = 1;
-				ItemDisplayNr = trackBar1.Value - 1;
-				
-				label15.Text = "0";
-				textBox2.Text = "0";
-				Domain.EditSourceShape = true;  // allow input of new vertices
-				RedrawDomain(this, null);
-			}
-		}
-		
-		//save source group
-		private void button4_Click(object sender, EventArgs e)
-		{
-			if (listBox2.SelectedIndex < 0 && listBox2.Items.Count > 1) // no source group selected & more than 1 source groups available
+                else
+                    ask = true; // Cancel -> do not delete!
+            }
+            if (ask == false)
             {
-		        Color _col = listBox2.BackColor;
-		        listBox2.BackColor = Color.Yellow;
+                textBox1.Text = "";
+                textBox4.Text = "1";
+                numericUpDown1.Value = 0;
+                numericUpDown2.Value = 7;
+                numericUpDown6.Value = 1000;
+                numericUpDown7.Value = Convert.ToDecimal(-0.1);
+                numericUpDown4.Value = 0;
+                for (int i = 0; i < 10; i++)
+                    lineemission[i].Text = "0";
+
+                if (ItemDisplayNr >= 0)
+                {
+                    try
+                    {
+                        if (trackBar1.Maximum > 1)
+                            trackBar1.Maximum = trackBar1.Maximum - 1;
+                        trackBar1.Value = Math.Min(trackBar1.Maximum, trackBar1.Value);
+
+                        ItemData.RemoveAt(ItemDisplayNr);
+
+                        ItemDisplayNr = trackBar1.Value - 1;
+                        FillValues();
+                    }
+                    catch
+                    {
+                    }
+                }
+            }
+        }
+
+        //remove all line sources
+        private void button3_Click(object sender, EventArgs e)
+        {
+            if (St_F.InputBox("Attention", "Delete all line sources??", this) == DialogResult.OK)
+            {
+                SourceGroupEmission.Clear();
+                SourceGroupEmission.TrimExcess();
+
+                ItemData.Clear();
+                ItemData.TrimExcess();
+
+                listBox2.Items.Clear();
+
+                textBox1.Text = "";
+                textBox4.Text = "1";
+                numericUpDown1.Value = 0;
+                numericUpDown3.Value = 3;
+                numericUpDown2.Value = 7;
+                numericUpDown6.Value = 1000;
+                numericUpDown7.Value = Convert.ToDecimal(-0.1);
+                numericUpDown4.Value = 0;
+                for (int i = 0; i < 10; i++)
+                {
+                    linepollutant[i].SelectedIndex = 0;
+                    lineemission[i].Text = "0";
+                    dep[i].init();
+                    but1[i].BackColor = SystemColors.ButtonFace;
+                }
+
+                trackBar1.Value = 1;
+                trackBar1.Maximum = 1;
+                ItemDisplayNr = trackBar1.Value - 1;
+
+                label15.Text = "0";
+                textBox2.Text = "0";
+                Domain.EditSourceShape = true;  // allow input of new vertices
+                RedrawDomain(this, null);
+            }
+        }
+
+        //save source group
+        private void button4_Click(object sender, EventArgs e)
+        {
+            if (listBox2.SelectedIndex < 0 && listBox2.Items.Count > 1) // no source group selected & more than 1 source groups available
+            {
+                Color _col = listBox2.BackColor;
+                listBox2.BackColor = Color.Yellow;
                 MessageBox.Show(this, "No source group selected, please \n - select a source group \n - enter the emission rates \n - save the source group", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 listBox2.BackColor = _col;
                 return;
             }
-		    if (listBox2.Items.Count == 0) // no source group  available
-		    {
-		        Color _col = listBox2.BackColor;
-		        listBox2.BackColor = Color.Yellow;
+            if (listBox2.Items.Count == 0) // no source group  available
+            {
+                Color _col = listBox2.BackColor;
+                listBox2.BackColor = Color.Yellow;
                 MessageBox.Show(this, "No source group added, please \n - add a source group \n - enter the emission rates \n - save the source group", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 listBox2.BackColor = _col;
                 return;
             }
-			
-		    UpdateNewSourcegroupEmission();
-			
-			SaveArray();
-		}
-		
-		private void UpdateNewSourcegroupEmission()
-		{
-			try
-			{
-				string sg_name = String.Empty;
-				if (listBox2.Items.Count == 1) // nothing selected but only 1 sg available
-				{
-					sg_name = listBox2.Items[0].ToString();
-				}
-				else if (listBox2.SelectedIndex >= 0)
-				{
-					sg_name = listBox2.SelectedItem.ToString();
-				}
-				
-				if (sg_name.Length > 0)
-				{
-					int sg_nr = St_F.GetSgNumber(sg_name);
-					int index = GetPollutantListIndex(sg_nr);
-					
-					if (index < 0) // new entry
-					{
-						SourceGroupEmission.Add(new PollutantsData());
-						index = SourceGroupEmission.Count - 1;
-					}
-					
-					SourceGroupEmission[index].SourceGroup = sg_nr;
-					
-					for (int i = 0; i < 10; i++)
-					{
-						SourceGroupEmission[index].Pollutant[i] = linepollutant[i].SelectedIndex;
-						double _val = 0;
-						double.TryParse(lineemission[i].Text, out _val);
-						SourceGroupEmission[index].EmissionRate[i] = _val;
-					}
-				}
-			}
-			catch
-			{
-				
-			}
-		}
-		
-		private int GetPollutantListIndex(int SourceGroupNumber)
-		{
-			int index = -1;
-			
-			for (int i = 0; i < SourceGroupEmission.Count; i++)
-			{
-				if(SourceGroupEmission[i].SourceGroup == SourceGroupNumber)
-				{
-					index = i;
-				}
-			}
-			
-			return index;
-		}
-		
-		//compute average PC speed based on the chosen traffic situation and the slope
-		private void PC_speed()
-		{
-			if (listBox1.SelectedIndex != 0)
-			{
-				//read velocities for each vehicle-type according to the driving pattern and the slope
-				Assembly _assembly;
-				_assembly = Assembly.GetExecutingAssembly();
-				StreamReader myReader = new StreamReader(_assembly.GetManifestResourceStream("Gral.Resources.NEMO_velocities.txt"));
-				string[] line = new string[400];
-				line[0] = myReader.ReadLine();
-				string[] velo = new string[11];
-				for (int k = 1; k < 400; k++)
-				{
-					try
-					{
-						line[k] = myReader.ReadLine();
-					}
-					catch
-					{
-						break;
-					}
-				}
-				myReader.Close();
-				myReader.Dispose();
-				
-				for (int k = 1; k < 400; k++)
-				{
-					try
-					{
-						velo = line[k].Split(new char[] { ('\t') }, StringSplitOptions.RemoveEmptyEntries);
-						if (velo[0] == Convert.ToString(listBox1.SelectedItem))
-						{
-							//check for the slope
-							double slpnemo = Convert.ToDouble(velo[2], ic);
-							double slpinput = Convert.ToDouble(numericUpDown4.Value, ic);
-							if (slpnemo >= slpinput)
-							{
-								textBox3.Text = St_F.ICultToLCult(velo[4]);
-								break;
-							}
-						}
-					}
-					catch
-					{
-						break;
-					}
-				}
-			}
-		}
 
-		
-		//change traffic situation
-		private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
-		{
-			//compute PC speed
-			PC_speed();		
-		}
+            UpdateNewSourcegroupEmission();
 
-		//change slope
-		private void numericUpDown4_ValueChanged(object sender, EventArgs e)
-		{
-			//compute PC speed
-			PC_speed();
-		}
+            SaveArray();
+        }
 
-		void EditlinesourcesResizeEnd(object sender, EventArgs e)
-		{
-			int dialog_width = ClientSize.Width;
-			
-			if (dialog_width < Dialog_Initial_Width)
-			{
-				dialog_width = Dialog_Initial_Width;
-			}
-			
-			if (dialog_width > 200)
-			{
-				dialog_width -= 12;
-				trackBar1.Width = dialog_width - TrackBar_x0;
-				textBox1.Width = dialog_width - TextBox_x0;
-				textBox2.Width = dialog_width - button8.Right - 5;
-				textBox4.Width = dialog_width - TextBox_x0;
-				label15.Width  = dialog_width - TextBox_x0;
-				numericUpDown1.Width = dialog_width - TextBox_x0;
-				numericUpDown2.Width = dialog_width - TextBox_x0;
-				numericUpDown3.Width = dialog_width - TextBox_x0;
-				groupBox2.Width = dialog_width - listbox_x0;
-				listBox2.Width = groupBox2.Width - listBox2.Left - 4;
-				tabControl1.Width = dialog_width - TabControl_x0;
-				button5.Left = groupBox2.Width - 5 - button5.Width;
-				button7.Left = groupBox2.Width / 2 - button7.Width / 2;
-			}
-			
-			if (ClientSize.Height > (tabControl1.Top + TabControl1_Height))
-			{
-				tabControl1.Height = ClientSize.Height - tabControl1.Top;
-			}
-			
-			int element_width = (tabPage1.Width - but1[1].Width - 20) / 2;
-			if (element_width < TBWidth)
-			{
-				element_width = TBWidth;
-			}
+        private void UpdateNewSourcegroupEmission()
+        {
+            try
+            {
+                string sg_name = String.Empty;
+                if (listBox2.Items.Count == 1) // nothing selected but only 1 sg available
+                {
+                    sg_name = listBox2.Items[0].ToString();
+                }
+                else if (listBox2.SelectedIndex >= 0)
+                {
+                    sg_name = listBox2.SelectedItem.ToString();
+                }
+
+                if (sg_name.Length > 0)
+                {
+                    int sg_nr = St_F.GetSgNumber(sg_name);
+                    int index = GetPollutantListIndex(sg_nr);
+
+                    if (index < 0) // new entry
+                    {
+                        SourceGroupEmission.Add(new PollutantsData());
+                        index = SourceGroupEmission.Count - 1;
+                    }
+
+                    SourceGroupEmission[index].SourceGroup = sg_nr;
+
+                    for (int i = 0; i < 10; i++)
+                    {
+                        SourceGroupEmission[index].Pollutant[i] = linepollutant[i].SelectedIndex;
+                        double _val = 0;
+                        double.TryParse(lineemission[i].Text, out _val);
+                        SourceGroupEmission[index].EmissionRate[i] = _val;
+                    }
+                }
+            }
+            catch
+            {
+
+            }
+        }
+
+        private int GetPollutantListIndex(int SourceGroupNumber)
+        {
+            int index = -1;
+
+            for (int i = 0; i < SourceGroupEmission.Count; i++)
+            {
+                if (SourceGroupEmission[i].SourceGroup == SourceGroupNumber)
+                {
+                    index = i;
+                }
+            }
+
+            return index;
+        }
+
+        //compute average PC speed based on the chosen traffic situation and the slope
+        private void PC_speed()
+        {
+            if (listBox1.SelectedIndex != 0)
+            {
+                //read velocities for each vehicle-type according to the driving pattern and the slope
+                Assembly _assembly;
+                _assembly = Assembly.GetExecutingAssembly();
+                StreamReader myReader = new StreamReader(_assembly.GetManifestResourceStream("Gral.Resources.NEMO_velocities.txt"));
+                string[] line = new string[400];
+                line[0] = myReader.ReadLine();
+                string[] velo = new string[11];
+                for (int k = 1; k < 400; k++)
+                {
+                    try
+                    {
+                        line[k] = myReader.ReadLine();
+                    }
+                    catch
+                    {
+                        break;
+                    }
+                }
+                myReader.Close();
+                myReader.Dispose();
+
+                for (int k = 1; k < 400; k++)
+                {
+                    try
+                    {
+                        velo = line[k].Split(new char[] { ('\t') }, StringSplitOptions.RemoveEmptyEntries);
+                        if (velo[0] == Convert.ToString(listBox1.SelectedItem))
+                        {
+                            //check for the slope
+                            double slpnemo = Convert.ToDouble(velo[2], ic);
+                            double slpinput = Convert.ToDouble(numericUpDown4.Value, ic);
+                            if (slpnemo >= slpinput)
+                            {
+                                textBox3.Text = St_F.ICultToLCult(velo[4]);
+                                break;
+                            }
+                        }
+                    }
+                    catch
+                    {
+                        break;
+                    }
+                }
+            }
+        }
+
+
+        //change traffic situation
+        private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+            //compute PC speed
+            PC_speed();
+        }
+
+        //change slope
+        private void numericUpDown4_ValueChanged(object sender, EventArgs e)
+        {
+            //compute PC speed
+            PC_speed();
+        }
+
+        void EditlinesourcesResizeEnd(object sender, EventArgs e)
+        {
+            int dialog_width = ClientSize.Width;
+
+            if (dialog_width < Dialog_Initial_Width)
+            {
+                dialog_width = Dialog_Initial_Width;
+            }
+
+            if (dialog_width > 200)
+            {
+                dialog_width -= 12;
+                trackBar1.Width = dialog_width - TrackBar_x0;
+                trackBar2.Width = dialog_width - TrackBar_x0;
+                textBox1.Width = dialog_width - TextBox_x0;
+                textBox2.Width = dialog_width - button8.Right - 5;
+                textBox4.Width = dialog_width - TextBox_x0;
+                label15.Width = dialog_width - TextBox_x0;
+                numericUpDown1.Width = dialog_width - TextBox_x0;
+                numericUpDown2.Width = dialog_width - TextBox_x0;
+                numericUpDown3.Width = dialog_width - TextBox_x0;
+                groupBox2.Width = dialog_width - listbox_x0;
+                listBox2.Width = groupBox2.Width - listBox2.Left - 4;
+                tabControl1.Width = dialog_width - TabControl_x0;
+                button5.Left = groupBox2.Width - 5 - button5.Width;
+                button7.Left = groupBox2.Width / 2 - button7.Width / 2;
+            }
+
+            if (ClientSize.Height > (tabControl1.Top + TabControl1_Height))
+            {
+                tabControl1.Height = ClientSize.Height - tabControl1.Top;
+            }
+
+            int element_width = (tabPage1.Width - but1[1].Width - 20) / 2;
+            if (element_width < TBWidth)
+            {
+                element_width = TBWidth;
+            }
 
             button9.Left = (int)((dialog_width - button9.Width) * 0.5);
 
             for (int nr = 0; nr < 10; nr++)
-			{
-				linepollutant[nr].Width  = (int) (element_width);
-				labelpollutant[nr].Width = (int) (element_width); 
-				lineemission [nr].Location = new System.Drawing.Point (linepollutant[nr].Left + linepollutant[nr].Width + 5, linepollutant[nr].Top);
-				lineemission [nr].Width = (int) (element_width);
-				but1[nr].Location = new System.Drawing.Point(lineemission[nr].Left + lineemission[nr].Width + 5, linepollutant[nr].Top - 1);
-			}		
-		}		
-		
-		void EditlinesourcesVisibleChanged(object sender, EventArgs e) // Kuntner: save sourcedata if form is hidden
-		{
-			if (!Visible)
-			{
-				SaveArray(); // save sourcedata
-				//save line sources input to file
-			}
-			else // Enable/disable items 
-			{
-				bool enable = !Main.Project_Locked;
-				if (enable)
-				{
-					Text = "Edit line sources";
-				}
-				else
-				{
-					Text = "Line source settings (project locked)";
-				}
-				foreach (Control c in Controls)
-				{
-					if (c != trackBar1 && c != groupBox2 && c != tabControl1)
-					{
-						c.Enabled = enable;
-					}
-				}
-				button4.Enabled = enable;
-				button5.Enabled = enable;
-				button7.Enabled = enable;
-				
-				foreach (Control c in tabControl1.Controls)
-				{
-					if (c!= tabPage1)
-					{
-						c.Enabled = enable;
-					}
-				}
-				foreach (Control c in tabPage1.Controls)
-				{
-					if (c != trackBar1 && c.GetType() != typeof(Button) && (c.GetType() != typeof(ListBox)))
-					{
-						c.Enabled = enable;
-					}
-				}
-				
-				for (int i = 0; i < 10; i++)
-				{
-					linepollutant[i].Visible = enable;
-					labelpollutant[i].Visible = !enable;
-				}
-			}
-		}
-		
-		private void RedrawDomain(object sender, EventArgs e)
-		{
-			// send Message to domain Form, that redraw is necessary
-			try
-			{
-				if (LinesourceRedraw != null)
-					LinesourceRedraw(this, e);
-			}
-			catch
-			{}
-		}
-		
-		public void ShowForm()
-		{
-			ItemDisplayNr = trackBar1.Value - 1;
-			RedrawDomain(this, null);
-		}
-		
-		
-		void TextBox2Click(object sender, EventArgs e)
-		{
-			{
-				try
-				{
-					int number_of_vertices = Convert.ToInt32(textBox2.Text);
-					if (number_of_vertices < 2) throw new System.InvalidOperationException("Nothing digitized");
-                    VerticesEditDialog vert = new VerticesEditDialog(number_of_vertices, ref CornerLineX, ref CornerLineY)
+            {
+                linepollutant[nr].Width = (int)(element_width);
+                labelpollutant[nr].Width = (int)(element_width);
+                lineemission[nr].Location = new System.Drawing.Point(linepollutant[nr].Left + linepollutant[nr].Width + 5, linepollutant[nr].Top);
+                lineemission[nr].Width = (int)(element_width);
+                but1[nr].Location = new System.Drawing.Point(lineemission[nr].Left + lineemission[nr].Width + 5, linepollutant[nr].Top - 1);
+            }
+        }
+
+        void EditlinesourcesVisibleChanged(object sender, EventArgs e) // Kuntner: save sourcedata if form is hidden
+        {
+            if (!Visible)
+            {
+                SaveArray(); // save sourcedata
+                GralDomain.Domain.MarkerPoint.X = 0;
+                GralDomain.Domain.MarkerPoint.Y = 0;
+            }
+            else // Enable/disable items 
+            {
+                bool enable = !Main.Project_Locked;
+                if (enable)
+                {
+                    Text = "Edit line sources";
+                }
+                else
+                {
+                    Text = "Line source settings (project locked)";
+                }
+                foreach (Control c in Controls)
+                {
+                    if (c != trackBar1 && c != groupBox2 && c != tabControl1 && c != trackBar2)
                     {
-                        StartPosition = FormStartPosition.Manual
-                    };
+                        c.Enabled = enable;
+                    }
+                }
+                button4.Enabled = enable;
+                button5.Enabled = enable;
+                button7.Enabled = enable;
+
+                foreach (Control c in tabControl1.Controls)
+                {
+                    if (c != tabPage1 && c != trackBar2)
+                    {
+                        c.Enabled = enable;
+                    }    
+                }
+
+                foreach (Control c in tabPage1.Controls)
+                {
+                    if (c != trackBar1 && c.GetType() != typeof(Button) && (c.GetType() != typeof(ListBox)))
+                    {
+                        c.Enabled = enable;
+                    }
+                }
+
+                for (int i = 0; i < 10; i++)
+                {
+                    linepollutant[i].Visible = enable;
+                    labelpollutant[i].Visible = !enable;
+                }
+            }
+        }
+
+        private void RedrawDomain(object sender, EventArgs e)
+        {
+            // send Message to domain Form, that redraw is necessary
+            try
+            {
+                if (LinesourceRedraw != null)
+                    LinesourceRedraw(this, e);
+            }
+            catch
+            { }
+        }
+
+        public void ShowForm()
+        {
+            ItemDisplayNr = trackBar1.Value - 1;
+            RedrawDomain(this, null);
+        }
+
+
+        void TextBox2Click(object sender, EventArgs e)
+        {
+            {
+                try
+                {
+                    int number_of_vertices = Convert.ToInt32(textBox2.Text);
+                    if (number_of_vertices < 2) throw new System.InvalidOperationException("Nothing digitized");
+                    VerticesEditDialog vert;
+
+                    if (checkBox2.Checked) // 3D Lines
+                    {
+                        vert = new VerticesEditDialog(number_of_vertices, ref CornerLineX, ref CornerLineY, ref CornerLineZ)
+                        {
+                            StartPosition = FormStartPosition.Manual
+                        };
+                    }
+                    else
+                    {
+                        vert = new VerticesEditDialog(number_of_vertices, ref CornerLineX, ref CornerLineY)
+                        {
+                            StartPosition = FormStartPosition.Manual
+                        };
+                    }
+
                     if (Right < SystemInformation.PrimaryMonitorSize.Width / 2)
-					{
-						vert.Location = new Point(Right + 4, Top);
-					}
-					else
-					{
-						vert.Location = new Point(Left - 250, Top);
-					}
-					
-					vert.Vertices_redraw += new ForceDomainRedraw(RedrawDomain);
-					if (vert.ShowDialog() == DialogResult.OK)
-        			{
-        			    int cornerCount = vert.Lines;
-        			    SetNumberOfVerticesText(cornerCount.ToString());
-        			}
-					
-					SaveArray();
-					vert.Dispose();
-				}
-				catch
-				{MessageBox.Show(this, "Nothing digitized","GRAL GUI",MessageBoxButtons.OK,MessageBoxIcon.Error);
-				}
-			}
-		}
-		
-		private void edit_deposition(object sender, EventArgs e)
-		{
-			int nr = 0;
-			for (int i = 0; i < 10; i++)
-			{
-				if (sender == but1[i])
-					nr = i;
-			}
-            
-			using (EditDeposition edit = new EditDeposition
-			{
-			   	StartPosition = FormStartPosition.Manual
-			})
-			{
-				if (Right < SystemInformation.PrimaryMonitorSize.Width / 2)
-				{
-					edit.Location = new Point(Right + 4, Top);
-				}
-				else
-				{
-					edit.Location = new Point(Left - 370, Top);
-				}
-				edit.Dep = dep[nr]; // set actual values
-				edit.Emission = St_F.TxtToDbl(lineemission[nr].Text, true);
-				edit.Pollutant = linepollutant[nr].SelectedIndex;
-				if (edit.ShowDialog() == DialogResult.OK)
-					edit.Hide();
-			}
-			if (Main.Project_Locked == false)
-			{
-				if (dep[nr].V_Dep1 > 0 || dep[nr].V_Dep2 > 0 || dep[nr].V_Dep3 > 0)
-					but1[nr].BackColor = Color.LightGreen; // mark that deposition is set
-				else
-					but1[nr].BackColor = SystemColors.ButtonFace;
-				
-				SaveArray(); // save values
-			}
-		}
-		
-		void ListBox2SelectedIndexChanged(object sender, EventArgs e)
-		{
-			try
-			{
-				string sg_name = string.Empty;
-				if (listBox2.Items.Count > 0)
-				{
-					sg_name = listBox2.Items[0].ToString();
-				}
-				if (listBox2.SelectedIndex >= 0 || listBox2.Items.Count == 1) // an entry is selected or only one entry
-				{
-				    if (listBox2.SelectedIndex >= 0)
-				    {
-					   sg_name = listBox2.SelectedItem.ToString();
-				    }
-				    else if (listBox2.Items.Count == 1)
-				    {
-				        sg_name = listBox2.Items[0].ToString();
-				    }
-				}
-				
-				if (listBox2.Items.Count >= 1)
-				{
-					if (Main.Project_Locked == false)
-					{
-						button4.Enabled = true; // enable save source group button
-						if (listBox2.Items.Count > 1)
-						{
-							button5.Enabled = true; // enable delete source group button
-						}
-					}
-				}
-				else
-				{
-					button4.Enabled = false; // disable save source group button
-					button5.Enabled = false; // disable delete source group button
-				}
-				
-				if (sg_name.Length > 0)
-				{
-					int sg_nr = St_F.GetSgNumber(sg_name);
-					int index = GetPollutantListIndex(sg_nr);
-					
-					// block change of pollutants
-					if (listBox2.SelectedIndex > 0 || Main.Project_Locked == true)
-					{
-						for (int i = 0; i < 10; i++)
-						{
-							linepollutant[i].Visible = false;
-							labelpollutant[i].Visible = true;
-						}
-					}
-					else
-					{
-						for (int i = 0; i < 10; i++)
-						{
-							linepollutant[i].Visible = true;
-							labelpollutant[i].Visible = false;
-						}
-					}
-					
-					for (int i = 0; i < 10; i++)
-					{
-						if (index < 0)
-						{
-							linepollutant[i].SelectedIndex = 0;
-							labelpollutant[i].Text = linepollutant[i].Text;
-							lineemission[i].Text = "0";
-						}
-						else
-						{
-							if (listBox2.SelectedIndex > 0) // set pollutant from first Source group
-							{
-								linepollutant[i].SelectedIndex = SourceGroupEmission[0].Pollutant[i];
-							}
-							else // set saved pollutant (compatibility to old projects)
-							{
-								linepollutant[i].SelectedIndex = SourceGroupEmission[index].Pollutant[i];
-							}
-							
-							labelpollutant[i].Text = linepollutant[i].Text;
-							lineemission[i].Text = SourceGroupEmission[index].EmissionRate[i].ToString();
-						}
-					}
-				}
-			}
-			catch
-			{}
-		}
-		
-		// remove a SG - uncheck the checkbox
-		void Button5Click(object sender, EventArgs e)
-		{
-			// reset emission of this sg
-			if (listBox2.SelectedIndex >= 0)
-			{
-				string sg_name = listBox2.SelectedItem.ToString();
-				int sg_nr = St_F.GetSgNumber(sg_name);
-				int indexold = GetPollutantListIndex(sg_nr);
-				
-				SourceGroupEmission.RemoveAt(indexold);
-				listBox2.Items.RemoveAt(listBox2.SelectedIndex);
-			}
-			SaveArray();
-			// fill in new values
-		}
-		
-		void CheckBox1CheckedChanged(object sender, EventArgs e)
-		{
-			if (checkBox1.Checked)
-				label5.BackColor = Color.Yellow;
-			else
-				label5.BackColor = Color.Transparent;
-		}
+                    {
+                        vert.Location = new Point(Right + 4, Top);
+                    }
+                    else
+                    {
+                        vert.Location = new Point(Left - 250, Top);
+                    }
+
+                    vert.Vertices_redraw += new ForceDomainRedraw(RedrawDomain);
+                    if (vert.ShowDialog() == DialogResult.OK)
+                    {
+                        int cornerCount = vert.Lines;
+                        SetNumberOfVerticesText(cornerCount.ToString());
+                    }
+
+                    SaveArray();
+                    vert.Dispose();
+                }
+                catch
+                {
+                    MessageBox.Show(this, "Nothing digitized", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
+
+        private void edit_deposition(object sender, EventArgs e)
+        {
+            int nr = 0;
+            for (int i = 0; i < 10; i++)
+            {
+                if (sender == but1[i])
+                    nr = i;
+            }
+
+            using (EditDeposition edit = new EditDeposition
+            {
+                StartPosition = FormStartPosition.Manual
+            })
+            {
+                if (Right < SystemInformation.PrimaryMonitorSize.Width / 2)
+                {
+                    edit.Location = new Point(Right + 4, Top);
+                }
+                else
+                {
+                    edit.Location = new Point(Left - 370, Top);
+                }
+                edit.Dep = dep[nr]; // set actual values
+                edit.Emission = St_F.TxtToDbl(lineemission[nr].Text, true);
+                edit.Pollutant = linepollutant[nr].SelectedIndex;
+                if (edit.ShowDialog() == DialogResult.OK)
+                    edit.Hide();
+            }
+            if (Main.Project_Locked == false)
+            {
+                if (dep[nr].V_Dep1 > 0 || dep[nr].V_Dep2 > 0 || dep[nr].V_Dep3 > 0)
+                    but1[nr].BackColor = Color.LightGreen; // mark that deposition is set
+                else
+                    but1[nr].BackColor = SystemColors.ButtonFace;
+
+                SaveArray(); // save values
+            }
+        }
+
+        void ListBox2SelectedIndexChanged(object sender, EventArgs e)
+        {
+            try
+            {
+                string sg_name = string.Empty;
+                if (listBox2.Items.Count > 0)
+                {
+                    sg_name = listBox2.Items[0].ToString();
+                }
+                if (listBox2.SelectedIndex >= 0 || listBox2.Items.Count == 1) // an entry is selected or only one entry
+                {
+                    if (listBox2.SelectedIndex >= 0)
+                    {
+                        sg_name = listBox2.SelectedItem.ToString();
+                    }
+                    else if (listBox2.Items.Count == 1)
+                    {
+                        sg_name = listBox2.Items[0].ToString();
+                    }
+                }
+
+                if (listBox2.Items.Count >= 1)
+                {
+                    if (Main.Project_Locked == false)
+                    {
+                        button4.Enabled = true; // enable save source group button
+                        if (listBox2.Items.Count > 1)
+                        {
+                            button5.Enabled = true; // enable delete source group button
+                        }
+                    }
+                }
+                else
+                {
+                    button4.Enabled = false; // disable save source group button
+                    button5.Enabled = false; // disable delete source group button
+                }
+
+                if (sg_name.Length > 0)
+                {
+                    int sg_nr = St_F.GetSgNumber(sg_name);
+                    int index = GetPollutantListIndex(sg_nr);
+
+                    // block change of pollutants
+                    if (listBox2.SelectedIndex > 0 || Main.Project_Locked == true)
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            linepollutant[i].Visible = false;
+                            labelpollutant[i].Visible = true;
+                        }
+                    }
+                    else
+                    {
+                        for (int i = 0; i < 10; i++)
+                        {
+                            linepollutant[i].Visible = true;
+                            labelpollutant[i].Visible = false;
+                        }
+                    }
+
+                    for (int i = 0; i < 10; i++)
+                    {
+                        if (index < 0)
+                        {
+                            linepollutant[i].SelectedIndex = 0;
+                            labelpollutant[i].Text = linepollutant[i].Text;
+                            lineemission[i].Text = "0";
+                        }
+                        else
+                        {
+                            if (listBox2.SelectedIndex > 0) // set pollutant from first Source group
+                            {
+                                linepollutant[i].SelectedIndex = SourceGroupEmission[0].Pollutant[i];
+                            }
+                            else // set saved pollutant (compatibility to old projects)
+                            {
+                                linepollutant[i].SelectedIndex = SourceGroupEmission[index].Pollutant[i];
+                            }
+
+                            labelpollutant[i].Text = linepollutant[i].Text;
+                            lineemission[i].Text = SourceGroupEmission[index].EmissionRate[i].ToString();
+                        }
+                    }
+                }
+            }
+            catch
+            { }
+        }
+
+        // remove a SG - uncheck the checkbox
+        void Button5Click(object sender, EventArgs e)
+        {
+            // reset emission of this sg
+            if (listBox2.SelectedIndex >= 0)
+            {
+                string sg_name = listBox2.SelectedItem.ToString();
+                int sg_nr = St_F.GetSgNumber(sg_name);
+                int indexold = GetPollutantListIndex(sg_nr);
+
+                SourceGroupEmission.RemoveAt(indexold);
+                listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+            }
+            SaveArray();
+            // fill in new values
+        }
+
+        void CheckBox1CheckedChanged(object sender, EventArgs e)
+        {
+            if (checkBox1.Checked)
+                label5.BackColor = Color.Yellow;
+            else
+                label5.BackColor = Color.Transparent;
+        }
 
         private void EditLinesources_FormClosing(object sender, FormClosingEventArgs e)
         {
@@ -1113,83 +1173,85 @@ namespace GralItemForms
                     e.Cancel = true;
                 }
             }
+            GralDomain.Domain.MarkerPoint.X = 0;
+            GralDomain.Domain.MarkerPoint.Y = 0;
         }
 
         void EditlinesourcesFormClosed(object sender, FormClosedEventArgs e)
-		{
-			foreach(TextBox tex in lineemission)
-			{
-				tex.TextChanged -= new System.EventHandler(St_F.CheckInput);
-			}
-			
-			foreach(Button but in but1)
-				but.Click -= new EventHandler(edit_deposition);
-			
-			textBox1.KeyPress -= new KeyPressEventHandler(Comma1); //only point as decimal seperator is allowed
-			
-			CornerLineX = null;
-			CornerLineY = null;
-			ItemData.Clear();
-			ItemData.TrimExcess();
-			SourceGroupEmission.Clear();
-			SourceGroupEmission.TrimExcess();
-			
-			for (int nr = 0; nr < 10; nr++)
-			{
-				linepollutant[nr].SelectedValueChanged -= new System.EventHandler(Odour);
-				linepollutant[nr].Items.Clear();
-				lineemission[nr].KeyPress -= new KeyPressEventHandler(St_F.NumericInput);
-				linepollutant[nr].Dispose();
-				labelpollutant[nr].Dispose();
-			}
-			
-			listBox2.Items.Clear();
-			SG_List.Clear();
-			SG_List.TrimExcess();
-			
-			toolTip1.Dispose();
-		}
-		
-		void Button7Click(object sender, EventArgs e)
-		{
+        {
+            foreach (TextBox tex in lineemission)
+            {
+                tex.TextChanged -= new System.EventHandler(St_F.CheckInput);
+            }
+
+            foreach (Button but in but1)
+                but.Click -= new EventHandler(edit_deposition);
+
+            textBox1.KeyPress -= new KeyPressEventHandler(Comma1); //only point as decimal seperator is allowed
+
+            CornerLineX = null;
+            CornerLineY = null;
+            ItemData.Clear();
+            ItemData.TrimExcess();
+            SourceGroupEmission.Clear();
+            SourceGroupEmission.TrimExcess();
+
+            for (int nr = 0; nr < 10; nr++)
+            {
+                linepollutant[nr].SelectedValueChanged -= new System.EventHandler(Odour);
+                linepollutant[nr].Items.Clear();
+                lineemission[nr].KeyPress -= new KeyPressEventHandler(St_F.NumericInput);
+                linepollutant[nr].Dispose();
+                labelpollutant[nr].Dispose();
+            }
+
+            listBox2.Items.Clear();
+            SG_List.Clear();
+            SG_List.TrimExcess();
+
+            toolTip1.Dispose();
+        }
+
+        void Button7Click(object sender, EventArgs e)
+        {
             EditSelectSourcegroup sgsel = new EditSelectSourcegroup
             {
                 StartPosition = FormStartPosition.Manual
             };
             if (Right < SystemInformation.PrimaryMonitorSize.Width / 2)
-			{
-				sgsel.Location = new Point(Right + 4, Top);
-			}
-			else
-			{
-				sgsel.Location = new Point(Left - 460, Top);
-			}
-			sgsel.SourceGroup = SG_List;
-			sgsel.CopyFrom = new List<string>();
-			foreach (var text in listBox2.Items)
-			{
-				sgsel.CopyFrom.Add(text.ToString());
-			}
-			
-			if (sgsel.ShowDialog() == DialogResult.OK)
-			{
-				if (sgsel.ShiftCopy == 0) // add new sg
-				{
-					int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
+            {
+                sgsel.Location = new Point(Right + 4, Top);
+            }
+            else
+            {
+                sgsel.Location = new Point(Left - 460, Top);
+            }
+            sgsel.SourceGroup = SG_List;
+            sgsel.CopyFrom = new List<string>();
+            foreach (var text in listBox2.Items)
+            {
+                sgsel.CopyFrom.Add(text.ToString());
+            }
+
+            if (sgsel.ShowDialog() == DialogResult.OK)
+            {
+                if (sgsel.ShiftCopy == 0) // add new sg
+                {
+                    int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
                     PollutantsData _poll = new PollutantsData
                     {
                         SourceGroup = new_sg
                     };
                     SourceGroupEmission.Add(_poll);
-					listBox2.Items.Add(sgsel.SelectedSourceGroup);
-					listBox2.SelectedIndex = listBox2.Items.Count - 1;
-				}
-				else if (sgsel.ShiftCopy == 1 && sgsel.SelCopyFrom.Length > 0) // copy a Source group
-				{
-					int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
-					int old_sg = St_F.GetSgNumber(sgsel.SelCopyFrom);
-					
-					int indexold = GetPollutantListIndex(old_sg);
+                    listBox2.Items.Add(sgsel.SelectedSourceGroup);
+                    listBox2.SelectedIndex = listBox2.Items.Count - 1;
+                }
+                else if (sgsel.ShiftCopy == 1 && sgsel.SelCopyFrom.Length > 0) // copy a Source group
+                {
+                    int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
+                    int old_sg = St_F.GetSgNumber(sgsel.SelCopyFrom);
+
+                    int indexold = GetPollutantListIndex(old_sg);
 
                     PollutantsData _poll = new PollutantsData(SourceGroupEmission[indexold])
                     {
@@ -1197,85 +1259,152 @@ namespace GralItemForms
                     }; // copy from old to new sourcegroup
 
                     SourceGroupEmission.Add(_poll);
-					listBox2.Items.Add(sgsel.SelectedSourceGroup);
-					SaveArray();
-					//FillValues();
-					listBox2.SelectedIndex = listBox2.Items.Count - 1;
-				}
-				else if (sgsel.ShiftCopy == 2 && sgsel.SelCopyFrom.Length > 0) // Shift a Source group?
-				{
-					if (MessageBox.Show(this, "Move source group " + sgsel.SelCopyFrom +
-					                    "\n to " + sgsel.SelectedSourceGroup + " ?", "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
-					{
-						int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
-						int old_sg = St_F.GetSgNumber(sgsel.SelCopyFrom);
-						
-						int indexold = GetPollutantListIndex(old_sg);
-						SourceGroupEmission[indexold].SourceGroup = new_sg; // set new source group
-						
-						for(int i = 0; i < listBox2.Items.Count; i++)
-						{
-							if (St_F.GetSgNumber(listBox2.Items[i].ToString()) == old_sg)
-							{
-								listBox2.Items.RemoveAt(i);
-							}
-						}
-						listBox2.Items.Add(sgsel.SelectedSourceGroup);
-						SaveArray();
-						listBox2.SelectedIndex = listBox2.Items.Count - 1;
-						//FillValues();
-					}
-				} //shift a source group
-				
-			}
-			sgsel.Dispose();
-		}
-		
-		/// <summary>
-    	/// Set the trackbar to the desired item number
-    	/// </summary> 
-		public bool SetTrackBar(int _nr)
-		{
-			if (_nr >= trackBar1.Minimum && _nr <= trackBar1.Maximum)
-			{
-				trackBar1.Value = _nr;
-				return true;
-			}
-			else
-			{
-				trackBar1.Value = trackBar1.Minimum;
-				return false;
-			}
-		}
-		
-		/// <summary>
-    	/// Set the trackbar maximum to the maximum count in the item list
-    	/// </summary> 
-		public void SetTrackBarMaximum()
-		{
-			trackBar1.Minimum = 1;
-			trackBar1.Maximum = Math.Max(ItemData.Count, 1);
-		}
-		
-		public string GetSelectedListBox1Item()
-		{
-			return Convert.ToString(listBox1.SelectedItem);
-		}
-		
-		public string GetNumberOfVerticesText()
-		{
-			return textBox2.Text;
-		}
-		public void SetNumberOfVerticesText(string _s)
-		{
-			textBox2.Text = _s;
-		}
+                    listBox2.Items.Add(sgsel.SelectedSourceGroup);
+                    SaveArray();
+                    //FillValues();
+                    listBox2.SelectedIndex = listBox2.Items.Count - 1;
+                }
+                else if (sgsel.ShiftCopy == 2 && sgsel.SelCopyFrom.Length > 0) // Shift a Source group?
+                {
+                    if (MessageBox.Show(this, "Move source group " + sgsel.SelCopyFrom +
+                                        "\n to " + sgsel.SelectedSourceGroup + " ?", "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Question) == DialogResult.Yes)
+                    {
+                        int new_sg = St_F.GetSgNumber(sgsel.SelectedSourceGroup);
+                        int old_sg = St_F.GetSgNumber(sgsel.SelCopyFrom);
+
+                        int indexold = GetPollutantListIndex(old_sg);
+                        SourceGroupEmission[indexold].SourceGroup = new_sg; // set new source group
+
+                        for (int i = 0; i < listBox2.Items.Count; i++)
+                        {
+                            if (St_F.GetSgNumber(listBox2.Items[i].ToString()) == old_sg)
+                            {
+                                listBox2.Items.RemoveAt(i);
+                            }
+                        }
+                        listBox2.Items.Add(sgsel.SelectedSourceGroup);
+                        SaveArray();
+                        listBox2.SelectedIndex = listBox2.Items.Count - 1;
+                        //FillValues();
+                    }
+                } //shift a source group
+
+            }
+            sgsel.Dispose();
+        }
+
+        /// <summary>
+        /// Set the trackbar to the desired item number
+        /// </summary> 
+        public bool SetTrackBar(int _nr)
+        {
+            if (_nr >= trackBar1.Minimum && _nr <= trackBar1.Maximum)
+            {
+                trackBar1.Value = _nr;
+                return true;
+            }
+            else
+            {
+                trackBar1.Value = trackBar1.Minimum;
+                return false;
+            }
+        }
+
+        /// <summary>
+        /// Set the trackbar maximum to the maximum count in the item list
+        /// </summary> 
+        public void SetTrackBarMaximum()
+        {
+            trackBar1.Minimum = 1;
+            trackBar1.Maximum = Math.Max(ItemData.Count, 1);
+        }
+
+        public string GetSelectedListBox1Item()
+        {
+            return Convert.ToString(listBox1.SelectedItem);
+        }
+
+        public string GetNumberOfVerticesText()
+        {
+            return textBox2.Text;
+        }
+        public void SetNumberOfVerticesText(string _s)
+        {
+            textBox2.Text = _s;
+        }
 
         private void button9_Click(object sender, EventArgs e)
         {
             this.Close(); // does not close the form, because closing hides the form
         }
-    
+
+        private void trackBar2_Scroll(object sender, EventArgs e)
+        {
+            int edge = Math.Max(0, trackBar2.Value - 1);
+
+            // absolut height allowed at point 0
+            if (trackBar2.Value > 1 || Main.Project_Locked == true)
+                checkBox1.Enabled = false;
+            else
+                checkBox1.Enabled = true;
+
+            if (edge < Convert.ToInt32(textBox2.Text))
+            {
+                numericUpDown1.Value = (decimal)Math.Abs(CornerLineZ[edge]);
+
+                Domain.MarkerPoint.X = CornerLineX[edge];
+                Domain.MarkerPoint.Y = CornerLineY[edge];
+
+                if (checkBox1.Checked)
+                    label5.BackColor = Color.Yellow;
+                else
+                    label5.BackColor = Color.Transparent;
+
+                RedrawDomain(this, e);
+            }
+        }
+
+        private void checkBox2_CheckedChanged(object sender, EventArgs e)
+        {
+            if (checkBox2.Checked)
+            {
+                trackBar2.Enabled = true;
+            }
+            else
+            {
+                trackBar2.Value = 1;
+                trackBar2.Enabled = false;             
+            }
+        }
+
+        private void textBox2_TextChanged(object sender, EventArgs e)
+        {
+            {
+                get_edgepoint_height(); // get recent edgepoint height
+                vertices = Convert.ToInt32(textBox2.Text);
+                if (vertices <= 1) return; // not enough vertices
+
+                trackBar2.Maximum = vertices;
+            }
+        }
+        private void get_edgepoint_height()
+        {
+            int edge = Math.Max(0, trackBar2.Value - 1);
+            if (edge < Convert.ToInt32(textBox2.Text))
+            {
+                float height = 0;
+                if (checkBox1.Checked == true) // absolute height
+                    height = (float)numericUpDown1.Value * (-1);
+                else
+                    height = (float)numericUpDown1.Value;
+                CornerLineZ[edge] = height;
+                //MessageBox.Show(edge.ToString());
+            }
+        }
+
+        private void numericUpDown1_ValueChanged(object sender, EventArgs e)
+        {
+            get_edgepoint_height(); // get recent edgepoint height	
+        }
     }
-	
 }

--- a/Source/Gral/GRALItemForms/EditLineSources.cs
+++ b/Source/Gral/GRALItemForms/EditLineSources.cs
@@ -391,7 +391,7 @@ namespace GralItemForms
 
                     for (int i = 0; i < 10; i++) // save deposition
                     {
-                        _ls.Dep[i] = new Deposition(dep[i]);
+                        _ls.GetDep()[i] = new Deposition(dep[i]);
                     }
 
 
@@ -528,7 +528,7 @@ namespace GralItemForms
 
                 for (int i = 0; i < 10; i++)
                 {
-                    dep[i] = _ldata.Dep[i];
+                    dep[i] = _ldata.GetDep()[i];
 
                     if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
                         but1[i].BackColor = Color.LightGreen; // mark that deposition is set

--- a/Source/Gral/GRALItemForms/EditLineSources.resx
+++ b/Source/Gral/GRALItemForms/EditLineSources.resx
@@ -120,6 +120,9 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="button8.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Source/Gral/GRALItemForms/EditPointSources.Designer.cs
+++ b/Source/Gral/GRALItemForms/EditPointSources.Designer.cs
@@ -169,6 +169,7 @@
             this.numericUpDown2.Size = new System.Drawing.Size(64, 20);
             this.numericUpDown2.TabIndex = 8;
             this.numericUpDown2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip1.SetToolTip(this.numericUpDown2, "Exit velocity");
             // 
             // numericUpDown3
             // 
@@ -182,15 +183,16 @@
             this.numericUpDown3.Size = new System.Drawing.Size(64, 20);
             this.numericUpDown3.TabIndex = 10;
             this.numericUpDown3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip1.SetToolTip(this.numericUpDown3, "Exhaust gas temperature above ambient temperature");
             // 
             // label7
             // 
             this.label7.AutoSize = true;
             this.label7.Location = new System.Drawing.Point(0, 223);
             this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(69, 13);
+            this.label7.Size = new System.Drawing.Size(77, 13);
             this.label7.TabIndex = 12;
-            this.label7.Text = "Exit temp. [K]";
+            this.label7.Text = "Exit temp.Δ[°C]";
             // 
             // numericUpDown4
             // 
@@ -210,6 +212,7 @@
             this.numericUpDown4.Size = new System.Drawing.Size(92, 20);
             this.numericUpDown4.TabIndex = 11;
             this.numericUpDown4.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            this.toolTip1.SetToolTip(this.numericUpDown4, "Stack diameter");
             // 
             // label8
             // 

--- a/Source/Gral/GRALItemForms/EditPointSources.cs
+++ b/Source/Gral/GRALItemForms/EditPointSources.cs
@@ -322,7 +322,7 @@ namespace GralItemForms
 
 				for (int i = 0; i < 10; i++) // save deposition
 				{
-					_pdata.Dep[i] = new Deposition(dep[i]);
+					_pdata.GetDep()[i] = new Deposition(dep[i]);
 				}
 
 				string[] text2 = new string[2];
@@ -435,7 +435,7 @@ namespace GralItemForms
 
 				for (int i = 0; i < 10; i++)
 				{
-					dep[i] = _pdata.Dep[i];
+					dep[i] = _pdata.GetDep()[i];
 
 					if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
 						but1[i].BackColor = Color.LightGreen; // mark that deposition is set

--- a/Source/Gral/GRALItemForms/EditPortalSources.Designer.cs
+++ b/Source/Gral/GRALItemForms/EditPortalSources.Designer.cs
@@ -138,7 +138,7 @@
             this.numericUpDown1.Size = new System.Drawing.Size(84, 20);
             this.numericUpDown1.TabIndex = 3;
             this.numericUpDown1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.toolTip1.SetToolTip(this.numericUpDown1, "Height of the portal top edge\r\nabove ground level");
+            this.toolTip1.SetToolTip(this.numericUpDown1, "Relative height of the portal top edge");
             this.numericUpDown1.Value = new decimal(new int[] {
             5,
             0,
@@ -454,7 +454,7 @@
             this.checkBox1.Size = new System.Drawing.Size(122, 21);
             this.checkBox1.TabIndex = 5;
             this.checkBox1.Text = "absolute heights";
-            this.toolTip1.SetToolTip(this.checkBox1, "define heights as absolute height over sea");
+            this.toolTip1.SetToolTip(this.checkBox1, "define heights as absolute height above sea level");
             this.checkBox1.UseVisualStyleBackColor = true;
             this.checkBox1.CheckedChanged += new System.EventHandler(this.CheckBox1CheckedChanged);
             // 

--- a/Source/Gral/GRALItemForms/EditPortalSources.Designer.cs
+++ b/Source/Gral/GRALItemForms/EditPortalSources.Designer.cs
@@ -144,6 +144,7 @@
             0,
             0,
             0});
+            this.numericUpDown1.ValueChanged += new System.EventHandler(this.numericUpDown1_ValueChanged);
             // 
             // trackBar1
             // 

--- a/Source/Gral/GRALItemForms/EditPortalSources.cs
+++ b/Source/Gral/GRALItemForms/EditPortalSources.cs
@@ -1352,5 +1352,11 @@ namespace GralItemForms
         {
             this.Close(); // does not close the form, because closing hides the form
         }
-    }
+
+		private void numericUpDown1_ValueChanged(object sender, EventArgs e)
+		{
+			double height = (double) (numericUpDown1.Value);
+			textBox2.Text = Convert.ToInt32(height * Math.Sqrt(Math.Pow(CornerPortalX[0] - CornerPortalX[1], 2) + Math.Pow(CornerPortalY[0] - CornerPortalY[1], 2))).ToString();
+		}
+	}
 }

--- a/Source/Gral/GRALItemForms/EditPortalSources.cs
+++ b/Source/Gral/GRALItemForms/EditPortalSources.cs
@@ -359,7 +359,7 @@ namespace GralItemForms
 				
 				for (int i = 0; i < 10; i++) // save deposition
 				{
-					_ps.Dep[i] = new Deposition(dep[i]);
+					_ps.GetDep()[i] = new Deposition(dep[i]);
 				}
 				
 				string tunneldirection = "1";      //indicates whether the tunnel is bi- or uni-directional
@@ -508,7 +508,7 @@ namespace GralItemForms
 				
 				for (int i = 0; i < 10; i++)
 				{
-					dep[i] = _pdata.Dep[i];
+					dep[i] = _pdata.GetDep()[i];
 					
 					if (dep[i].V_Dep1 > 0 || dep[i].V_Dep2 > 0 || dep[i].V_Dep3 > 0)
 						but1[i].BackColor = Color.LightGreen; // mark that deposition is set

--- a/Source/Gral/GRALItemForms/EditReceptors.cs
+++ b/Source/Gral/GRALItemForms/EditReceptors.cs
@@ -199,16 +199,24 @@ namespace GralItemForms
         //remove actual receptor
         private void button2_Click(object sender, EventArgs e)
         {
-            RemoveOne();
+            RemoveOne(true);
             RedrawDomain(this, null);
         }
 
         /// <summary>
     	/// Remove the recent item object from the item list
     	/// </summary>
-        public void RemoveOne()
+        public void RemoveOne(bool ask)
         {
-           if (St_F.InputBox("Attention", "Do you really want to delete this receptor?", this) == DialogResult.OK)
+            if (ask == true)
+            {
+                if (St_F.InputBox("Attention", "Do you really want to delete this receptor?", this) == DialogResult.OK)
+                    ask = false;
+                else
+                    ask = true; // Cancel -> do not delete!
+            }
+
+            if (ask == false)
             {
                 textBox1.Text = "";
                 textBox2.Text = "";

--- a/Source/Gral/GRALItemForms/EditWalls.cs
+++ b/Source/Gral/GRALItemForms/EditWalls.cs
@@ -60,7 +60,7 @@ namespace GralItemForms
         /// <summary>
         /// Z corner points of a wall in meters
         /// </summary>
-        public float[]  CornerWallZ  = new float[1000];   
+        public double[] CornerWallZ  = new double[1000];   
         
         private int vertices;                              //number of maximum corner points
         private CultureInfo ic = CultureInfo.InvariantCulture;
@@ -217,25 +217,25 @@ namespace GralItemForms
         		RedrawDomain(this, e);
         	}
 		}
-        
+
         private void get_edgepoint_height()
         {
-        	 int edge = trackBar2.Value - 1;
-        	 if (edge < Convert.ToInt32(textBox2.Text))
-        	 {
-        	 	float height = 0;
-        	 	if (checkBox1.Checked == true) // absolute height
-        	 		height = (float) numericUpDown1.Value * (-1);
-        	 	else
-        	 		height = (float) numericUpDown1.Value;
-        	 	CornerWallZ[edge] = height;
-        	 }
-       }
-        
+            int edge = trackBar2.Value - 1;
+            if (edge < Convert.ToInt32(textBox2.Text))
+            {
+                float height = 0;
+                if (checkBox1.Checked == true) // absolute height
+                    height = (float)numericUpDown1.Value * (-1);
+                else
+                    height = (float)numericUpDown1.Value;
+                CornerWallZ[edge] = height;
+            }
+        }
+
         //fill actual values
         /// <summary>
-    	/// Fills the dialog with data from the recent item object
-    	/// </summary> 
+        /// Fills the dialog with data from the recent item object
+        /// </summary> 
         public void FillValues()
         {
         	WallData _wdata;
@@ -453,6 +453,8 @@ namespace GralItemForms
                     e.Cancel = true;
                 }
             }
+            GralDomain.Domain.MarkerPoint.X = 0;
+            GralDomain.Domain.MarkerPoint.Y = 0;
         }
 
         void EditWallsFormClosed(object sender, FormClosedEventArgs e)
@@ -469,7 +471,9 @@ namespace GralItemForms
 		{
 			if (!Visible)
 			{
-			}
+                GralDomain.Domain.MarkerPoint.X = 0;
+                GralDomain.Domain.MarkerPoint.Y = 0;
+            }
 			else // Enable/disable items
 			{
 				bool enable = !Main.Project_Locked;

--- a/Source/Gral/GRALItemForms/LayoutManager.cs
+++ b/Source/Gral/GRALItemForms/LayoutManager.cs
@@ -406,7 +406,7 @@ namespace GralItemForms
                     button12.Visible = true;
                 }
                 
-                if (DrawObject.Name.StartsWith("CONCENTRATION VALUES"))
+                if (DrawObject.Name.StartsWith("CONCENTRATION VALUES") || DrawObject.Name.StartsWith("ITEM INFO"))
                 {
                     // decimal places
                     groupBox3.Visible = true;
@@ -444,7 +444,7 @@ namespace GralItemForms
             //enable low pass filtering of raster data (contour maps)
             if (DrawObject.ContourFilename != string.Empty && DrawObject.ContourFilename != "x")
             {
-                if (!DrawObject.Name.StartsWith("CONCENTRATION VALUES"))
+                if (!DrawObject.Name.StartsWith("CONCENTRATION VALUES") && !DrawObject.Name.StartsWith("ITEM INFO"))
                 {
                     checkBox4.Visible = true;
                 }

--- a/Source/Gral/GRALItemForms/Objectmanager.cs
+++ b/Source/Gral/GRALItemForms/Objectmanager.cs
@@ -458,6 +458,8 @@ namespace GralItemForms
                 	button4.Visible = true;
                 if (domain.ItemOptions[listBox1.SelectedIndex].Name.StartsWith("CONCENTRATION VALUES"))
                 	button4.Visible = true;
+                if (domain.ItemOptions[listBox1.SelectedIndex].Name.StartsWith("ITEM INFO"))
+                    button4.Visible = true;
                 if (domain.ItemOptions[listBox1.SelectedIndex].Name.StartsWith("WINDROSE"))
                     button4.Visible = true;
             }
@@ -613,6 +615,7 @@ namespace GralItemForms
         			    domain.ItemOptions[index].Name.Equals("NORTH ARROW")    ||
         			    domain.ItemOptions[index].Name.Equals("SCALE BAR")      ||
         			    domain.ItemOptions[index].Name.StartsWith("CONCENTRATION VALUES") ||
+                        domain.ItemOptions[index].Name.StartsWith("ITEM INFO") ||
                         domain.ItemOptions[index].Name.Equals("WINDROSE"))
         			{
         				

--- a/Source/Gral/GRALItemForms/ShowVertices.cs
+++ b/Source/Gral/GRALItemForms/ShowVertices.cs
@@ -32,7 +32,7 @@ namespace GralItemForms
 		public int Lines = 0;
 	    private double[] x1 = new double[20];            //x corner points 
 	    private double[] y1 = new double[20];            //y corner points 		
-	    private float[] z1 = new float[20];              //z
+	    private double[] z1 = new double[20];              //z
 		
         // delegate to send redraw Message
        	public event ForceDomainRedraw Vertices_redraw;
@@ -59,7 +59,7 @@ namespace GralItemForms
         /// <param name="x"> Double array of x coordinates></param>
         /// <param name="y"> Double array of y coordinates></param>
         /// <param name="z"> Float array of z values></param>
-        public VerticesEditDialog(int lines, ref double [] x, ref double [] y, ref float [] z)
+        public VerticesEditDialog(int lines, ref double [] x, ref double [] y, ref double [] z)
 		{
 			InitializeComponent();
 			Lines = lines;

--- a/Source/Gral/GRALMainFunctions/Main_CollectPollutants.cs
+++ b/Source/Gral/GRALMainFunctions/Main_CollectPollutants.cs
@@ -141,7 +141,7 @@ namespace Gral
 				double ymax = double.MinValue;
 				double lenght = St_F.CalcLenght(_lsdata.Pt) / 1000;
 				
-				foreach (GralDomain.PointD _pt in _lsdata.Pt)
+				foreach (GralData.PointD_3d _pt in _lsdata.Pt)
 				{
 					xmin = Math.Min(xmin, _pt.X);
 					xmax = Math.Max(xmax, _pt.X);

--- a/Source/Gral/GRALMainFunctions/Main_DeleteFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_DeleteFiles.cs
@@ -126,6 +126,18 @@ namespace Gral
                 if (File.Exists(newPath))
                     File.Delete(newPath);
 
+                newPath = Path.Combine(ProjectName, "Computation", "zeitreihe.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
+                newPath = Path.Combine(ProjectName, "Computation", "ReceptorConcentrations.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
+                newPath = Path.Combine(ProjectName, "Computation", "GRAL_Meteozeitreihe.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
                 DispNrChanged(null, null); // change displaynumber
                 GralFileSizes();
             }

--- a/Source/Gral/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/Source/Gral/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -289,7 +289,7 @@ namespace Gral
         	int distance =  (int) (g.MeasureString("J", titlefont, 200).Height);
         	int distance2 =  (int) (g.MeasureString("J", subtitlefont, 200).Height);
         	
-        	g.DrawString("GRAL GUI V20.01 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+        	g.DrawString("GRAL GUI V21.01Alpha - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
         	g.DrawString("Development Team: Dietmar Oettl and Markus Kuntner", subtitlefont, Solid_black, x, 25 + distance, format1);
         	g.DrawString("Support and Training: Christian Kurz (kurz@ivt.tugraz.at)", subtitlefont, Solid_black, x, 25 + distance + distance2, format1);
         	

--- a/Source/Gral/GRALMainFunctions/Main_Filewatchers.cs
+++ b/Source/Gral/GRALMainFunctions/Main_Filewatchers.cs
@@ -94,10 +94,10 @@ namespace Gral
                         List<string> data_mettimeseries = new List<string>();
                         ReadMetTimeSeries(mettimeseries, ref data_mettimeseries);
                         weathersit_count = Math.Max(data_mettimeseries.Count, 1);
-                        if (data_mettimeseries.Count == 0) // no data available
-                        {
-                            MessageBox.Show("mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
-                        }
+                        //if (data_mettimeseries.Count == 0) // no data available
+                        //{
+                        //    MessageBox.Show("mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
+                        //}
                     }
                 }
             }

--- a/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
@@ -342,7 +342,7 @@ namespace Gral
 						double ymin = double.MaxValue;
 						double ymax = double.MinValue;
 						
-						foreach (PointD _pt in _lsdata.Pt)
+						foreach (GralData.PointD_3d _pt in _lsdata.Pt)
 						{
 							xmin = Math.Min(xmin, _pt.X);
 							xmax = Math.Max(xmax, _pt.X);
@@ -373,19 +373,21 @@ namespace Gral
 											{
 												double x1 = _lsdata.Pt[i].X;
 												double x2 = _lsdata.Pt[i + 1].X;
-												double y1 = _lsdata.Pt[i].Y;
-												double y2 = _lsdata.Pt[i + 1].Y;
-												
-												string line =
+                                                double y1 = _lsdata.Pt[i].Y;
+                                                double y2 = _lsdata.Pt[i + 1].Y;
+                                                double h1 = Math.Round(_lsdata.Pt[i].Z, 1);
+                                                double h2 = Math.Round(_lsdata.Pt[i + 1].Z, 1);
+
+                                                string line =
 													_lsdata.Name + "," +
 													_lsdata.Section + "," +
 													_poll.SourceGroup.ToString(ic) + "," +
 													Math.Round(x1, 1).ToString(ic) + "," +
 													Math.Round(y1, 1).ToString(ic) + "," +
-													_lsdata.Height.ToString(ic) + "," +
+													h1.ToString(ic) + "," +
 													Math.Round(x2, 1).ToString(ic) + "," +
 													Math.Round(y2, 1).ToString(ic) + "," +
-													_lsdata.Height.ToString(ic) + "," +
+													h2.ToString(ic) + "," +
 													_lsdata.Width.ToString(ic) + "," +
 													vert_extension.ToString(ic) + "," +
 													"0," + //Alternative: Math.Round(Math.Sqrt(Math.Pow(x1 - x2, 2) + Math.Pow(y1 - y2, 2)), 1).ToString(ic) + "," +

--- a/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
@@ -761,7 +761,7 @@ namespace Gral
 				
 				if (File.Exists(emission_ts))
 				{
-					dr = MessageBox.Show(this, "Overwrite emission modulation file" + Environment.NewLine +"emissions_timeseries.txt", "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+					dr = MessageBox.Show(this, "Overwrite emission modulation file" + Environment.NewLine +"emissions_timeseries.txt", "GRAL GUI", MessageBoxButtons.YesNo, MessageBoxIcon.Warning);
 				}
 				else
 				{

--- a/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_GenerateEmissionFiles.cs
@@ -118,17 +118,17 @@ namespace Gral
 										_psdata.Temperature.ToString(ic) + "," +
 										_psdata.Poll.SourceGroup.ToString(ic);
 									
-									if (_psdata.Dep != null) // deposition entry exists
+									if (_psdata.GetDep() != null) // deposition entry exists
 									{
 										pqline += "," +
-											_psdata.Dep[j].Frac_2_5.ToString(ic) + "," +
-											_psdata.Dep[j].Frac_10.ToString(ic) + "," +
-											_psdata.Dep[j].DM_30.ToString(ic) + "," +
-											_psdata.Dep[j].Density.ToString(ic) + "," +
-											_psdata.Dep[j].V_Dep1.ToString(ic) + "," +
-											_psdata.Dep[j].V_Dep2.ToString(ic) + "," +
-											_psdata.Dep[j].V_Dep3.ToString(ic) + "," +
-											_psdata.Dep[j].Conc.ToString(ic);
+											_psdata.GetDep()[j].Frac_2_5.ToString(ic) + "," +
+											_psdata.GetDep()[j].Frac_10.ToString(ic) + "," +
+											_psdata.GetDep()[j].DM_30.ToString(ic) + "," +
+											_psdata.GetDep()[j].Density.ToString(ic) + "," +
+											_psdata.GetDep()[j].V_Dep1.ToString(ic) + "," +
+											_psdata.GetDep()[j].V_Dep2.ToString(ic) + "," +
+											_psdata.GetDep()[j].V_Dep3.ToString(ic) + "," +
+											_psdata.GetDep()[j].Conc.ToString(ic);
 									}
 									
 									if (!string.IsNullOrEmpty(_psdata.TemperatureTimeSeries))
@@ -278,17 +278,17 @@ namespace Gral
 												"0,0,0," +
 												_asdata.Poll.SourceGroup.ToString(ic);
 											
-											if (_asdata.Dep != null) // deposition entry exists
+											if (_asdata.GetDep() != null) // deposition entry exists
 											{
 												cadestre += "," +
-													_asdata.Dep[j].Frac_2_5.ToString(ic) + "," +
-													_asdata.Dep[j].Frac_10.ToString(ic) + "," +
-													_asdata.Dep[j].DM_30.ToString(ic) + "," +
-													_asdata.Dep[j].Density.ToString(ic) + "," +
-													_asdata.Dep[j].V_Dep1.ToString(ic) + "," +
-													_asdata.Dep[j].V_Dep2.ToString(ic) + "," +
-													_asdata.Dep[j].V_Dep3.ToString(ic) + "," +
-													_asdata.Dep[j].Conc.ToString(ic);
+													_asdata.GetDep()[j].Frac_2_5.ToString(ic) + "," +
+													_asdata.GetDep()[j].Frac_10.ToString(ic) + "," +
+													_asdata.GetDep()[j].DM_30.ToString(ic) + "," +
+													_asdata.GetDep()[j].Density.ToString(ic) + "," +
+													_asdata.GetDep()[j].V_Dep1.ToString(ic) + "," +
+													_asdata.GetDep()[j].V_Dep2.ToString(ic) + "," +
+													_asdata.GetDep()[j].V_Dep3.ToString(ic) + "," +
+													_asdata.GetDep()[j].Conc.ToString(ic);
 											}
 											
 											myWriter.WriteLine(cadestre);
@@ -395,17 +395,17 @@ namespace Gral
 													_poll.EmissionRate[j].ToString(ic) + "," +
 													"0,0,0,0,0";
 												
-												if (_lsdata.Dep != null) // deposition entry exists
+												if (_lsdata.GetDep() != null) // deposition entry exists
 												{
 													line += "," +
-														_lsdata.Dep[j].Frac_2_5.ToString(ic) + "," +
-														_lsdata.Dep[j].Frac_10.ToString(ic) + "," +
-														_lsdata.Dep[j].DM_30.ToString(ic) + "," +
-														_lsdata.Dep[j].Density.ToString(ic) + "," +
-														_lsdata.Dep[j].V_Dep1.ToString(ic) + "," +
-														_lsdata.Dep[j].V_Dep2.ToString(ic) + "," +
-														_lsdata.Dep[j].V_Dep3.ToString(ic) + "," +
-														_lsdata.Dep[j].Conc.ToString(ic);
+														_lsdata.GetDep()[j].Frac_2_5.ToString(ic) + "," +
+														_lsdata.GetDep()[j].Frac_10.ToString(ic) + "," +
+														_lsdata.GetDep()[j].DM_30.ToString(ic) + "," +
+														_lsdata.GetDep()[j].Density.ToString(ic) + "," +
+														_lsdata.GetDep()[j].V_Dep1.ToString(ic) + "," +
+														_lsdata.GetDep()[j].V_Dep2.ToString(ic) + "," +
+														_lsdata.GetDep()[j].V_Dep3.ToString(ic) + "," +
+														_lsdata.GetDep()[j].Conc.ToString(ic);
 												}
 												
 												myWriter.WriteLine(line);
@@ -517,17 +517,17 @@ namespace Gral
 											"0,0,0," +
 											_poll.SourceGroup.ToString(ic);
 										
-										if (_pdData.Dep != null) // deposition entry exists
+										if (_pdData.GetDep() != null) // deposition entry exists
 										{
 											portal += "," +
-												_pdData.Dep[j].Frac_2_5.ToString(ic) + "," +
-												_pdData.Dep[j].Frac_10.ToString(ic) + "," +
-												_pdData.Dep[j].DM_30.ToString(ic) + "," +
-												_pdData.Dep[j].Density.ToString(ic) + "," +
-												_pdData.Dep[j].V_Dep1.ToString(ic) + "," +
-												_pdData.Dep[j].V_Dep2.ToString(ic) + "," +
-												_pdData.Dep[j].V_Dep3.ToString(ic) + "," +
-												_pdData.Dep[j].Conc.ToString(ic);
+												_pdData.GetDep()[j].Frac_2_5.ToString(ic) + "," +
+												_pdData.GetDep()[j].Frac_10.ToString(ic) + "," +
+												_pdData.GetDep()[j].DM_30.ToString(ic) + "," +
+												_pdData.GetDep()[j].Density.ToString(ic) + "," +
+												_pdData.GetDep()[j].V_Dep1.ToString(ic) + "," +
+												_pdData.GetDep()[j].V_Dep2.ToString(ic) + "," +
+												_pdData.GetDep()[j].V_Dep3.ToString(ic) + "," +
+												_pdData.GetDep()[j].Conc.ToString(ic);
 										}
 										
 										portal += "," + _pdData.DeltaT.ToString(ic) + "," +

--- a/Source/Gral/GRALMainFunctions/Main_GenerateMettimeSeriesAndMeteopgt.cs
+++ b/Source/Gral/GRALMainFunctions/Main_GenerateMettimeSeriesAndMeteopgt.cs
@@ -31,57 +31,57 @@ namespace Gral
     /// The functions within the Main MeteoTab.
     /// </summary>
     partial class Main
-	{
+    {
         /// <summary>
         /// routine computes mettimeseries.dat and meteopgt.all
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
         private void GRALGenerateMeteoFiles(object sender, EventArgs e)
-		{
-			string filename = Path.Combine("Computation", "meteopgt.all");
-			string newPath = Path.Combine(ProjectName, filename);
-			if (listBox2.Items.Count != 0 && File.Exists(newPath))
-			{
-				DialogResult result = MessageBox.Show("You are using a GRAMM wind field and met-files exist. Would you delete the existing and create new met.files?", "Create new met-files?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-				if (result == DialogResult.No)
-					return;
-			}
+        {
+            string filename = Path.Combine("Computation", "meteopgt.all");
+            string newPath = Path.Combine(ProjectName, filename);
+            if (listBox2.Items.Count != 0 && File.Exists(newPath))
+            {
+                DialogResult result = MessageBox.Show("You are using a GRAMM wind field and met-files exist. Would you delete the existing and create new met.files?", "Create new met-files?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                if (result == DialogResult.No)
+                    return;
+            }
 
-			//this.Cursor = Cursors.WaitCursor;
-			//check if all input values and user defined classes are O.K.
-			int ok = 0;
-			for (int nr = 0; nr < WindSpeedClasses - 1; nr++)
-			{
-				try
-				{
-					if (NumUpDown[nr].Value < decimal.Parse(TBox[nr].Text))
-					{
-						MessageBox.Show("Wind speed needs to be larger", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-						NumUpDown[nr].Value = 0M;
-						TBox[nr + 1].Text = NumUpDown[nr].Text;
-						ok = 0;
-						break;
-					}
-					else
-					{
-						ok = 1;
-					}
-				}
-				catch
-				{
-					MessageBox.Show("Wind classes input needs to be a valid number", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-					break;
-				}
-			}
+            //this.Cursor = Cursors.WaitCursor;
+            //check if all input values and user defined classes are O.K.
+            int ok = 0;
+            for (int nr = 0; nr < WindSpeedClasses - 1; nr++)
+            {
+                try
+                {
+                    if (NumUpDown[nr].Value < decimal.Parse(TBox[nr].Text))
+                    {
+                        MessageBox.Show("Wind speed needs to be larger", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                        NumUpDown[nr].Value = 0M;
+                        TBox[nr + 1].Text = NumUpDown[nr].Text;
+                        ok = 0;
+                        break;
+                    }
+                    else
+                    {
+                        ok = 1;
+                    }
+                }
+                catch
+                {
+                    MessageBox.Show("Wind classes input needs to be a valid number", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                    break;
+                }
+            }
 
-			//generate the gral input files mettimeseries.dat and meteopgt.all
-			if (ok > 0)
-			{
-				try
-				{
-					filename = Path.Combine("Computation", "mettimeseries.dat");
-					newPath = Path.Combine(ProjectName, filename);
+            //generate the gral input files mettimeseries.dat and meteopgt.all
+            if (ok > 0)
+            {
+                try
+                {
+                    filename = Path.Combine("Computation", "mettimeseries.dat");
+                    newPath = Path.Combine(ProjectName, filename);
                     string[] daymonthyear = new string[3];
                     double windclasse = 0;
                     double[] avwclass = new double[WindSpeedClasses];
@@ -162,11 +162,11 @@ namespace Gral
                             frequmet[iwg, iwr, data.StabClass - 1] = frequmet[iwg, iwr, data.StabClass - 1] + 1;
                         }
                     }
-					
-					//save met data to file meteopgt.all
-					Textbox16_Set(MetfileName);
-					filename = Path.Combine("Computation", "meteopgt.all");
-					newPath = Path.Combine(ProjectName, filename);
+
+                    //save met data to file meteopgt.all
+                    Textbox16_Set(MetfileName);
+                    filename = Path.Combine("Computation", "meteopgt.all");
+                    newPath = Path.Combine(ProjectName, filename);
                     using (StreamWriter myWriter = new StreamWriter(newPath))
                     {
                         int filelength = MeteoTimeSeries.Count;
@@ -244,15 +244,15 @@ namespace Gral
                             }
                         }
                     }
-					
-					//save met input data
-					try
-					{
-						filename = Path.GetFileNameWithoutExtension(MetfileName);
-						newPath = Path.Combine(ProjectName, @"Metfiles" + Path.DirectorySeparatorChar);
-						foreach (string path in Directory.GetFiles(newPath, "*.*", SearchOption.AllDirectories))
-							File.Delete(path);
-						newPath = Path.Combine(ProjectName, @"Metfiles", filename + ".met");
+
+                    //save met input data
+                    try
+                    {
+                        filename = Path.GetFileNameWithoutExtension(MetfileName);
+                        newPath = Path.Combine(ProjectName, @"Metfiles" + Path.DirectorySeparatorChar);
+                        foreach (string path in Directory.GetFiles(newPath, "*.*", SearchOption.AllDirectories))
+                            File.Delete(path);
+                        newPath = Path.Combine(ProjectName, @"Metfiles", filename + ".met");
                         using (StreamWriter myWriter = new StreamWriter(newPath))
                         {
                             foreach (GralData.WindData data in MeteoTimeSeries)
@@ -261,172 +261,6 @@ namespace Gral
                                                    "," + Convert.ToString(data.Vel, ic) +
                                                    "," + Convert.ToString(data.Dir, ic) +
                                                    "," + Convert.ToString(data.StabClass));
-                            }
-                        }
-						
-						SaveMeteoDataFile();
-						Change_Label(1, 2); // meteo button green
-						ChangedWindData = false;
-					}
-					catch
-					{
-						MessageBox.Show("Could not copy meteorological input file", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-					}
-
-					//delete existing windfield and concentration fields
-					newPath = Path.Combine(ProjectName, "Computation" + Path.DirectorySeparatorChar);
-					DirectoryInfo di = new DirectoryInfo(newPath);
-					FileInfo[] files_conc = di.GetFiles("*.con");
-					if (files_conc.Length > 0)
-					{
-                        using (FileDeleteMessage fdm = new FileDeleteMessage())
-                        {
-                            if (files_conc.Length > 0)
-                                fdm.listView1.Items.Add("..Computation" + Path.DirectorySeparatorChar + "*.con");
-                            
-                            if (fdm.ShowDialog() == DialogResult.OK)
-                            {
-                                for (int i = 0; i < files_conc.Length; i++)
-                                    files_conc[i].Delete();
-                            }
-                        }
-					}
-					files_conc = di.GetFiles("*.grz");
-					if (files_conc.Length > 0)
-					{
-                        using (FileDeleteMessage fdm = new FileDeleteMessage())
-                        {
-                            if (files_conc.Length > 0)
-                                fdm.listView1.Items.Add("..Computation" + Path.DirectorySeparatorChar + "*.grz");
-
-                            if (fdm.ShowDialog() == DialogResult.OK)
-                            {
-                                for (int i = 0; i < files_conc.Length; i++)
-                                    files_conc[i].Delete();
-                            }
-                        }
-					}
-                }
-				catch
-				{
-					MessageBox.Show("Please define Project Folder first. Change to the menu 'Project'.", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-				}
-            }
-
-			//modify control file for GRAL simulations in.dat
-			GenerateInDat();
-
-			//enable/disable GRAL simulations
-			Enable_GRAL();
-			//enable/disable GRAMM simulations
-			Enable_GRAMM();
-
-			// Delete GRAMIn.dat
-			try
-			{
-				File.Delete(Path.Combine(ProjectName, @"Computation", "GRAMMin.dat"));
-			}
-			catch
-			{ }
-			// write new GRAMMin, because of sunrise option
-			GRAMMin(true);
-
-			Cursor = Cursors.Default;
-		}
-
-        /// <summary>
-        /// Create meteopgt.all and mettimeseries.dat for the usage of ERA5 meteo data
-        /// </summary>
-        private void GRALGenerateMeteoFilesForERA5()
-        {
-            if (EmifileReset == true)
-            {
-                string filename = Path.Combine("Computation", "meteopgt.all");
-                string newPath = Path.Combine(ProjectName, filename);
-                if (listBox2.Items.Count != 0 && File.Exists(newPath))
-                {
-                    DialogResult result = MessageBox.Show("You are using a GRAMM wind field and met-files exist. Would you delete the existing and create new met.files?", "Create new met-files?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
-                    if (result == DialogResult.No)
-                        return;
-                }
-
-                //generate the gral input files mettimeseries.dat and meteopgt.all
-                try
-                {
-                    filename = Path.Combine("Computation", "mettimeseries.dat");
-                    newPath = Path.Combine(ProjectName, filename);
-                    int hour = 0;
-                    float vel = 0.0f;
-                    float dir = 1.0f;
-
-                    using (StreamWriter myWriter = File.CreateText(newPath))
-                    {
-                        for (int i = 1; i < 18000; i++)
-                        {
-                            if (hour == 25)
-                                hour = 0;
-                            if (dir == 361)
-                            {
-                                dir = 1.0f;
-                                vel += 0.1f;
-                            }
-                            myWriter.WriteLine("01.01" + "," + Convert.ToString(hour++, ic) + ","
-                                                       + Convert.ToString(vel, ic) + "," + Convert.ToString(dir++ / 10, ic) + ",4");
-                        }
-                    }
-
-                    //save met data to file meteopgt.all
-                    Textbox16_Set("Artificial Metfile for ERA5 usage.met");
-                    filename = Path.Combine("Computation", "meteopgt.all");
-                    newPath = Path.Combine(ProjectName, filename);
-                    hour = 0;
-                    vel = 0.0f;
-                    dir = 1.0f;
-                    using (StreamWriter myWriter = new StreamWriter(newPath))
-                    {
-                        //write anemometer height, flag indicating whether dispersion situations are classified or not, sector width for wind direction in the classification
-                        myWriter.WriteLine("10,1,0,    !Are dispersion situations classified =0 or not =1");
-                        myWriter.WriteLine("Wind direction sector,Wind speed class,stability class, frequency");
-                        for (int i = 1; i < 18000; i++)
-                        {
-                            if (hour == 25)
-                                hour = 0;
-                            if (dir == 361)
-                            {
-                                dir = 1.0f;
-                                vel += 0.1f;
-                            }
-                            myWriter.WriteLine(Convert.ToString(dir++ / 10, ic) + "," + Convert.ToString(vel, ic) + ",4" + ",0.05556");
-                        }
-                    }
-
-                    //save met input data
-                    try
-                    {
-                        MetfileName = "Artificial Metfile for ERA5 usage.met";
-                        MetoColumnSeperator = ',';
-                        MeteoDecSeperator = ".";
-                        Anemometerheight = 10;
-                        filename = Path.GetFileNameWithoutExtension("Artificial Metfile for ERA5 usage.met");
-                        newPath = Path.Combine(ProjectName, @"Metfiles" + Path.DirectorySeparatorChar);
-                        foreach (string path in Directory.GetFiles(newPath, "*.*", SearchOption.AllDirectories))
-                            File.Delete(path);
-                        newPath = Path.Combine(ProjectName, @"Metfiles", filename + ".met");
-                        hour = 0;
-                        vel = 0.0f;
-                        dir = 1.0f;
-                        using (StreamWriter myWriter = new StreamWriter(newPath))
-                        {
-                            for (int i = 1; i < 18000; i++)
-                            {
-                                if (hour == 25)
-                                    hour = 0;
-                                if (dir == 361)
-                                {
-                                    dir = 1.0f;
-                                    vel += 0.1f;
-                                }
-                                myWriter.WriteLine("01.01," + Convert.ToString(hour++, ic) + "," + Convert.ToString(vel, ic) + "," + Convert.ToString(dir++, ic) + ",4");
                             }
                         }
 
@@ -438,10 +272,139 @@ namespace Gral
                     {
                         MessageBox.Show("Could not copy meteorological input file", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
                     }
+
+                    //delete existing windfield and concentration fields
+                    newPath = Path.Combine(ProjectName, "Computation" + Path.DirectorySeparatorChar);
+                    DirectoryInfo di = new DirectoryInfo(newPath);
+                    FileInfo[] files_conc = di.GetFiles("*.con");
+                    if (files_conc.Length > 0)
+                    {
+                        using (FileDeleteMessage fdm = new FileDeleteMessage())
+                        {
+                            if (files_conc.Length > 0)
+                                fdm.listView1.Items.Add("..Computation" + Path.DirectorySeparatorChar + "*.con");
+
+                            if (fdm.ShowDialog() == DialogResult.OK)
+                            {
+                                for (int i = 0; i < files_conc.Length; i++)
+                                    files_conc[i].Delete();
+                            }
+                        }
+                    }
+                    files_conc = di.GetFiles("*.grz");
+                    if (files_conc.Length > 0)
+                    {
+                        using (FileDeleteMessage fdm = new FileDeleteMessage())
+                        {
+                            if (files_conc.Length > 0)
+                                fdm.listView1.Items.Add("..Computation" + Path.DirectorySeparatorChar + "*.grz");
+
+                            if (fdm.ShowDialog() == DialogResult.OK)
+                            {
+                                for (int i = 0; i < files_conc.Length; i++)
+                                    files_conc[i].Delete();
+                            }
+                        }
+                    }
                 }
                 catch
                 {
                     MessageBox.Show("Please define Project Folder first. Change to the menu 'Project'.", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                }
+            }
+
+            //modify control file for GRAL simulations in.dat
+            GenerateInDat();
+
+            //enable/disable GRAL simulations
+            Enable_GRAL();
+            //enable/disable GRAMM simulations
+            Enable_GRAMM();
+
+            // Delete GRAMIn.dat
+            try
+            {
+                File.Delete(Path.Combine(ProjectName, @"Computation", "GRAMMin.dat"));
+            }
+            catch
+            { }
+            // write new GRAMMin, because of sunrise option
+            GRAMMin(true);
+
+            Cursor = Cursors.Default;
+        }
+
+        /// <summary>
+        /// Create meteopgt.all and mettimeseries.dat for the usage of ERA5 meteo data
+        /// </summary>
+        private void GRALGenerateMeteoFilesForERA5()
+        {
+            if (EmifileReset == true)
+            {
+                if (listBox2.Items.Count != 0 && File.Exists(Path.Combine(ProjectName, "Computation", "meteopgt.all")))
+                {
+                    DialogResult result = MessageBox.Show(this, "You are using a GRAMM wind field and met-files exist. Would you delete the existing and create new met.files?", "Create new met-files?", MessageBoxButtons.YesNo, MessageBoxIcon.Question);
+                    if (result == DialogResult.No)
+                        return;
+                }
+
+                DateTime _date = dateTimePicker1.Value; // get start date and time
+
+                //generate the gral input files mettimeseries.dat and meteopgt.all
+                try
+                {
+                    string filenameMet = Path.Combine("Computation", "mettimeseries.dat");
+                    string newPathMet = Path.Combine(ProjectName, filenameMet);
+                    string filenameAll = Path.Combine("Computation", "meteopgt.all");
+                    string newPathAll = Path.Combine(ProjectName, filenameAll);
+                    string filenameERA = "Artificial Metfile for ERA5 usage.met";
+                    string newPathERA = Path.Combine(ProjectName, @"Metfiles" + Path.DirectorySeparatorChar);
+                    //foreach (string path in Directory.GetFiles(newPathERA, "*.*", SearchOption.AllDirectories))
+                    //{
+                    //    File.Delete(path);
+                    //}
+                    newPathERA = Path.Combine(ProjectName, @"Metfiles", filenameERA);
+
+                    using (StreamWriter myWriterMet = File.CreateText(newPathMet))
+                    {
+                        using (StreamWriter myWriterAll = new StreamWriter(newPathAll))
+                        {
+                            using (StreamWriter myWriterERA = new StreamWriter(newPathERA))
+                            {
+                                for (int i = 1; i < 18000; i++)
+                                {
+                                    string vel = Math.Round(((int)(i / 360) * 0.1) + 0.1, 2).ToString(ic);
+                                    int dirDeg = (i % 360);
+                                    string dirDecDeg = (dirDeg * 0.1).ToString(ic);
+                                    string _dateTime = _date.Day.ToString(ic) + "." + _date.Month.ToString(ic) + "," + _date.Hour.ToString(ic) + ",";
+
+                                    myWriterMet.WriteLine(_dateTime + vel + "," + dirDecDeg + ",4");
+
+                                    myWriterAll.WriteLine(dirDecDeg + "," + vel + ",4" + ",0.05556");
+
+                                    _dateTime = _date.Day.ToString(ic) + "." + _date.Month.ToString(ic) + "." + _date.Year.ToString(ic) + "," + _date.Hour.ToString(ic) + ":00,";
+                                    myWriterERA.WriteLine(_dateTime + vel + "," + dirDeg.ToString(ic) + ",4");
+                                    
+                                    _date = _date.AddHours(1);
+                                }
+                            }
+                        }
+                    }
+
+                    //save met data to file meteopgt.all
+                    Textbox16_Set("Artificial Metfile for ERA5 usage.met");
+
+                    MetoColumnSeperator = ',';
+                    MeteoDecSeperator = ".";
+                    Anemometerheight = 10;
+
+                    SaveMeteoDataFile();
+                    Change_Label(1, 2); // meteo button green
+                    ChangedWindData = false;
+                }
+                catch
+                {
+                    MessageBox.Show("Could not write meteorological input file", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
                 }
 
                 //modify control file for GRAL simulations in.dat

--- a/Source/Gral/GRALMainFunctions/Main_LoadProject.cs
+++ b/Source/Gral/GRALMainFunctions/Main_LoadProject.cs
@@ -337,10 +337,10 @@ namespace Gral
                                 List<string> data_mettimeseries = new List<string>();
                                 ReadMetTimeSeries(mettimeseries, ref data_mettimeseries);
                                 weathersit_count = Math.Max(data_mettimeseries.Count, 1);
-                                if (data_mettimeseries.Count == 0) // no data available
-                                {
-                                    MessageBox.Show(this, "mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
-                                }
+                                //if (data_mettimeseries.Count == 0) // no data available
+                                //{
+                                //    MessageBox.Show(this, "mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
+                                //}
                             }
                         }
                     }

--- a/Source/Gral/GRALMainFunctions/Main_MeteoTab.cs
+++ b/Source/Gral/GRALMainFunctions/Main_MeteoTab.cs
@@ -517,6 +517,88 @@ namespace Gral
         }
 
         /// <summary>
+        /// wind veolcity distribution view
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
+        private void ShowWindVelocityDistribution(object sender, EventArgs e)
+        {
+            int count = 0;
+            int startstunde = 0;
+            int endstunden = 23;
+            int maxwind = 10;
+            List<WindData> wind = new List<WindData>();
+            bool showBias = WindroseSetting.ShowBias;
+            WindroseSetting.ShowBias = false;
+
+            using (GralMainForms.MeteoSelectTimeInterval mts = new GralMainForms.MeteoSelectTimeInterval
+            {
+                WindRoseSet = WindroseSetting,
+                StartPosition = FormStartPosition.Manual,
+                Left = this.Left + 20,
+                Top = this.Top + 150,
+
+            })
+            {
+                if (mts.ShowDialog() == DialogResult.OK)
+                {
+                    startstunde = mts.WindRoseSet.StartStunde;
+                    endstunden = mts.WindRoseSet.EndStunde;
+                    maxwind = mts.WindRoseSet.MaxVelocity;
+
+                    maxwind++;
+                    double[] wclassFrequency = new double[(maxwind + 1) * 4];
+
+                    if (startstunde == endstunden)
+                    {
+                        MessageBox.Show("Start- and endtime must be different values");
+                    }
+                    else
+                    {
+                        foreach (WindData data in MeteoTimeSeries)
+                        {
+                            //wind rose for a certain time interval within a day
+                            if (((startstunde < endstunden) && (data.Hour >= startstunde) && (data.Hour <= endstunden)) ||
+                                ((startstunde > endstunden) && ((data.Hour >= startstunde) || (data.Hour <= endstunden))))
+                            {
+                                //compute wind classes
+                                int j = 0;
+
+                                for (double i = 0; i < maxwind; i += 0.25)
+                                {
+                                    if (data.Vel > i)
+                                    {
+                                        wclassFrequency[j]++;
+                                    }
+                                    j++;
+                                }
+                                count = count + 1;
+                            }
+                        }
+
+                        //compute percent values
+                        for (int i = 0; i < (maxwind + 1) * 4; i++)
+                        {
+                            wclassFrequency[i] = wclassFrequency[i] / Convert.ToDouble(count);
+                        }
+
+                        GralMainForms.WindDistribution wDistr = new GralMainForms.WindDistribution()
+                        {
+                            StartPosition = FormStartPosition.Manual,
+                            Location = new System.Drawing.Point(this.Left, this.Top),
+                            WClassFrequency = wclassFrequency,
+                            MetFile = Path.GetFileName(MetfileName),
+                            MaxWind = maxwind,
+                            StartHour = startstunde,
+                            FinalHour = endstunden
+                        };
+                        wDistr.Show();
+                    }
+                }
+            }
+        }
+
+        /// <summary>
         /// show stability classes
         /// </summary>
         /// <param name="sender"></param>

--- a/Source/Gral/GRALMainFunctions/Main_MeteoTab.cs
+++ b/Source/Gral/GRALMainFunctions/Main_MeteoTab.cs
@@ -545,7 +545,7 @@ namespace Gral
                     startstunde = mts.WindRoseSet.StartStunde;
                     endstunden = mts.WindRoseSet.EndStunde;
                     maxwind = mts.WindRoseSet.MaxVelocity;
-
+                    double meanwind = 0;
                     maxwind++;
                     double[] wclassFrequency = new double[(maxwind + 1) * 4];
 
@@ -566,33 +566,41 @@ namespace Gral
 
                                 for (double i = 0; i < maxwind; i += 0.25)
                                 {
-                                    if (data.Vel > i)
+                                    if (data.Vel >= i)
                                     {
                                         wclassFrequency[j]++;
                                     }
                                     j++;
                                 }
+                                meanwind += data.Vel;
                                 count = count + 1;
                             }
                         }
 
-                        //compute percent values
-                        for (int i = 0; i < (maxwind + 1) * 4; i++)
+                        if (count > 0)
                         {
-                            wclassFrequency[i] = wclassFrequency[i] / Convert.ToDouble(count);
-                        }
+                            meanwind /= count;
+                            //compute percent values
+                            for (int i = 0; i < (maxwind + 1) * 4; i++)
+                            {
+                                wclassFrequency[i] = wclassFrequency[i] / Convert.ToDouble(count);
+                            }
 
-                        GralMainForms.WindDistribution wDistr = new GralMainForms.WindDistribution()
-                        {
-                            StartPosition = FormStartPosition.Manual,
-                            Location = new System.Drawing.Point(this.Left, this.Top),
-                            WClassFrequency = wclassFrequency,
-                            MetFile = Path.GetFileName(MetfileName),
-                            MaxWind = maxwind,
-                            StartHour = startstunde,
-                            FinalHour = endstunden
-                        };
-                        wDistr.Show();
+                            GralMainForms.WindDistribution wDistr = new GralMainForms.WindDistribution()
+                            {
+                                StartPosition = FormStartPosition.Manual,
+                                Location = new System.Drawing.Point(this.Left, this.Top),
+                                WClassFrequency = wclassFrequency,
+                                MetFile = Path.GetFileName(MetfileName),
+                                MaxWind = maxwind,
+                                StartHour = startstunde,
+                                FinalHour = endstunden,
+                                MeanWindSpeed = meanwind,
+                                StartDate = MeteoTimeSeries[0].Date,
+                                EndDate = MeteoTimeSeries[MeteoTimeSeries.Count - 1].Date
+                            };
+                            wDistr.Show();
+                        }
                     }
                 }
             }

--- a/Source/Gral/GRALMainFunctions/Main_SourceGroups.cs
+++ b/Source/Gral/GRALMainFunctions/Main_SourceGroups.cs
@@ -105,7 +105,7 @@ namespace Gral
 				double ymin = double.MaxValue;
 				double ymax = double.MinValue;
 				
-				foreach (GralDomain.PointD _pt in _lsdata.Pt)
+				foreach (GralData.PointD_3d _pt in _lsdata.Pt)
 				{
 					xmin = Math.Min(xmin, _pt.X);
 					xmax = Math.Max(xmax, _pt.X);

--- a/Source/Gral/GRALMainFunctions/Main_StartGral.cs
+++ b/Source/Gral/GRALMainFunctions/Main_StartGral.cs
@@ -81,10 +81,10 @@ namespace Gral
 						List<string> data_mettimeseries = new List<string>();
 						ReadMetTimeSeries(mettimeseries, ref data_mettimeseries);
 						weathersit_count = Math.Max(data_mettimeseries.Count, 1);
-						if (data_mettimeseries.Count == 0) // no data available
-						{
-							MessageBox.Show("mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
-						}
+						//if (data_mettimeseries.Count == 0) // no data available
+						//{
+						//	MessageBox.Show("mettimeseries.dat not available -> correct visualization of the simulation progress not possible");
+						//}
 					}
 				}
 			}

--- a/Source/Gral/GRALMainFunctions/Main_WriteLogFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_WriteLogFiles.cs
@@ -261,6 +261,10 @@ namespace Gral
 							}
 
 							pathy = Path.Combine(ProjectName, @"Emissions","Lsources.txt");
+							if (!File.Exists(pathy))
+							{
+								pathy = Path.Combine(ProjectName, @"Emissions", "LineSourceData.txt");
+							}
 							if (File.Exists(pathy))
 							{
 								try

--- a/Source/Gral/GRALMainSubForms/AppInfo.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/AppInfo.Designer.cs
@@ -39,7 +39,7 @@
             // 
             this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
             this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button1.Location = new System.Drawing.Point(223, 282);
+            this.button1.Location = new System.Drawing.Point(223, 344);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(95, 40);
             this.button1.TabIndex = 0;
@@ -65,15 +65,17 @@
             this.listBox1.Items.AddRange(new object[] {
             "Dietmar Öttl",
             "Markus Kuntner",
-            "..."});
+            "Contributors:",
+            "  * Raphael Reifeltshammer"});
             this.listBox1.Location = new System.Drawing.Point(26, 43);
             this.listBox1.Name = "listBox1";
-            this.listBox1.Size = new System.Drawing.Size(489, 84);
+            this.listBox1.Size = new System.Drawing.Size(489, 124);
             this.listBox1.TabIndex = 2;
+            this.listBox1.SelectedIndexChanged += new System.EventHandler(this.listBox1_SelectedIndexChanged);
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(26, 145);
+            this.textBox1.Location = new System.Drawing.Point(26, 207);
             this.textBox1.Multiline = true;
             this.textBox1.Name = "textBox1";
             this.textBox1.ReadOnly = true;
@@ -85,7 +87,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(544, 334);
+            this.ClientSize = new System.Drawing.Size(544, 397);
             this.Controls.Add(this.textBox1);
             this.Controls.Add(this.listBox1);
             this.Controls.Add(this.label1);

--- a/Source/Gral/GRALMainSubForms/AppInfo.cs
+++ b/Source/Gral/GRALMainSubForms/AppInfo.cs
@@ -46,6 +46,11 @@ namespace GralMainForms
         {
             this.Close();
         }
+
+        private void listBox1_SelectedIndexChanged(object sender, EventArgs e)
+        {
+
+        }
     }
 
 }

--- a/Source/Gral/GRALMainSubForms/DiurnalWinddirections.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/DiurnalWinddirections.Designer.cs
@@ -45,22 +45,22 @@
             this.checkedListBox1.Font = new System.Drawing.Font("Arial", 8F);
             this.checkedListBox1.FormattingEnabled = true;
             this.checkedListBox1.Items.AddRange(new object[] {
-                                    "N",
-                                    "NNE",
-                                    "NE",
-                                    "ENE",
-                                    "E",
-                                    "ESE",
-                                    "SE",
-                                    "SSE",
-                                    "S",
-                                    "SSW",
-                                    "SW",
-                                    "WSW",
-                                    "W",
-                                    "WNW",
-                                    "NW",
-                                    "NNW"});
+            "N",
+            "NNE",
+            "NE",
+            "ENE",
+            "E",
+            "ESE",
+            "SE",
+            "SSE",
+            "S",
+            "SSW",
+            "SW",
+            "WSW",
+            "W",
+            "WNW",
+            "NW",
+            "NNW"});
             this.checkedListBox1.Location = new System.Drawing.Point(763, 94);
             this.checkedListBox1.Name = "checkedListBox1";
             this.checkedListBox1.Size = new System.Drawing.Size(78, 315);
@@ -84,8 +84,8 @@
             // panel1
             // 
             this.panel1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-                                    | System.Windows.Forms.AnchorStyles.Left) 
-                                    | System.Windows.Forms.AnchorStyles.Right)));
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
             this.panel1.Controls.Add(this.checkedListBox1);
             this.panel1.Location = new System.Drawing.Point(0, 1);
             this.panel1.Name = "panel1";
@@ -100,6 +100,7 @@
             this.ClientSize = new System.Drawing.Size(900, 496);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.panel1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "DiurnalWinddirections";
             this.Text = "Diurnal wind direction frequencies";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.DiurnalWinddirectionsFormClosed);
@@ -108,6 +109,7 @@
             this.Resize += new System.EventHandler(this.DiurnalWinddirectionsResize);
             this.panel1.ResumeLayout(false);
             this.ResumeLayout(false);
+
         }
         private System.Windows.Forms.ToolTip toolTip1;
 

--- a/Source/Gral/GRALMainSubForms/GUI_Settings.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/GUI_Settings.Designer.cs
@@ -122,9 +122,9 @@ namespace GralMainForms
             // 
             this.checkBox1.Location = new System.Drawing.Point(12, 204);
             this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(245, 24);
+            this.checkBox1.Size = new System.Drawing.Size(334, 24);
             this.checkBox1.TabIndex = 4;
-            this.checkBox1.Text = "File compatibility to GUI version 19.01";
+            this.checkBox1.Text = "File compatibility to GUI version 19.01 and 20.01";
             this.checkBox1.UseVisualStyleBackColor = true;
             this.checkBox1.Click += new System.EventHandler(this.CheckBox1Click);
             // 

--- a/Source/Gral/GRALMainSubForms/Stabilityclasses.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/Stabilityclasses.Designer.cs
@@ -63,6 +63,7 @@
             this.ClientSize = new System.Drawing.Size(825, 476);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.panel1);
+            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.Name = "Stabilityclasses";
             this.Text = "Frequency distribution stability classes";
             this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.StabilityclassesFormClosed);
@@ -70,6 +71,7 @@
             this.ResizeEnd += new System.EventHandler(this.StabilityclassesResizeEnd);
             this.Resize += new System.EventHandler(this.StabilityclassesResize);
             this.ResumeLayout(false);
+
         }
         private System.Windows.Forms.ToolTip toolTip1;
 

--- a/Source/Gral/GRALMainSubForms/WindDistribution.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.Designer.cs
@@ -1,16 +1,16 @@
 ﻿namespace GralMainForms
 {
-    partial class Windclasses
+    partial class WindDistribution
     {
         /// <summary>
-        /// Erforderliche Designervariable.
+        /// Required designer variable.
         /// </summary>
         private System.ComponentModel.IContainer components = null;
 
         /// <summary>
-        /// Verwendete Ressourcen bereinigen.
+        /// Clean up any resources being used.
         /// </summary>
-        /// <param name="disposing">True, wenn verwaltete Ressourcen gelöscht werden sollen; andernfalls False.</param>
+        /// <param name="disposing">true if managed resources should be disposed; otherwise, false.</param>
         protected override void Dispose(bool disposing)
         {
             if (disposing && (components != null))
@@ -20,19 +20,17 @@
             base.Dispose(disposing);
         }
 
-        #region Vom Windows Form-Designer generierter Code
+        #region Windows Form Designer generated code
 
         /// <summary>
-        /// Erforderliche Methode für die Designerunterstützung.
-        /// Der Inhalt der Methode darf nicht mit dem Code-Editor geändert werden.
+        /// Required method for Designer support - do not modify
+        /// the contents of this method with the code editor.
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Windclasses));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WindDistribution));
             this.button1 = new System.Windows.Forms.Button();
             this.panel1 = new System.Windows.Forms.Panel();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
             this.SuspendLayout();
             // 
             // button1
@@ -40,11 +38,10 @@
             this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
             this.button1.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button1.BackgroundImage")));
             this.button1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.button1.Location = new System.Drawing.Point(768, 468);
+            this.button1.Location = new System.Drawing.Point(779, 495);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(40, 39);
-            this.button1.TabIndex = 0;
-            this.toolTip1.SetToolTip(this.button1, "Copy to Clipboard");
+            this.button1.TabIndex = 2;
             this.button1.UseVisualStyleBackColor = true;
             this.button1.Click += new System.EventHandler(this.button1_Click);
             // 
@@ -52,27 +49,26 @@
             // 
             this.panel1.Location = new System.Drawing.Point(0, 0);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(762, 508);
-            this.panel1.TabIndex = 1;
+            this.panel1.Size = new System.Drawing.Size(779, 534);
+            this.panel1.TabIndex = 3;
             this.panel1.Paint += new System.Windows.Forms.PaintEventHandler(this.panel1_Paint);
             // 
-            // Windclasses
+            // WindDistribution
             // 
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.None;
-            this.BackColor = System.Drawing.Color.White;
-            this.ClientSize = new System.Drawing.Size(810, 507);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.ClientSize = new System.Drawing.Size(818, 536);
             this.Controls.Add(this.button1);
             this.Controls.Add(this.panel1);
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "Windclasses";
-            this.Text = "Frequency distribution wind classes";
-            this.Load += new System.EventHandler(this.WindclassesLoad);
-            this.ResizeEnd += new System.EventHandler(this.WindclassesResizeEnd);
-            this.Resize += new System.EventHandler(this.WindclassesResize);
+            this.Name = "WindDistribution";
+            this.Text = "WindDistribution";
+            this.Load += new System.EventHandler(this.WindDistribution_Load);
+            this.ResizeEnd += new System.EventHandler(this.WindDistribution_ResizeEnd);
+            this.Resize += new System.EventHandler(this.WindDistribution_Resize);
             this.ResumeLayout(false);
 
         }
-        private System.Windows.Forms.ToolTip toolTip1;
 
         #endregion
 

--- a/Source/Gral/GRALMainSubForms/WindDistribution.cs
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.cs
@@ -79,6 +79,7 @@ namespace GralMainForms
             Pen p1 = new Pen(Color.Black, 3);
             Pen p2 = new Pen(Color.Black, 1);
             Pen p3 = new Pen(Color.Black, 1);
+            RectangleF ClipBounds = new RectangleF(0, 0, panel1.Width, panel1.Height);
 
             SizeF _lenght  = g.MeasureString(MetFile, _mediumFont);
             SizeF _lenght2 = g.MeasureString("100", _smallFont);
@@ -108,13 +109,15 @@ namespace GralMainForms
             g.DrawLine(p2, x0, ymin, panel1.Width - 10, ymin);
             g.DrawLine(p2, xmax, ymin, xmax, y0);
 
+            int xr = 0;
             for (int i = 0; i < (MaxWind); i++)
             {
                 string fs = Convert.ToString(i);
-                int xr = (int)(x0 + i * xfac);
+                xr = (int)(x0 + i * xfac);
                 g.DrawString(fs, _smallFont, _blackBrush, new PointF(xr - _lenght2.Height / 2, y0 + 5), format1);
                 g.DrawLine(p3, xr, ymin, xr, y0 + 2);
             }
+            ClipBounds.Width = xr;
             
             g.DrawString("v [m/s]", _smallFont, _blackBrush, new PointF((int) (panel1.Width / 2 - 30), (int) (y0 + _lenght2.Height)), format1);
 
@@ -140,6 +143,7 @@ namespace GralMainForms
             Pen p4 = new Pen(Color.Blue, 3);
             PointF[] _pt = new PointF[WClassFrequency.Length];
             double vw = 0;
+            g.Clip = new Region(ClipBounds);
             for (int i = 0; i < WClassFrequency.Length; i++)
             {
                 _pt[i].X = (float) (x0 + vw * xfac);
@@ -148,7 +152,8 @@ namespace GralMainForms
             }
              
             g.DrawCurve(p4, _pt, 0F);
-
+            g.ResetClip();
+            
             p1.Dispose(); p2.Dispose(); p3.Dispose(); p4.Dispose();
             verticalString.Dispose();
             format1.Dispose();

--- a/Source/Gral/GRALMainSubForms/WindDistribution.cs
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.cs
@@ -1,0 +1,162 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Drawing;
+using System.Drawing.Drawing2D;
+using System.Windows.Forms;
+
+namespace GralMainForms
+{
+    public partial class WindDistribution : Form
+    {
+        public double[] WClassFrequency;
+        public string MetFile;
+        public int StartHour;
+        public int FinalHour;
+        public int MaxWind;
+        public double MeanWindSpeed;
+        public string StartDate = string.Empty;
+        public string EndDate = string.Empty;
+
+        public WindDistribution()
+        {
+            InitializeComponent();
+        }
+
+        private void button1_Click(object sender, EventArgs e)
+        {
+            Bitmap bitMap = new Bitmap(panel1.Width, panel1.Height);
+            panel1.DrawToBitmap(bitMap, new Rectangle(0, 0, panel1.Width * 2, panel1.Height * 2));
+            Clipboard.SetDataObject(bitMap);
+        }
+
+        private void WindDistribution_Load(object sender, EventArgs e)
+        {
+            Text = "Velocity distribution - " + MetFile; 
+        }
+
+        private void WindDistribution_Resize(object sender, EventArgs e)
+        {
+            if (WindowState == FormWindowState.Maximized)
+            {
+                WindDistribution_ResizeEnd(null, null);
+                // Maximized!
+            }
+            if (WindowState == FormWindowState.Normal)
+            {
+                WindDistribution_ResizeEnd(null, null);
+                // Restored!
+            }
+        }
+
+        private void WindDistribution_ResizeEnd(object sender, EventArgs e)
+        {
+            if (ClientSize.Width > 60)
+            {
+                panel1.Width = ClientSize.Width - 55;
+                panel1.Height = ClientSize.Height;
+            }
+
+            panel1.Invalidate();
+            panel1.Update();
+        }
+
+        private void panel1_Paint(object sender, PaintEventArgs e)
+        {
+            Graphics g = e.Graphics;
+            g.Clear(Color.White);
+
+            StringFormat format1 = new StringFormat
+            {
+                LineAlignment = StringAlignment.Near,
+                Alignment = StringAlignment.Near
+            };
+
+            Font _smallFont = new Font("Arial", 10);
+            Font _mediumFont = new Font("Arial", 12);
+            Font _largeFont = new Font("Arial", 15);
+            Brush _blackBrush = new SolidBrush(Color.Black);
+            Brush _greyBrush = new SolidBrush(Color.Gray);
+            Pen p1 = new Pen(Color.Black, 3);
+            Pen p2 = new Pen(Color.Black, 1);
+            Pen p3 = new Pen(Color.Black, 1);
+
+            SizeF _lenght  = g.MeasureString(MetFile, _mediumFont);
+            SizeF _lenght2 = g.MeasureString("100", _smallFont);
+
+            int x0 = (int)(_lenght2.Width + _lenght2.Height) + 10;
+            int y0 = panel1.Height - (int)_lenght2.Height * 2 - 30;
+
+            g.DrawString(MetFile, _mediumFont, _blackBrush, (panel1.Width - _lenght.Width) / 2, _lenght.Height + 4, format1);
+            string infodata = StartDate + " - " + EndDate + " " + StartHour.ToString() + ":00 - " + FinalHour.ToString() + ":00  Mean wind speed: " + Math.Round(MeanWindSpeed, 1).ToString() + "m/s";
+            _lenght = g.MeasureString(infodata, _smallFont);
+            g.DrawString(infodata, _smallFont, _blackBrush, (panel1.Width - _lenght.Width) / 2, _lenght.Height * 2.5F + 4, format1);
+
+            double xfac = (panel1.Width - x0 - 10) / (MaxWind - 1);
+            double yfac = (y0 - 80) / 10;
+            int ymin = (int)(y0 - 10 * yfac);
+            int xmax = (int)(x0 + (MaxWind - 1) * xfac);
+
+            if (xfac < 0 || yfac < 0)
+            {
+                return;
+            }
+
+            //draw axis
+            p3.DashStyle = System.Drawing.Drawing2D.DashStyle.Dash;
+            g.DrawLine(p2, x0, ymin, x0, y0 + 5);
+            g.DrawLine(p2, x0 - 5, y0, panel1.Width - 10, y0);
+            g.DrawLine(p2, x0, ymin, panel1.Width - 10, ymin);
+            g.DrawLine(p2, xmax, ymin, xmax, y0);
+
+            for (int i = 0; i < (MaxWind - 1); i++)
+            {
+                string fs = Convert.ToString(i);
+                int xr = (int)(x0 + i * xfac);
+                g.DrawString(fs, _smallFont, _blackBrush, new PointF(xr - _lenght2.Height / 2, y0 + 5), format1);
+                g.DrawLine(p3, xr, ymin, xr, y0 + 2);
+            }
+            
+            g.DrawString("v [m/s]", _smallFont, _blackBrush, new PointF((int) (panel1.Width / 2 - 30), (int) (y0 + _lenght2.Height)), format1);
+
+            StringFormat verticalString = new StringFormat
+            {
+                FormatFlags = StringFormatFlags.DirectionVertical,
+                Alignment = StringAlignment.Near,
+                LineAlignment = StringAlignment.Near
+            };
+            SizeF _lenght3 = g.MeasureString("Frequency [%]", _smallFont);
+            g.DrawString("Frequency [%]", _smallFont, _blackBrush, 4, (int) ((panel1.Height - _lenght3.Width) / 2), verticalString);
+            
+            //draw frequency levels
+            for (int i = 0; i < 11; i++)
+            {
+                int yr = (int)(y0 - i * yfac);
+                g.DrawLine(p3, x0 - 3, yr, xmax, yr);
+                g.DrawString((i * 10).ToString(), _smallFont, _blackBrush, x0 - _lenght2.Width - 1, (int)(yr - _lenght2.Height / 2));
+                base.OnPaint(e);
+            }
+
+            // Draw Graph
+            Pen p4 = new Pen(Color.Blue, 3);
+            PointF[] _pt = new PointF[WClassFrequency.Length];
+            double vw = 0;
+            for (int i = 0; i < WClassFrequency.Length; i++)
+            {
+                _pt[i].X = (float) (x0 + vw * xfac);
+                _pt[i].Y = (float)(y0 - WClassFrequency[i] * 10 * yfac);
+                vw += 0.25;
+            }
+             
+            g.DrawCurve(p4, _pt, 0F);
+
+            p1.Dispose(); p2.Dispose(); p3.Dispose(); p4.Dispose();
+            verticalString.Dispose();
+            format1.Dispose();
+            _smallFont.Dispose();
+            _mediumFont.Dispose();
+            _largeFont.Dispose();
+            _blackBrush.Dispose();
+            _greyBrush.Dispose();
+        }
+    }
+}

--- a/Source/Gral/GRALMainSubForms/WindDistribution.cs
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.cs
@@ -31,7 +31,7 @@ namespace GralMainForms
 
         private void WindDistribution_Load(object sender, EventArgs e)
         {
-            Text = "Velocity distribution - " + MetFile; 
+            Text = "Wind velocity - cumulative frequency distribution - " + MetFile; 
         }
 
         private void WindDistribution_Resize(object sender, EventArgs e)

--- a/Source/Gral/GRALMainSubForms/WindDistribution.cs
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.cs
@@ -108,7 +108,7 @@ namespace GralMainForms
             g.DrawLine(p2, x0, ymin, panel1.Width - 10, ymin);
             g.DrawLine(p2, xmax, ymin, xmax, y0);
 
-            for (int i = 0; i < (MaxWind - 1); i++)
+            for (int i = 0; i < (MaxWind); i++)
             {
                 string fs = Convert.ToString(i);
                 int xr = (int)(x0 + i * xfac);

--- a/Source/Gral/GRALMainSubForms/WindDistribution.resx
+++ b/Source/Gral/GRALMainSubForms/WindDistribution.resx
@@ -1,0 +1,178 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!-- 
+    Microsoft ResX Schema 
+    
+    Version 2.0
+    
+    The primary goals of this format is to allow a simple XML format 
+    that is mostly human readable. The generation and parsing of the 
+    various data types are done through the TypeConverter classes 
+    associated with the data types.
+    
+    Example:
+    
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+                
+    There are any number of "resheader" rows that contain simple 
+    name/value pairs.
+    
+    Each data row contains a name, and value. The row also contains a 
+    type or mimetype. Type corresponds to a .NET class that support 
+    text/value conversion through the TypeConverter architecture. 
+    Classes that don't support this are serialized and stored with the 
+    mimetype set.
+    
+    The mimetype is used for serialized objects, and tells the 
+    ResXResourceReader how to depersist the object. This is currently not 
+    extensible. For a given mimetype the value must be set accordingly:
+    
+    Note - application/x-microsoft.net.object.binary.base64 is the format 
+    that the ResXResourceWriter will generate, however the reader can 
+    read any of the formats listed below.
+    
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with 
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array 
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
+  <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
+    <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
+    <xsd:element name="root" msdata:IsDataSet="true">
+      <xsd:complexType>
+        <xsd:choice maxOccurs="unbounded">
+          <xsd:element name="metadata">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" />
+              </xsd:sequence>
+              <xsd:attribute name="name" use="required" type="xsd:string" />
+              <xsd:attribute name="type" type="xsd:string" />
+              <xsd:attribute name="mimetype" type="xsd:string" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="assembly">
+            <xsd:complexType>
+              <xsd:attribute name="alias" type="xsd:string" />
+              <xsd:attribute name="name" type="xsd:string" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="data">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+                <xsd:element name="comment" type="xsd:string" minOccurs="0" msdata:Ordinal="2" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" msdata:Ordinal="1" />
+              <xsd:attribute name="type" type="xsd:string" msdata:Ordinal="3" />
+              <xsd:attribute name="mimetype" type="xsd:string" msdata:Ordinal="4" />
+              <xsd:attribute ref="xml:space" />
+            </xsd:complexType>
+          </xsd:element>
+          <xsd:element name="resheader">
+            <xsd:complexType>
+              <xsd:sequence>
+                <xsd:element name="value" type="xsd:string" minOccurs="0" msdata:Ordinal="1" />
+              </xsd:sequence>
+              <xsd:attribute name="name" type="xsd:string" use="required" />
+            </xsd:complexType>
+          </xsd:element>
+        </xsd:choice>
+      </xsd:complexType>
+    </xsd:element>
+  </xsd:schema>
+  <resheader name="resmimetype">
+    <value>text/microsoft-resx</value>
+  </resheader>
+  <resheader name="version">
+    <value>2.0</value>
+  </resheader>
+  <resheader name="reader">
+    <value>System.Resources.ResXResourceReader, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <resheader name="writer">
+    <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
+  </resheader>
+  <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
+  <data name="button1.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        Qk02DAAAAAAAADYAAAAoAAAAIAAAACAAAAABABgAAAAAAAAAAAATCwAAEwsAAAAAAAAAAAAA////////
+        ////////////08m1pI9onohfnohfnohfnohfnohfnohfnohfnohfnohfnohfnohfnohfnohfnohfnohf
+        nohfnohfnohfpI9o08m2////////////////////////////////////7urjnohenohenohenohenohe
+        nohenohenohenohenohenohenohenohenohenohenohenohenohenohenohenohenohf7+vk////////
+        ////////////////////////4dvOnoheoo1l5+HX7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg
+        7Ojg08q2nolfnohenohenohenohenohenohe4tvO////////////////////////////////4drNnohe
+        qpZy////////////////////////////////////////////////4tvP1s68nolfnohenohenohenohe
+        nohe4tvO////////////////////////////////4drNnoheqpZy////////////////////////////
+        ////////////////////uamLyb2m1s68nolfnohenohenohenohe4tvO////////////////////////
+        ////////4drNnoheqpZy////////////////////////////////////////////////uamLnoheyb2m
+        1s68nolfnohenohenohe4tvO////////////////////////////////4drNnoheqpZy////////////
+        ////////////////////////////////////uamLnohenoheyb2m1s68nolfnohenohe4tvO////////
+        ////////////////////////4drNnoheqpZy////////////////////////////////////////////
+        ////w7Wbnohenohenoheyb2m1s68nolfnohe4tvO////////////////////////////////4drNnohe
+        qpZy/////////////////////////////////////////////////////Pz7/Pz7/Pz7/Pz7////qZZx
+        nohe4tvO////////////////////////////////4drNnoheqpZy////////////////////////////
+        ////////////////////////////////////////////qZZxnohe4tvO////////////////////////
+        ////////4drNnoheqpZy////+vn3taSFtKODtKODtKODtKODtKODtqaH/v39////////////////////
+        ////////////qZZxnohe4tvO////////////////////////////////4drNnoheqpZy////////////
+        ////////////////////////////////////////////////////////////qZZxnohe4tvO////////
+        ////////////////////////4drNnoheqpZy////+vn3tqWFtaSEtaSEtaSEtaSEtaSEtaSEtaSEtaSE
+        taSEtaSEtaSEtaSEtaSE9fPu////qZZxnohe4tvO////////////////////////////////4drNnohe
+        qpZy////////////////////////////////////////////////////////////////////////qZZx
+        nohe4tvO////////////////////////////////4drNnoheqpZy////+/r4yLykx7ujx7ujx7ujx7uj
+        x7ujx7ujx7ujx7ujx7ujx7ujx7ujx7ujx7uj9/Xx////qZZxnohe4tvO////////////////////////
+        ////////4drNnoheqpZy//////7+7enh7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg7Ojg
+        7Ojg/f38////qZZxnohe4tvO////////////////////////////////4drNnoheqpZy/////fz729PD
+        2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC2tLC+vn3////qZZxnohe4tvO////////
+        ////////////////////////4drNnoheqpZy/////fz72tLC2tHB2tHB2tHB2tHB2tHB2tHB2tHB2tHB
+        2tHB2tHB2tHB2tHB2tHB+vn3////qZZxnohe4tvO////////////////////////////////4drNnohe
+        qpZy/////v795+LY5+HX5+HX5+HX6OLZ////+vn25+HX5+HX5+HX5+HX5+HX5+HX5+HX/Pz7////qZZx
+        nohe4tvO////////////////////////////////4drNnoheqpZy////9fPvnohenohenohenohenohe
+        +vn28u/qzcGrzcGrzcGrzcGrzcGrzcGrzcGr+Pbz////qZZxnohe4tvO////////////////////////
+        ////////4drNnoheqpZy////9fPvnohenohenohenohenohe+vn2/v7++fj2+fj2+fj2+fj2+fj2+fj2
+        +fj2////////qZZxnohe4tvO////////////////////////////////4drNnoheqpZy////9fPvnohe
+        nohenohenohenohe+vn27uniuqqNuqqNuqqNuqqNuqqNuqqNuqqN9fPv////qZZxnohe4tvO////////
+        ////////////////////////4drNnoheqpZy////9fPvnohenohenohenohenohe+vn2////////////
+        ////////////////////////////qZZxnohe4tvO////////////////////////////////4drNnohe
+        qpZy////+PbzqJRup5Ntp5Ntp5NtqJRv+/r57enhtKODtKODtKODtKODtKODtKODtKOD9fPu////qZZx
+        nohe4tvO////////////////////////////////4drNnoheqpZy////////////////////////////
+        ////////////////////////////////////////////qZZxnohe4tvO////////////////////////
+        ////////4drNnoheqpZy////////////////////////////////////////////////////////////
+        ////////////qZZxnohe4tvO////////////////////////////////4drNnoheqZZx////////////
+        /////Pz6+Pby+Pby+Pby+Pby+Pby+Pby+Pby+Pby/Pz6////////////////qZVwnohe4tvO////////
+        ////////////////////////49zQnohenohfwrSayLujyLuj2M69yr6nnohenohenohenohenohenohe
+        nohenoheyr6n1868yLujyLujwrSZnohenohe493R////////////////////////////////+Pf0ppFq
+        nohenohenohenoheuamLyr6mnohenohenohenohenohenohenohenoheyr6muKmKnohenohenohenohe
+        pZFq+ff0////////////////////////////////////8O3mybylw7acw7acw7ac1Mq4y8Cpnohenohe
+        noheoItioItinohenohenohey8Cp08q3w7acw7acw7acybyl8O3n////////////////////////////
+        ////////////////////////////////////8/Dryr6nyLykt6eH2M++186+t6eHyLykyr6n8/Hs////
+        ////////////////////////////////////////////////////////////////////////////////
+        ////////////////8vDqsqF/sqGA8/Dr////////////////////////////////////////////////
+        ////////
+</value>
+  </data>
+</root>

--- a/Source/Gral/GRALMainSubForms/Windclasses.Designer.cs
+++ b/Source/Gral/GRALMainSubForms/Windclasses.Designer.cs
@@ -50,7 +50,7 @@
             // 
             // panel1
             // 
-            this.panel1.Location = new System.Drawing.Point(0, -1);
+            this.panel1.Location = new System.Drawing.Point(0, 0);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(762, 508);
             this.panel1.TabIndex = 1;
@@ -69,6 +69,7 @@
             this.ResizeEnd += new System.EventHandler(this.WindclassesResizeEnd);
             this.Resize += new System.EventHandler(this.WindclassesResize);
             this.ResumeLayout(false);
+
         }
         private System.Windows.Forms.ToolTip toolTip1;
 

--- a/Source/Gral/GRALShapeFiles/SHPLine.cs
+++ b/Source/Gral/GRALShapeFiles/SHPLine.cs
@@ -15,7 +15,7 @@ using System.Drawing;
 namespace GralShape
 {
     /// <summary>
-    /// Shapefile Line class
+    /// Shapefile line class
     /// </summary>
     public class SHPLine
     {
@@ -24,5 +24,9 @@ namespace GralShape
         public int NumPoints;
         public int[] Parts;
         public GralDomain.PointD[] Points;
+        /// <summary>
+        /// Z value of a Point
+        /// </summary>
+        public double[] PointsZ;
     }
 }

--- a/Source/Gral/GRALShapeFiles/ShapeAreaDialog.cs
+++ b/Source/Gral/GRALShapeFiles/ShapeAreaDialog.cs
@@ -293,7 +293,7 @@ namespace GralShape
 							
 							for (int di = 0; di < 10; di++) // save deposition
 							{
-								_as.Dep[di] = dep[di];
+								_as.GetDep()[di] = dep[di];
 							}
 							
 							domain.EditAS.ItemData.Add(_as);

--- a/Source/Gral/GRALShapeFiles/ShapeBuildingDialog.Designer.cs
+++ b/Source/Gral/GRALShapeFiles/ShapeBuildingDialog.Designer.cs
@@ -46,13 +46,14 @@
             this.label7 = new System.Windows.Forms.Label();
             this.label6 = new System.Windows.Forms.Label();
             this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            this.button4 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             this.SuspendLayout();
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(4, 1);
+            this.button1.Location = new System.Drawing.Point(11, 80);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(92, 24);
@@ -67,17 +68,17 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView1.Location = new System.Drawing.Point(4, 74);
+            this.dataGridView1.Location = new System.Drawing.Point(4, 114);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(2);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowTemplate.Height = 24;
-            this.dataGridView1.Size = new System.Drawing.Size(716, 289);
+            this.dataGridView1.Size = new System.Drawing.Size(909, 376);
             this.dataGridView1.TabIndex = 1;
             // 
             // comboBox1
             // 
             this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(298, 50);
+            this.comboBox1.Location = new System.Drawing.Point(318, 46);
             this.comboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox1.Name = "comboBox1";
             this.comboBox1.Size = new System.Drawing.Size(92, 21);
@@ -87,7 +88,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.ForeColor = System.Drawing.Color.Red;
-            this.label1.Location = new System.Drawing.Point(298, 33);
+            this.label1.Location = new System.Drawing.Point(318, 29);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(81, 13);
@@ -96,7 +97,7 @@
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(322, 1);
+            this.button2.Location = new System.Drawing.Point(141, 80);
             this.button2.Margin = new System.Windows.Forms.Padding(2);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(79, 24);
@@ -107,7 +108,7 @@
             // 
             // button3
             // 
-            this.button3.Location = new System.Drawing.Point(406, 1);
+            this.button3.Location = new System.Drawing.Point(257, 80);
             this.button3.Margin = new System.Windows.Forms.Padding(2);
             this.button3.Name = "button3";
             this.button3.Size = new System.Drawing.Size(93, 24);
@@ -120,7 +121,7 @@
             // 
             this.label3.AutoSize = true;
             this.label3.ForeColor = System.Drawing.Color.Blue;
-            this.label3.Location = new System.Drawing.Point(2, 33);
+            this.label3.Location = new System.Drawing.Point(5, 29);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(78, 13);
@@ -130,7 +131,7 @@
             // comboBox3
             // 
             this.comboBox3.FormattingEnabled = true;
-            this.comboBox3.Location = new System.Drawing.Point(4, 50);
+            this.comboBox3.Location = new System.Drawing.Point(7, 46);
             this.comboBox3.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox3.Name = "comboBox3";
             this.comboBox3.Size = new System.Drawing.Size(92, 21);
@@ -139,29 +140,31 @@
             // label17
             // 
             this.label17.AutoSize = true;
+            this.label17.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label17.ForeColor = System.Drawing.Color.Blue;
-            this.label17.Location = new System.Drawing.Point(115, 6);
+            this.label17.Location = new System.Drawing.Point(11, 9);
             this.label17.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(44, 13);
+            this.label17.Size = new System.Drawing.Size(46, 15);
             this.label17.TabIndex = 41;
             this.label17.Text = "optional";
             // 
             // label16
             // 
             this.label16.AutoSize = true;
+            this.label16.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label16.ForeColor = System.Drawing.Color.Red;
-            this.label16.Location = new System.Drawing.Point(163, 6);
+            this.label16.Location = new System.Drawing.Point(72, 9);
             this.label16.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(29, 13);
+            this.label16.Size = new System.Drawing.Size(31, 15);
             this.label16.TabIndex = 40;
             this.label16.Text = "must";
             // 
             // checkBox1
             // 
             this.checkBox1.ForeColor = System.Drawing.Color.Blue;
-            this.checkBox1.Location = new System.Drawing.Point(395, 50);
+            this.checkBox1.Location = new System.Drawing.Point(415, 46);
             this.checkBox1.Name = "checkBox1";
             this.checkBox1.Size = new System.Drawing.Size(104, 21);
             this.checkBox1.TabIndex = 12;
@@ -172,7 +175,7 @@
             // 
             this.label2.AutoSize = true;
             this.label2.ForeColor = System.Drawing.Color.Blue;
-            this.label2.Location = new System.Drawing.Point(100, 33);
+            this.label2.Location = new System.Drawing.Point(103, 29);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(38, 13);
@@ -182,7 +185,7 @@
             // comboBox2
             // 
             this.comboBox2.FormattingEnabled = true;
-            this.comboBox2.Location = new System.Drawing.Point(100, 50);
+            this.comboBox2.Location = new System.Drawing.Point(103, 46);
             this.comboBox2.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox2.Name = "comboBox2";
             this.comboBox2.Size = new System.Drawing.Size(92, 21);
@@ -192,7 +195,7 @@
             // 
             this.label4.AutoSize = true;
             this.label4.ForeColor = System.Drawing.Color.Blue;
-            this.label4.Location = new System.Drawing.Point(196, 33);
+            this.label4.Location = new System.Drawing.Point(199, 29);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(24, 13);
@@ -202,7 +205,7 @@
             // comboBox4
             // 
             this.comboBox4.FormattingEnabled = true;
-            this.comboBox4.Location = new System.Drawing.Point(196, 50);
+            this.comboBox4.Location = new System.Drawing.Point(199, 46);
             this.comboBox4.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox4.Name = "comboBox4";
             this.comboBox4.Size = new System.Drawing.Size(92, 21);
@@ -223,7 +226,7 @@
             // 
             this.label6.AutoSize = true;
             this.label6.ForeColor = System.Drawing.Color.Blue;
-            this.label6.Location = new System.Drawing.Point(544, 1);
+            this.label6.Location = new System.Drawing.Point(544, 9);
             this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(89, 26);
@@ -238,7 +241,7 @@
             0,
             0,
             65536});
-            this.numericUpDown1.Location = new System.Drawing.Point(544, 49);
+            this.numericUpDown1.Location = new System.Drawing.Point(547, 45);
             this.numericUpDown1.Maximum = new decimal(new int[] {
             2,
             0,
@@ -248,12 +251,23 @@
             this.numericUpDown1.Size = new System.Drawing.Size(76, 20);
             this.numericUpDown1.TabIndex = 6;
             // 
+            // button4
+            // 
+            this.button4.Location = new System.Drawing.Point(383, 80);
+            this.button4.Margin = new System.Windows.Forms.Padding(2);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(92, 24);
+            this.button4.TabIndex = 0;
+            this.button4.Text = "&Cancel";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
             // ShapeBuildingDialog
             // 
             this.AcceptButton = this.button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(723, 365);
+            this.ClientSize = new System.Drawing.Size(916, 490);
             this.ControlBox = false;
             this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
@@ -272,6 +286,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.comboBox1);
             this.Controls.Add(this.dataGridView1);
+            this.Controls.Add(this.button4);
             this.Controls.Add(this.button1);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "ShapeBuildingDialog";
@@ -305,5 +320,6 @@
         private System.Windows.Forms.ComboBox comboBox3;
         private System.Windows.Forms.Label label17;
         private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.Button button4;
     }
 }

--- a/Source/Gral/GRALShapeFiles/ShapeBuildingDialog.cs
+++ b/Source/Gral/GRALShapeFiles/ShapeBuildingDialog.cs
@@ -250,13 +250,12 @@ namespace GralShape
 				
 				wait.Close();
 				wait.Dispose();
-				
+				Close();
 			}
 			else
 			{
 				MessageBox.Show("No heights defined - data is not imported", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
-			}
-			Close();
+			}	
 		}
 
 		//read attribute table from dbf file
@@ -428,10 +427,39 @@ namespace GralShape
 				areapolygon = Math.Abs(areapolygon);
 			}
 		}
-		
-		void Shape_Building_DialogFormClosed(object sender, FormClosedEventArgs e)
+
+        void Shape_Building_DialogFormClosed(object sender, FormClosedEventArgs e)
+        {
+#if __MonoCS__
+#else
+            if (dataGridView1 != null)
+            {
+                dataGridView1.DataSource = null;
+                dataGridView1.Rows.Clear();
+            }
+
+			if (dt != null)
+			{
+				DataRowCollection itemColumns = dt.Rows; // mark elements as deleted
+				for (int i = itemColumns.Count - 1; i >= 0; i--)
+				{
+					itemColumns[i].Delete();
+				}
+				dt.AcceptChanges(); // accept deletion
+				dt.Clear(); // clear data table
+			}
+#endif
+
+            if (dt != null)
+                dt.Dispose();
+
+            if (dataGridView1 != null) dataGridView1.Dispose(); // Kuntner
+            dataGridView1 = null;
+        }
+
+        private void button4_Click(object sender, EventArgs e)
 		{
-			
+			Close();
 		}
 	}
 }

--- a/Source/Gral/GRALShapeFiles/ShapeLineDialog.Designer.cs
+++ b/Source/Gral/GRALShapeFiles/ShapeLineDialog.Designer.cs
@@ -85,6 +85,8 @@
             this.label7 = new System.Windows.Forms.Label();
             this.comboBox31 = new System.Windows.Forms.ComboBox();
             this.label8 = new System.Windows.Forms.Label();
+            this.checkBox3 = new System.Windows.Forms.CheckBox();
+            this.button4 = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.dataGridView1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
             ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
@@ -92,7 +94,7 @@
             // 
             // button1
             // 
-            this.button1.Location = new System.Drawing.Point(1, 1);
+            this.button1.Location = new System.Drawing.Point(11, 268);
             this.button1.Margin = new System.Windows.Forms.Padding(2);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(94, 24);
@@ -107,17 +109,17 @@
             | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.dataGridView1.ColumnHeadersHeightSizeMode = System.Windows.Forms.DataGridViewColumnHeadersHeightSizeMode.AutoSize;
-            this.dataGridView1.Location = new System.Drawing.Point(1, 256);
+            this.dataGridView1.Location = new System.Drawing.Point(7, 300);
             this.dataGridView1.Margin = new System.Windows.Forms.Padding(2);
             this.dataGridView1.Name = "dataGridView1";
             this.dataGridView1.RowTemplate.Height = 24;
-            this.dataGridView1.Size = new System.Drawing.Size(645, 292);
+            this.dataGridView1.Size = new System.Drawing.Size(760, 325);
             this.dataGridView1.TabIndex = 1;
             // 
             // comboBox1
             // 
             this.comboBox1.FormattingEnabled = true;
-            this.comboBox1.Location = new System.Drawing.Point(98, 43);
+            this.comboBox1.Location = new System.Drawing.Point(104, 47);
             this.comboBox1.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox1.Name = "comboBox1";
             this.comboBox1.Size = new System.Drawing.Size(92, 21);
@@ -127,7 +129,7 @@
             // 
             this.label1.AutoSize = true;
             this.label1.ForeColor = System.Drawing.Color.Blue;
-            this.label1.Location = new System.Drawing.Point(96, 27);
+            this.label1.Location = new System.Drawing.Point(102, 31);
             this.label1.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(72, 13);
@@ -136,7 +138,7 @@
             // 
             // button2
             // 
-            this.button2.Location = new System.Drawing.Point(458, 1);
+            this.button2.Location = new System.Drawing.Point(194, 268);
             this.button2.Margin = new System.Windows.Forms.Padding(2);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(79, 24);
@@ -147,7 +149,7 @@
             // 
             // button3
             // 
-            this.button3.Location = new System.Drawing.Point(541, 1);
+            this.button3.Location = new System.Drawing.Point(332, 268);
             this.button3.Margin = new System.Windows.Forms.Padding(2);
             this.button3.Name = "button3";
             this.button3.Size = new System.Drawing.Size(93, 24);
@@ -160,7 +162,7 @@
             // 
             this.label2.AutoSize = true;
             this.label2.ForeColor = System.Drawing.Color.Blue;
-            this.label2.Location = new System.Drawing.Point(190, 27);
+            this.label2.Location = new System.Drawing.Point(196, 31);
             this.label2.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label2.Name = "label2";
             this.label2.Size = new System.Drawing.Size(41, 13);
@@ -170,7 +172,7 @@
             // comboBox2
             // 
             this.comboBox2.FormattingEnabled = true;
-            this.comboBox2.Location = new System.Drawing.Point(193, 43);
+            this.comboBox2.Location = new System.Drawing.Point(199, 47);
             this.comboBox2.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox2.Name = "comboBox2";
             this.comboBox2.Size = new System.Drawing.Size(92, 21);
@@ -180,7 +182,7 @@
             // 
             this.label3.AutoSize = true;
             this.label3.ForeColor = System.Drawing.Color.Blue;
-            this.label3.Location = new System.Drawing.Point(2, 27);
+            this.label3.Location = new System.Drawing.Point(8, 31);
             this.label3.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label3.Name = "label3";
             this.label3.Size = new System.Drawing.Size(64, 13);
@@ -190,7 +192,7 @@
             // comboBox3
             // 
             this.comboBox3.FormattingEnabled = true;
-            this.comboBox3.Location = new System.Drawing.Point(4, 43);
+            this.comboBox3.Location = new System.Drawing.Point(10, 47);
             this.comboBox3.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox3.Name = "comboBox3";
             this.comboBox3.Size = new System.Drawing.Size(92, 21);
@@ -200,7 +202,7 @@
             // 
             this.label4.AutoSize = true;
             this.label4.ForeColor = System.Drawing.Color.Red;
-            this.label4.Location = new System.Drawing.Point(286, 27);
+            this.label4.Location = new System.Drawing.Point(292, 31);
             this.label4.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label4.Name = "label4";
             this.label4.Size = new System.Drawing.Size(74, 13);
@@ -210,7 +212,7 @@
             // comboBox4
             // 
             this.comboBox4.FormattingEnabled = true;
-            this.comboBox4.Location = new System.Drawing.Point(288, 43);
+            this.comboBox4.Location = new System.Drawing.Point(294, 47);
             this.comboBox4.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox4.Name = "comboBox4";
             this.comboBox4.Size = new System.Drawing.Size(92, 21);
@@ -220,7 +222,7 @@
             // 
             this.label5.AutoSize = true;
             this.label5.ForeColor = System.Drawing.Color.Red;
-            this.label5.Location = new System.Drawing.Point(381, 27);
+            this.label5.Location = new System.Drawing.Point(387, 31);
             this.label5.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label5.Name = "label5";
             this.label5.Size = new System.Drawing.Size(38, 13);
@@ -230,7 +232,7 @@
             // comboBox6
             // 
             this.comboBox6.FormattingEnabled = true;
-            this.comboBox6.Location = new System.Drawing.Point(3, 139);
+            this.comboBox6.Location = new System.Drawing.Point(9, 143);
             this.comboBox6.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox6.Name = "comboBox6";
             this.comboBox6.Size = new System.Drawing.Size(92, 21);
@@ -239,7 +241,7 @@
             // comboBox5
             // 
             this.comboBox5.FormattingEnabled = true;
-            this.comboBox5.Location = new System.Drawing.Point(98, 139);
+            this.comboBox5.Location = new System.Drawing.Point(104, 143);
             this.comboBox5.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox5.Name = "comboBox5";
             this.comboBox5.Size = new System.Drawing.Size(92, 21);
@@ -248,7 +250,7 @@
             // comboBox7
             // 
             this.comboBox7.FormattingEnabled = true;
-            this.comboBox7.Location = new System.Drawing.Point(192, 139);
+            this.comboBox7.Location = new System.Drawing.Point(198, 143);
             this.comboBox7.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox7.Name = "comboBox7";
             this.comboBox7.Size = new System.Drawing.Size(92, 21);
@@ -257,7 +259,7 @@
             // comboBox8
             // 
             this.comboBox8.FormattingEnabled = true;
-            this.comboBox8.Location = new System.Drawing.Point(286, 139);
+            this.comboBox8.Location = new System.Drawing.Point(292, 143);
             this.comboBox8.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox8.Name = "comboBox8";
             this.comboBox8.Size = new System.Drawing.Size(92, 21);
@@ -266,7 +268,7 @@
             // comboBox9
             // 
             this.comboBox9.FormattingEnabled = true;
-            this.comboBox9.Location = new System.Drawing.Point(381, 139);
+            this.comboBox9.Location = new System.Drawing.Point(387, 143);
             this.comboBox9.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox9.Name = "comboBox9";
             this.comboBox9.Size = new System.Drawing.Size(92, 21);
@@ -275,7 +277,7 @@
             // comboBox10
             // 
             this.comboBox10.FormattingEnabled = true;
-            this.comboBox10.Location = new System.Drawing.Point(381, 207);
+            this.comboBox10.Location = new System.Drawing.Point(387, 211);
             this.comboBox10.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox10.Name = "comboBox10";
             this.comboBox10.Size = new System.Drawing.Size(92, 21);
@@ -284,7 +286,7 @@
             // comboBox11
             // 
             this.comboBox11.FormattingEnabled = true;
-            this.comboBox11.Location = new System.Drawing.Point(286, 207);
+            this.comboBox11.Location = new System.Drawing.Point(292, 211);
             this.comboBox11.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox11.Name = "comboBox11";
             this.comboBox11.Size = new System.Drawing.Size(92, 21);
@@ -293,7 +295,7 @@
             // comboBox12
             // 
             this.comboBox12.FormattingEnabled = true;
-            this.comboBox12.Location = new System.Drawing.Point(192, 207);
+            this.comboBox12.Location = new System.Drawing.Point(198, 211);
             this.comboBox12.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox12.Name = "comboBox12";
             this.comboBox12.Size = new System.Drawing.Size(92, 21);
@@ -302,7 +304,7 @@
             // comboBox13
             // 
             this.comboBox13.FormattingEnabled = true;
-            this.comboBox13.Location = new System.Drawing.Point(98, 207);
+            this.comboBox13.Location = new System.Drawing.Point(104, 211);
             this.comboBox13.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox13.Name = "comboBox13";
             this.comboBox13.Size = new System.Drawing.Size(92, 21);
@@ -311,7 +313,7 @@
             // comboBox14
             // 
             this.comboBox14.FormattingEnabled = true;
-            this.comboBox14.Location = new System.Drawing.Point(3, 207);
+            this.comboBox14.Location = new System.Drawing.Point(9, 211);
             this.comboBox14.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox14.Name = "comboBox14";
             this.comboBox14.Size = new System.Drawing.Size(92, 21);
@@ -320,29 +322,31 @@
             // label16
             // 
             this.label16.AutoSize = true;
+            this.label16.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label16.ForeColor = System.Drawing.Color.Red;
-            this.label16.Location = new System.Drawing.Point(160, 6);
+            this.label16.Location = new System.Drawing.Point(66, 6);
             this.label16.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label16.Name = "label16";
-            this.label16.Size = new System.Drawing.Size(29, 13);
+            this.label16.Size = new System.Drawing.Size(31, 15);
             this.label16.TabIndex = 38;
             this.label16.Text = "must";
             // 
             // label17
             // 
             this.label17.AutoSize = true;
+            this.label17.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.label17.ForeColor = System.Drawing.Color.Blue;
-            this.label17.Location = new System.Drawing.Point(112, 6);
+            this.label17.Location = new System.Drawing.Point(11, 6);
             this.label17.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label17.Name = "label17";
-            this.label17.Size = new System.Drawing.Size(44, 13);
+            this.label17.Size = new System.Drawing.Size(46, 15);
             this.label17.TabIndex = 39;
             this.label17.Text = "optional";
             // 
             // comboBox15
             // 
             this.comboBox15.FormattingEnabled = true;
-            this.comboBox15.Location = new System.Drawing.Point(381, 160);
+            this.comboBox15.Location = new System.Drawing.Point(387, 164);
             this.comboBox15.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox15.Name = "comboBox15";
             this.comboBox15.Size = new System.Drawing.Size(92, 21);
@@ -351,7 +355,7 @@
             // comboBox16
             // 
             this.comboBox16.FormattingEnabled = true;
-            this.comboBox16.Location = new System.Drawing.Point(286, 160);
+            this.comboBox16.Location = new System.Drawing.Point(292, 164);
             this.comboBox16.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox16.Name = "comboBox16";
             this.comboBox16.Size = new System.Drawing.Size(92, 21);
@@ -360,7 +364,7 @@
             // comboBox17
             // 
             this.comboBox17.FormattingEnabled = true;
-            this.comboBox17.Location = new System.Drawing.Point(192, 160);
+            this.comboBox17.Location = new System.Drawing.Point(198, 164);
             this.comboBox17.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox17.Name = "comboBox17";
             this.comboBox17.Size = new System.Drawing.Size(92, 21);
@@ -369,7 +373,7 @@
             // comboBox18
             // 
             this.comboBox18.FormattingEnabled = true;
-            this.comboBox18.Location = new System.Drawing.Point(98, 160);
+            this.comboBox18.Location = new System.Drawing.Point(104, 164);
             this.comboBox18.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox18.Name = "comboBox18";
             this.comboBox18.Size = new System.Drawing.Size(92, 21);
@@ -378,7 +382,7 @@
             // comboBox19
             // 
             this.comboBox19.FormattingEnabled = true;
-            this.comboBox19.Location = new System.Drawing.Point(3, 160);
+            this.comboBox19.Location = new System.Drawing.Point(9, 164);
             this.comboBox19.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox19.Name = "comboBox19";
             this.comboBox19.Size = new System.Drawing.Size(92, 21);
@@ -387,7 +391,7 @@
             // comboBox20
             // 
             this.comboBox20.FormattingEnabled = true;
-            this.comboBox20.Location = new System.Drawing.Point(381, 229);
+            this.comboBox20.Location = new System.Drawing.Point(387, 233);
             this.comboBox20.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox20.Name = "comboBox20";
             this.comboBox20.Size = new System.Drawing.Size(92, 21);
@@ -396,7 +400,7 @@
             // comboBox21
             // 
             this.comboBox21.FormattingEnabled = true;
-            this.comboBox21.Location = new System.Drawing.Point(286, 229);
+            this.comboBox21.Location = new System.Drawing.Point(292, 233);
             this.comboBox21.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox21.Name = "comboBox21";
             this.comboBox21.Size = new System.Drawing.Size(92, 21);
@@ -405,7 +409,7 @@
             // comboBox22
             // 
             this.comboBox22.FormattingEnabled = true;
-            this.comboBox22.Location = new System.Drawing.Point(192, 229);
+            this.comboBox22.Location = new System.Drawing.Point(198, 233);
             this.comboBox22.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox22.Name = "comboBox22";
             this.comboBox22.Size = new System.Drawing.Size(92, 21);
@@ -414,7 +418,7 @@
             // comboBox23
             // 
             this.comboBox23.FormattingEnabled = true;
-            this.comboBox23.Location = new System.Drawing.Point(98, 229);
+            this.comboBox23.Location = new System.Drawing.Point(104, 233);
             this.comboBox23.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox23.Name = "comboBox23";
             this.comboBox23.Size = new System.Drawing.Size(92, 21);
@@ -423,7 +427,7 @@
             // comboBox24
             // 
             this.comboBox24.FormattingEnabled = true;
-            this.comboBox24.Location = new System.Drawing.Point(3, 229);
+            this.comboBox24.Location = new System.Drawing.Point(9, 233);
             this.comboBox24.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox24.Name = "comboBox24";
             this.comboBox24.Size = new System.Drawing.Size(92, 21);
@@ -433,7 +437,7 @@
             // 
             this.label18.AutoSize = true;
             this.label18.ForeColor = System.Drawing.Color.Blue;
-            this.label18.Location = new System.Drawing.Point(496, 115);
+            this.label18.Location = new System.Drawing.Point(502, 119);
             this.label18.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label18.Name = "label18";
             this.label18.Size = new System.Drawing.Size(118, 39);
@@ -443,7 +447,7 @@
             // comboBox25
             // 
             this.comboBox25.FormattingEnabled = true;
-            this.comboBox25.Location = new System.Drawing.Point(383, 43);
+            this.comboBox25.Location = new System.Drawing.Point(389, 47);
             this.comboBox25.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox25.Name = "comboBox25";
             this.comboBox25.Size = new System.Drawing.Size(92, 21);
@@ -453,7 +457,7 @@
             // 
             this.label19.AutoSize = true;
             this.label19.ForeColor = System.Drawing.Color.Blue;
-            this.label19.Location = new System.Drawing.Point(2, 71);
+            this.label19.Location = new System.Drawing.Point(8, 75);
             this.label19.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label19.Name = "label19";
             this.label19.Size = new System.Drawing.Size(79, 13);
@@ -463,7 +467,7 @@
             // comboBox26
             // 
             this.comboBox26.FormattingEnabled = true;
-            this.comboBox26.Location = new System.Drawing.Point(4, 87);
+            this.comboBox26.Location = new System.Drawing.Point(10, 91);
             this.comboBox26.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox26.Name = "comboBox26";
             this.comboBox26.Size = new System.Drawing.Size(92, 21);
@@ -473,7 +477,7 @@
             // 
             this.label20.AutoSize = true;
             this.label20.ForeColor = System.Drawing.Color.Blue;
-            this.label20.Location = new System.Drawing.Point(96, 71);
+            this.label20.Location = new System.Drawing.Point(102, 75);
             this.label20.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label20.Name = "label20";
             this.label20.Size = new System.Drawing.Size(75, 13);
@@ -483,7 +487,7 @@
             // comboBox27
             // 
             this.comboBox27.FormattingEnabled = true;
-            this.comboBox27.Location = new System.Drawing.Point(98, 87);
+            this.comboBox27.Location = new System.Drawing.Point(104, 91);
             this.comboBox27.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox27.Name = "comboBox27";
             this.comboBox27.Size = new System.Drawing.Size(92, 21);
@@ -493,7 +497,7 @@
             // 
             this.label21.AutoSize = true;
             this.label21.ForeColor = System.Drawing.Color.Blue;
-            this.label21.Location = new System.Drawing.Point(191, 71);
+            this.label21.Location = new System.Drawing.Point(197, 75);
             this.label21.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label21.Name = "label21";
             this.label21.Size = new System.Drawing.Size(48, 13);
@@ -503,7 +507,7 @@
             // comboBox28
             // 
             this.comboBox28.FormattingEnabled = true;
-            this.comboBox28.Location = new System.Drawing.Point(194, 87);
+            this.comboBox28.Location = new System.Drawing.Point(200, 91);
             this.comboBox28.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox28.Name = "comboBox28";
             this.comboBox28.Size = new System.Drawing.Size(92, 21);
@@ -513,7 +517,7 @@
             // 
             this.label22.AutoSize = true;
             this.label22.ForeColor = System.Drawing.Color.Blue;
-            this.label22.Location = new System.Drawing.Point(286, 71);
+            this.label22.Location = new System.Drawing.Point(292, 75);
             this.label22.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label22.Name = "label22";
             this.label22.Size = new System.Drawing.Size(72, 13);
@@ -523,7 +527,7 @@
             // comboBox29
             // 
             this.comboBox29.FormattingEnabled = true;
-            this.comboBox29.Location = new System.Drawing.Point(288, 87);
+            this.comboBox29.Location = new System.Drawing.Point(294, 91);
             this.comboBox29.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox29.Name = "comboBox29";
             this.comboBox29.Size = new System.Drawing.Size(92, 21);
@@ -533,7 +537,7 @@
             // 
             this.label23.AutoSize = true;
             this.label23.ForeColor = System.Drawing.Color.Blue;
-            this.label23.Location = new System.Drawing.Point(381, 71);
+            this.label23.Location = new System.Drawing.Point(387, 75);
             this.label23.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label23.Name = "label23";
             this.label23.Size = new System.Drawing.Size(54, 13);
@@ -543,7 +547,7 @@
             // comboBox30
             // 
             this.comboBox30.FormattingEnabled = true;
-            this.comboBox30.Location = new System.Drawing.Point(383, 87);
+            this.comboBox30.Location = new System.Drawing.Point(389, 91);
             this.comboBox30.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox30.Name = "comboBox30";
             this.comboBox30.Size = new System.Drawing.Size(92, 21);
@@ -563,7 +567,7 @@
             // numericUpDown1
             // 
             this.numericUpDown1.DecimalPlaces = 1;
-            this.numericUpDown1.Location = new System.Drawing.Point(498, 229);
+            this.numericUpDown1.Location = new System.Drawing.Point(504, 233);
             this.numericUpDown1.Maximum = new decimal(new int[] {
             20,
             0,
@@ -572,7 +576,7 @@
             this.numericUpDown1.Name = "numericUpDown1";
             this.numericUpDown1.Size = new System.Drawing.Size(76, 20);
             this.numericUpDown1.TabIndex = 64;
-            this.toolTip1.SetToolTip(this.numericUpDown1, "reduce number of edge points");
+            this.toolTip1.SetToolTip(this.numericUpDown1, "reduce number of edge points \r\nnot available, when using 3D Lines (PolylineZ)");
             // 
             // numericUpDown2
             // 
@@ -582,7 +586,7 @@
             0,
             0,
             65536});
-            this.numericUpDown2.Location = new System.Drawing.Point(498, 161);
+            this.numericUpDown2.Location = new System.Drawing.Point(504, 165);
             this.numericUpDown2.Maximum = new decimal(new int[] {
             100000,
             0,
@@ -600,7 +604,7 @@
             // 
             // checkBox2
             // 
-            this.checkBox2.Location = new System.Drawing.Point(580, 161);
+            this.checkBox2.Location = new System.Drawing.Point(586, 165);
             this.checkBox2.Margin = new System.Windows.Forms.Padding(2);
             this.checkBox2.Name = "checkBox2";
             this.checkBox2.Size = new System.Drawing.Size(64, 20);
@@ -613,7 +617,7 @@
             // 
             this.label6.AutoSize = true;
             this.label6.ForeColor = System.Drawing.Color.Blue;
-            this.label6.Location = new System.Drawing.Point(496, 194);
+            this.label6.Location = new System.Drawing.Point(502, 198);
             this.label6.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label6.Name = "label6";
             this.label6.Size = new System.Drawing.Size(89, 26);
@@ -624,7 +628,7 @@
             // 
             this.label7.AutoSize = true;
             this.label7.ForeColor = System.Drawing.Color.Blue;
-            this.label7.Location = new System.Drawing.Point(579, 232);
+            this.label7.Location = new System.Drawing.Point(585, 236);
             this.label7.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label7.Name = "label7";
             this.label7.Size = new System.Drawing.Size(21, 13);
@@ -634,7 +638,7 @@
             // comboBox31
             // 
             this.comboBox31.FormattingEnabled = true;
-            this.comboBox31.Location = new System.Drawing.Point(479, 43);
+            this.comboBox31.Location = new System.Drawing.Point(485, 47);
             this.comboBox31.Margin = new System.Windows.Forms.Padding(2);
             this.comboBox31.Name = "comboBox31";
             this.comboBox31.Size = new System.Drawing.Size(92, 21);
@@ -644,19 +648,41 @@
             // 
             this.label8.AutoSize = true;
             this.label8.ForeColor = System.Drawing.Color.Blue;
-            this.label8.Location = new System.Drawing.Point(479, 27);
+            this.label8.Location = new System.Drawing.Point(485, 31);
             this.label8.Margin = new System.Windows.Forms.Padding(2, 0, 2, 0);
             this.label8.Name = "label8";
             this.label8.Size = new System.Drawing.Size(90, 13);
             this.label8.TabIndex = 68;
             this.label8.Text = "Vertical extension";
             // 
+            // checkBox3
+            // 
+            this.checkBox3.ForeColor = System.Drawing.Color.Blue;
+            this.checkBox3.Location = new System.Drawing.Point(384, 4);
+            this.checkBox3.Name = "checkBox3";
+            this.checkBox3.Size = new System.Drawing.Size(104, 21);
+            this.checkBox3.TabIndex = 63;
+            this.checkBox3.Text = "3D Line";
+            this.toolTip1.SetToolTip(this.checkBox3, "Use PolylineZ from the shape file");
+            this.checkBox3.UseVisualStyleBackColor = true;
+            // 
+            // button4
+            // 
+            this.button4.Location = new System.Drawing.Point(505, 268);
+            this.button4.Margin = new System.Windows.Forms.Padding(2);
+            this.button4.Name = "button4";
+            this.button4.Size = new System.Drawing.Size(94, 24);
+            this.button4.TabIndex = 0;
+            this.button4.Text = "&Cancel";
+            this.button4.UseVisualStyleBackColor = true;
+            this.button4.Click += new System.EventHandler(this.button4_Click);
+            // 
             // ShapeLineDialog
             // 
             this.AcceptButton = this.button1;
             this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(646, 549);
+            this.ClientSize = new System.Drawing.Size(761, 622);
             this.ControlBox = false;
             this.Controls.Add(this.checkBox2);
             this.Controls.Add(this.numericUpDown2);
@@ -665,6 +691,7 @@
             this.Controls.Add(this.label7);
             this.Controls.Add(this.label6);
             this.Controls.Add(this.numericUpDown1);
+            this.Controls.Add(this.checkBox3);
             this.Controls.Add(this.checkBox1);
             this.Controls.Add(this.label23);
             this.Controls.Add(this.comboBox30);
@@ -712,6 +739,7 @@
             this.Controls.Add(this.label1);
             this.Controls.Add(this.comboBox1);
             this.Controls.Add(this.dataGridView1);
+            this.Controls.Add(this.button4);
             this.Controls.Add(this.button1);
             this.Margin = new System.Windows.Forms.Padding(2);
             this.Name = "ShapeLineDialog";
@@ -784,5 +812,7 @@
         private System.Windows.Forms.ComboBox comboBox29;
         private System.Windows.Forms.Label label23;
         private System.Windows.Forms.ComboBox comboBox30;
+        private System.Windows.Forms.CheckBox checkBox3;
+        private System.Windows.Forms.Button button4;
     }
 }

--- a/Source/Gral/GRALShapeFiles/ShapeLineDialog.cs
+++ b/Source/Gral/GRALShapeFiles/ShapeLineDialog.cs
@@ -542,7 +542,7 @@ namespace GralShape
 							
 							for (int di = 0; di < 10; di++) // save deposition
 							{
-								_ls.Dep[di] = dep[di];
+								_ls.GetDep()[di] = dep[di];
 							}
 							
 							domain.EditLS.ItemData.Add(_ls);

--- a/Source/Gral/GRALShapeFiles/ShapeLineDialog.resx
+++ b/Source/Gral/GRALShapeFiles/ShapeLineDialog.resx
@@ -118,6 +118,6 @@
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
+    <value>17, 21</value>
   </metadata>
 </root>

--- a/Source/Gral/GRALShapeFiles/ShapePointDialog.cs
+++ b/Source/Gral/GRALShapeFiles/ShapePointDialog.cs
@@ -294,7 +294,7 @@ namespace GralShape
 							
 							for (int di = 0; di < 10; di++) // save deposition
 							{
-								_psdata.Dep[di] = dep[di];
+								_psdata.GetDep()[di] = dep[di];
 							}
 							
 							domain.EditPS.ItemData.Add(_psdata);

--- a/Source/Gral/GRALShapeFiles/Shapereader.cs
+++ b/Source/Gral/GRALShapeFiles/Shapereader.cs
@@ -38,8 +38,7 @@ namespace GralShape
 		public double PixelMx {get {return _pixelmx;}}
 		private int _pixelmy;
 		public int PixelMy {get {return _pixelmy;}}
-		
-		
+
 		public ShapeReader(GralDomain.Domain d)
 		{
 			domain = d;
@@ -139,7 +138,8 @@ namespace GralShape
 					//domain.shplines[index].Add(line);
 					yield return line;
 				}
-				if (shapetype == 13)
+
+				if (shapetype == 13) // PolylineZ
 				{
 					SHPLine line = new SHPLine();
 					int recordShapeType = readIntLittle(data, recordContentStart);
@@ -152,21 +152,27 @@ namespace GralShape
 					line.Parts = new int[line.NumParts];
 					line.NumPoints = readIntLittle(data, recordContentStart + 40);
 					line.Points = new GralDomain.PointD[line.NumPoints];
+					line.PointsZ = new double[line.NumPoints];
+
 					int partStart = recordContentStart + 44;
 					for (int i = 0; i < line.NumParts; i++)
 					{
 						line.Parts[i] = readIntLittle(data, partStart + i * 4);
 					}
-					int pointStart = recordContentStart + 44 + 4 * line.NumParts;
 
-					for (int i = 0; i < line.NumPoints; i++)
+                    int pointStart = recordContentStart + 44 + 4 * line.NumParts;
+                    for (int i = 0; i < line.NumPoints; i++)
 					{
 						line.Points[i].X = readDoubleLittle(data, pointStart + (i * 16));
-						line.Points[i].Y = readDoubleLittle(data, pointStart + (i * 16) + 8);
+						int index = pointStart + (i * 16) + 8;
+						line.Points[i].Y = readDoubleLittle(data, index);
+						index = pointStart + 16 * line.NumPoints + 16 + 8 * i;
+						line.PointsZ[i]  = readDoubleLittle(data, index);
 					}
 					//domain.shplines[index].Add(line);
 					yield return line;
                 }
+
                 if (shapetype == 23)
                 {
                     GralShape.SHPLine line = new GralShape.SHPLine();

--- a/Source/Gral/GRALStaticFunctions/StaticFunctions.cs
+++ b/Source/Gral/GRALStaticFunctions/StaticFunctions.cs
@@ -337,12 +337,35 @@ namespace GralStaticFunctions
             //MessageBox.Show(this, "Number of vertices is below 3\t\nNo area could be computed");
             return Math.Round(lenght, 1);
         }
-        
         //compute lenght of a polygon
         /// <summary>
     	/// Compute the lenght of a polyline
     	/// </summary>
-    	/// <param name="polypoints">List of PointD with polygon points</param>
+    	/// <param name="numpoints">Number of points in the array</param> 
+    	/// <param name="polypoints">Array for polygon points</param> 
+        public static double CalcLenght(int numpoints, GralData.PointD_3d[] polypoints)
+        {
+            double lenght = 0;
+            if (numpoints > 1 && numpoints < (polypoints.Length - 1))
+            {
+                polypoints[numpoints] = polypoints[0];
+                for (int i = 0; i < numpoints - 1; i++)
+                {
+                    lenght += Math.Sqrt(Math.Pow(polypoints[i].X - polypoints[i + 1].X, 2) + 
+                                        Math.Pow(polypoints[i].Y - polypoints[i + 1].Y, 2) +
+                                        Math.Pow(polypoints[i].Z - polypoints[i + 1].Z, 2));
+                }
+            }
+            //else
+            //MessageBox.Show(this, "Number of vertices is below 3\t\nNo area could be computed");
+            return Math.Round(lenght, 1);
+        }
+
+        //compute lenght of a polygon
+        /// <summary>
+        /// Compute the lenght of a polyline
+        /// </summary>
+        /// <param name="polypoints">List of PointD with polygon points</param>
         public static double CalcLenght(List <GralDomain.PointD> polypoints)
         {
             double lenght = 0;
@@ -351,6 +374,27 @@ namespace GralStaticFunctions
                 for (int i = 0; i < polypoints.Count - 1; i++)
                 {
                 	lenght += Math.Sqrt(Math.Pow(polypoints[i].X - polypoints[i + 1].X, 2) + Math.Pow(polypoints[i].Y - polypoints[i + 1].Y, 2));
+                }
+            }
+            //else
+            //MessageBox.Show(this, "Number of vertices is below 3\t\nNo area could be computed");
+            return Math.Round(lenght, 1);
+        }
+        //compute lenght of a polygon
+        /// <summary>
+        /// Compute the lenght of a polyline
+        /// </summary>
+        /// <param name="polypoints">List of PointD_3D with polygon points</param>
+        public static double CalcLenght(List<GralData.PointD_3d> polypoints)
+        {
+            double lenght = 0;
+            if (polypoints.Count > 1)
+            {
+                for (int i = 0; i < polypoints.Count - 1; i++)
+                {
+                    lenght += Math.Sqrt(Math.Pow(polypoints[i].X - polypoints[i + 1].X, 2) + 
+                                        Math.Pow(polypoints[i].Y - polypoints[i + 1].Y, 2) +
+                                        Math.Pow(polypoints[i].Z - polypoints[i + 1].Z, 2));
                 }
             }
             //else

--- a/Source/Gral/Gral.csproj
+++ b/Source/Gral/Gral.csproj
@@ -821,6 +821,12 @@
     <Compile Include="GRALMainSubForms\Windclasses.Designer.cs">
       <DependentUpon>Windclasses.cs</DependentUpon>
     </Compile>
+    <Compile Include="GRALMainSubForms\WindDistribution.cs">
+      <SubType>Form</SubType>
+    </Compile>
+    <Compile Include="GRALMainSubForms\WindDistribution.Designer.cs">
+      <DependentUpon>WindDistribution.cs</DependentUpon>
+    </Compile>
     <Compile Include="GRALMainSubForms\Windrose.cs">
       <SubType>Form</SubType>
     </Compile>
@@ -1149,6 +1155,9 @@
     </EmbeddedResource>
     <EmbeddedResource Include="GRALMainSubForms\VerticalLayerHeights.resx">
       <DependentUpon>VerticalLayerHeights.cs</DependentUpon>
+    </EmbeddedResource>
+    <EmbeddedResource Include="GRALMainSubForms\WindDistribution.resx">
+      <DependentUpon>WindDistribution.cs</DependentUpon>
     </EmbeddedResource>
     <EmbeddedResource Include="GRALMainSubForms\Windrose.resx">
       <SubType>Designer</SubType>

--- a/Source/Gral/Gral.csproj
+++ b/Source/Gral/Gral.csproj
@@ -240,6 +240,9 @@
     <Compile Include="GRALDomain\DrawMap\Domain_DrawConcentrationValues.cs">
       <SubType>Form</SubType>
     </Compile>
+    <Compile Include="GRALDomain\DrawMap\Domain_DrawItemInfos.cs">
+      <SubType>Form</SubType>
+    </Compile>
     <Compile Include="GRALDomain\DrawMap\Domain_DrawRubberLines.cs">
       <SubType>Form</SubType>
     </Compile>

--- a/Source/Gral/Main.Designer.cs
+++ b/Source/Gral/Main.Designer.cs
@@ -981,7 +981,7 @@
             this.numericUpDown5.TabIndex = 4;
             this.numericUpDown5.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             this.toolTip1.SetToolTip(this.numericUpDown5, "Start the calculation with that dispersion situation\r\nThis option is not availabl" +
-        "e at transient calculations");
+        "e for transient calculations");
             this.numericUpDown5.Value = new decimal(new int[] {
             1,
             0,

--- a/Source/Gral/Main.Designer.cs
+++ b/Source/Gral/Main.Designer.cs
@@ -2945,6 +2945,7 @@
             this.groupBox25.TabIndex = 60;
             this.groupBox25.TabStop = false;
             this.groupBox25.Text = "ECMWF coupling";
+            this.groupBox25.Visible = false;
             // 
             // numericUpDown44
             // 

--- a/Source/Gral/Main.Designer.cs
+++ b/Source/Gral/Main.Designer.cs
@@ -195,6 +195,7 @@
             this.button5 = new System.Windows.Forms.Button();
             this.button4 = new System.Windows.Forms.Button();
             this.button3 = new System.Windows.Forms.Button();
+            this.button56 = new System.Windows.Forms.Button();
             this.button2 = new System.Windows.Forms.Button();
             this.button1 = new System.Windows.Forms.Button();
             this.OpenMetFile = new System.Windows.Forms.Button();
@@ -2806,6 +2807,7 @@
             this.groupBox1.Controls.Add(this.button5);
             this.groupBox1.Controls.Add(this.button4);
             this.groupBox1.Controls.Add(this.button3);
+            this.groupBox1.Controls.Add(this.button56);
             this.groupBox1.Controls.Add(this.button2);
             this.groupBox1.Controls.Add(this.button1);
             this.groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 10F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
@@ -2820,7 +2822,7 @@
             // button39
             // 
             this.button39.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button39.Location = new System.Drawing.Point(8, 68);
+            this.button39.Location = new System.Drawing.Point(8, 60);
             this.button39.Name = "button39";
             this.button39.Size = new System.Drawing.Size(116, 34);
             this.button39.TabIndex = 5;
@@ -2832,7 +2834,7 @@
             // button5
             // 
             this.button5.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button5.Location = new System.Drawing.Point(9, 246);
+            this.button5.Location = new System.Drawing.Point(9, 250);
             this.button5.Name = "button5";
             this.button5.Size = new System.Drawing.Size(116, 34);
             this.button5.TabIndex = 9;
@@ -2844,7 +2846,7 @@
             // button4
             // 
             this.button4.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button4.Location = new System.Drawing.Point(9, 203);
+            this.button4.Location = new System.Drawing.Point(9, 212);
             this.button4.Name = "button4";
             this.button4.Size = new System.Drawing.Size(116, 34);
             this.button4.TabIndex = 8;
@@ -2856,7 +2858,7 @@
             // button3
             // 
             this.button3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button3.Location = new System.Drawing.Point(9, 158);
+            this.button3.Location = new System.Drawing.Point(9, 174);
             this.button3.Name = "button3";
             this.button3.Size = new System.Drawing.Size(116, 34);
             this.button3.TabIndex = 7;
@@ -2865,10 +2867,21 @@
             this.button3.UseVisualStyleBackColor = true;
             this.button3.Click += new System.EventHandler(this.ShowWindDirectionFrequency_Click);
             // 
+            // button56
+            // 
+            this.button56.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.button56.Location = new System.Drawing.Point(9, 136);
+            this.button56.Name = "button56";
+            this.button56.Size = new System.Drawing.Size(116, 34);
+            this.button56.TabIndex = 6;
+            this.button56.Text = "&Vel. classes distr.";
+            this.button56.UseVisualStyleBackColor = true;
+            this.button56.Click += new System.EventHandler(this.ShowWindVelocityClassesDistr_Click);
+            // 
             // button2
             // 
             this.button2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button2.Location = new System.Drawing.Point(9, 113);
+            this.button2.Location = new System.Drawing.Point(9, 98);
             this.button2.Name = "button2";
             this.button2.Size = new System.Drawing.Size(116, 34);
             this.button2.TabIndex = 6;
@@ -2880,7 +2893,7 @@
             // button1
             // 
             this.button1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button1.Location = new System.Drawing.Point(9, 24);
+            this.button1.Location = new System.Drawing.Point(9, 22);
             this.button1.Name = "button1";
             this.button1.Size = new System.Drawing.Size(116, 34);
             this.button1.TabIndex = 4;
@@ -5518,6 +5531,7 @@
         private System.Windows.Forms.NumericUpDown numericUpDown40;
         private System.Windows.Forms.NumericUpDown numericUpDown37;
         private System.Windows.Forms.NumericUpDown numericUpDown44;
+        private System.Windows.Forms.Button button56;
     }
 }
 

--- a/Source/Gral/Main.Designer.cs
+++ b/Source/Gral/Main.Designer.cs
@@ -2945,7 +2945,6 @@
             this.groupBox25.TabIndex = 60;
             this.groupBox25.TabStop = false;
             this.groupBox25.Text = "ECMWF coupling";
-            this.groupBox25.Visible = false;
             // 
             // numericUpDown44
             // 
@@ -3040,7 +3039,7 @@
             // 
             // numericUpDown40
             // 
-            this.numericUpDown40.Location = new System.Drawing.Point(99, 65);
+            this.numericUpDown40.Location = new System.Drawing.Point(141, 65);
             this.numericUpDown40.Maximum = new decimal(new int[] {
             1000000,
             0,
@@ -5488,10 +5487,7 @@
         private System.Windows.Forms.GroupBox groupBox25;
         private System.Windows.Forms.Label label62;
         private System.Windows.Forms.Label label35;
-        public System.Windows.Forms.CheckBox checkBox35;
-        public System.Windows.Forms.NumericUpDown numericUpDown40;
         private System.Windows.Forms.Label label63;
-        public System.Windows.Forms.DateTimePicker dateTimePicker1;
         private System.Windows.Forms.ListView listView2;
         private System.Windows.Forms.ColumnHeader SG_Number_List;
         private System.Windows.Forms.ColumnHeader SG_Name_List;
@@ -5514,10 +5510,13 @@
         private System.Windows.Forms.Timer timer1;
         private System.Windows.Forms.CheckBox checkBox29;
         private System.Windows.Forms.Button button55;
-        public System.Windows.Forms.NumericUpDown numericUpDown37;
         private System.Windows.Forms.Label label5;
-        public System.Windows.Forms.NumericUpDown numericUpDown44;
         private System.Windows.Forms.Label label99;
+        private System.Windows.Forms.DateTimePicker dateTimePicker1;
+        private System.Windows.Forms.CheckBox checkBox35;
+        private System.Windows.Forms.NumericUpDown numericUpDown40;
+        private System.Windows.Forms.NumericUpDown numericUpDown37;
+        private System.Windows.Forms.NumericUpDown numericUpDown44;
     }
 }
 

--- a/Source/Gral/Main.cs
+++ b/Source/Gral/Main.cs
@@ -279,7 +279,7 @@ namespace Gral
         private GralDomain.DomainformClosed DomainClosedHandle;
 
         /// <summary>
-        /// Start the Main Form of this application
+        /// Start the main form of this application
         /// </summary>
         public Main()
         {
@@ -447,7 +447,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Close the Application
+        /// Close the application
         /// </summary>
         void MainFormClosing(object sender, FormClosingEventArgs e)
         {
@@ -850,7 +850,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Save pollutant information in File Pollutant.txt including wet deposition and the decay rate to computation folder
+        /// Save pollutant information in the file Pollutant.txt including wet deposition and the decay rate to computation folder
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -1006,7 +1006,7 @@ namespace Gral
             }
         }
 
-        //Wait for Keystroke when GRAL is finished
+        //Wait for a keystroke when GRAL has been finished?
         private void checkBox29_CheckedChanged(object sender, EventArgs e)
         {
             GRALSettings.WaitForKeyStroke = checkBox29.Checked;
@@ -1754,7 +1754,7 @@ namespace Gral
         }
         
         /// <summary>
-		/// Check if the most important files for a GRAL computation are available and enable/disable GRAL simulations
+		/// Check if the most important input files for a GRAL computation are available and enable/disable GRAL simulations
 		/// </summary>
 		public void Enable_GRAL()
         {
@@ -1838,7 +1838,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Save comments 
+        /// Save user comments 
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -1921,7 +1921,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Update file size information every 120 seconds for intermediate GRAL files (con and gff)
+        /// Update file size information every 120 seconds for intermediate GRAL files (*.con and *.gff)
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -1931,7 +1931,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Get *.con, *.gff and *.wnd file size and write it to the main form
+        /// Get *.con, *.gff and *.wnd file size and display it in the main form
         /// </summary>
         private void GralFileSizes()
         {
@@ -2435,7 +2435,7 @@ namespace Gral
                 }
                 if (checkBox32.Checked) // GRAL Transient mode
                 {
-                    groupBox27.Text = "Emission-time-series (mandatory)";
+                    groupBox27.Text = "Emission-time-series (mandatory - transient mode)";
                 }
                 else
                 {
@@ -2771,7 +2771,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Save comments
+        /// Save user comments
         /// </summary>
         private void Button38_Click_1(object sender, EventArgs e)
         {
@@ -2788,7 +2788,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Compression mode for GRAL result files
+        /// Set the compression mode for GRAL result files
         /// </summary>
         private void numericUpDown43_ValueChanged(object sender, EventArgs e)
         {
@@ -2929,7 +2929,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Enable transient GRAL simulations
+        /// Enable the Transient GRAL mode
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -2970,7 +2970,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Set cut-off concentration in transient simulations
+        /// Set the cut-off concentration for transient simulations
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3071,7 +3071,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// OPen the GUI settings form
+        /// Open the GUI settings form
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3087,7 +3087,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Load and show Log File
+        /// Load and show log file
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3156,7 +3156,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Set the compression rate for *.gff files
+        /// Set the compression type for *.gff files
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3169,7 +3169,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Set a flexible vertical stretching factor
+        /// Set a flexible vertical stretching factor for the flow field grid
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3229,7 +3229,7 @@ namespace Gral
         }
 
         /// <summary>
-        /// Show the vertical layer heights
+        /// Show the vertical flow field grid layer heights
         /// </summary>
         /// <param name="sender"></param>
         /// <param name="e"></param>
@@ -3249,6 +3249,11 @@ namespace Gral
             }
         }
 
+        /// <summary>
+        /// Show a simple App info form
+        /// </summary>
+        /// <param name="sender"></param>
+        /// <param name="e"></param>
         private void button55_Click(object sender, EventArgs e)
         {
             bool open = false;

--- a/Source/Gral/Main.cs
+++ b/Source/Gral/Main.cs
@@ -430,8 +430,8 @@ namespace Gral
         }
         
         /// <summary>
-		/// Get all control item of the type T
-		/// </summary>
+        /// Get all control item of the type T
+        /// </summary>
         public static IList<T> GetAllControls<T>(Control control) where T : Control
         {
             var lst = new List<T>();
@@ -763,8 +763,8 @@ namespace Gral
 
         //save settings of meteorological input data
         /// <summary>
-		/// Save the file Meteorology.txt in the settings folder
-		/// </summary>
+        /// Save the file Meteorology.txt in the settings folder
+        /// </summary>
         public void SaveMeteoDataFile()
         {
             string newPath = Path.Combine(ProjectName, @"Settings", "Meteorology.txt");
@@ -996,10 +996,10 @@ namespace Gral
 
             InDatVariables indattemp = new InDatVariables();
             InDatFileIO InDataIO = new InDatFileIO();
-			indattemp.InDatPath = Path.Combine(ProjectName, "Computation", "in.dat");
+            indattemp.InDatPath = Path.Combine(ProjectName, "Computation", "in.dat");
 
-			InDataIO.Data = indattemp;
-			if (InDataIO.ReadInDat() == true)
+            InDataIO.Data = indattemp;
+            if (InDataIO.ReadInDat() == true)
             {
                 indattemp.DispersionSituation = GRALSettings.DispersionSituation;
                 InDataIO.WriteInDat();
@@ -1126,8 +1126,8 @@ namespace Gral
 
         //delete the file "in.dat" whenever a value is changed
         /// <summary>
-		/// Delete the file "in.dat" whenever a value is changed
-		/// </summary>
+        /// Delete the file "in.dat" whenever a value is changed
+        /// </summary>
         private void ResetInDat()
         {
             if (IndatReset == true)
@@ -1464,171 +1464,171 @@ namespace Gral
             #if __MonoCS__
             MessageBox.Show("This function is not available at LINUX", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
             #else
-			try
-			{
-				Nemo NemoWork = new Main.Nemo();
-				//source group seperation
-				GralMainForms.Nemostartwindow nemo = new GralMainForms.Nemostartwindow(this);
-				DialogResult dr = new DialogResult();
-				dr = nemo.ShowDialog();
-				string [] text=new string[2];
-				int sg1=1;
-				int sg2=1;
-				int sg3=1;
-				int sg4=1;
-				if (dr == DialogResult.OK)
-				{
-				}
-				//check, whether source seperation has been chosen or not
-				if (nemo.checkBox1.Checked == true)
-				{
-					//generate NEMO input files
-					text = nemo.comboBox1.Text.Split(new char[] { ',' });
-					try
-					{
-						sg1 = Convert.ToInt32(text[1].Replace(" ", ""));
-					}
-					catch
-					{
-						sg1 = Convert.ToInt32(text[0]);
-					}
-					text = nemo.comboBox4.Text.Split(new char[] { ',' });
-					try
-					{
-						sg2 = Convert.ToInt32(text[1].Replace(" ", ""));
-					}
-					catch
-					{
-						sg2 = Convert.ToInt32(text[0]);
-					}
-					text = nemo.comboBox2.Text.Split(new char[] { ',' });
-					try
-					{
-						sg3 = Convert.ToInt32(text[1].Replace(" ", ""));
-					}
-					catch
-					{
-						sg3 = Convert.ToInt32(text[0]);
-					}
-					text = nemo.comboBox3.Text.Split(new char[] { ',' });
-					try
-					{
-						sg4 = Convert.ToInt32(text[1].Replace(" ", ""));
-					}
-					catch
-					{
-						sg4 = Convert.ToInt32(text[0]);
-					}
-					NemoWork.NemoInput(true, sg1, sg2, sg3, sg4);
-				}
-				else
-				{
-					//generate NEMO input files
-					NemoWork.NemoInput(false, sg1, sg2, sg3, sg4);
-				}
-				NemoWork = null;
-				if (nemo != null)
-				{
-					nemo.Close();
-					nemo.Dispose();
-				}
-			}
-			catch
-			{
-				//MessageBox.Show (ex.Message);
-			}
+            try
+            {
+                Nemo NemoWork = new Main.Nemo();
+                //source group seperation
+                GralMainForms.Nemostartwindow nemo = new GralMainForms.Nemostartwindow(this);
+                DialogResult dr = new DialogResult();
+                dr = nemo.ShowDialog();
+                string [] text=new string[2];
+                int sg1=1;
+                int sg2=1;
+                int sg3=1;
+                int sg4=1;
+                if (dr == DialogResult.OK)
+                {
+                }
+                //check, whether source seperation has been chosen or not
+                if (nemo.checkBox1.Checked == true)
+                {
+                    //generate NEMO input files
+                    text = nemo.comboBox1.Text.Split(new char[] { ',' });
+                    try
+                    {
+                        sg1 = Convert.ToInt32(text[1].Replace(" ", ""));
+                    }
+                    catch
+                    {
+                        sg1 = Convert.ToInt32(text[0]);
+                    }
+                    text = nemo.comboBox4.Text.Split(new char[] { ',' });
+                    try
+                    {
+                        sg2 = Convert.ToInt32(text[1].Replace(" ", ""));
+                    }
+                    catch
+                    {
+                        sg2 = Convert.ToInt32(text[0]);
+                    }
+                    text = nemo.comboBox2.Text.Split(new char[] { ',' });
+                    try
+                    {
+                        sg3 = Convert.ToInt32(text[1].Replace(" ", ""));
+                    }
+                    catch
+                    {
+                        sg3 = Convert.ToInt32(text[0]);
+                    }
+                    text = nemo.comboBox3.Text.Split(new char[] { ',' });
+                    try
+                    {
+                        sg4 = Convert.ToInt32(text[1].Replace(" ", ""));
+                    }
+                    catch
+                    {
+                        sg4 = Convert.ToInt32(text[0]);
+                    }
+                    NemoWork.NemoInput(true, sg1, sg2, sg3, sg4);
+                }
+                else
+                {
+                    //generate NEMO input files
+                    NemoWork.NemoInput(false, sg1, sg2, sg3, sg4);
+                }
+                NemoWork = null;
+                if (nemo != null)
+                {
+                    nemo.Close();
+                    nemo.Dispose();
+                }
+            }
+            catch
+            {
+                //MessageBox.Show (ex.Message);
+            }
             #endif
         }
 
         /// <summary>
-		/// Temporary input box
-		/// </summary>
+        /// Temporary input box
+        /// </summary>
         private DialogResult InputBox1(string title, string promptText, int lowlimit, int uplimit, ref int trans)
         {
-        	DialogResult dialogResult = DialogResult.Cancel;
-        	using (Form form = new Form())
-        	{
-        		Label label = new Label();
-        		NumericUpDown numdown = new NumericUpDown();
-        		Button buttonOk = new Button();
-        		Button buttonCancel = new Button();
-        		form.Text = title;
-        		label.Text = promptText;
-        		numdown.Maximum = uplimit;
-        		numdown.Minimum = lowlimit;
-        		numdown.Value = trans;
-        		numdown.Increment = 1;
-        		buttonOk.Text = "OK";
-        		buttonCancel.Text = "Cancel";
-        		buttonOk.DialogResult = DialogResult.OK;
-        		buttonCancel.DialogResult = DialogResult.Cancel;
-        		label.SetBounds(9, 10, 372, 13);
-        		numdown.SetBounds(12, 36, 372, 20);
-        		buttonOk.SetBounds(228, 72, 75, 23);
-        		buttonCancel.SetBounds(309, 72, 75, 23);
-        		label.AutoSize = true;
-        		numdown.Anchor = numdown.Anchor | AnchorStyles.Right;
-        		buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-        		buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-        		form.ClientSize = new Size(396, 107);
-        		form.Controls.AddRange(new Control[] { label, numdown, buttonOk, buttonCancel });
-        		form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
-        		form.FormBorderStyle = FormBorderStyle.FixedDialog;
-        		form.StartPosition = FormStartPosition.CenterScreen;
-        		form.MinimizeBox = false;
-        		form.MaximizeBox = false;
-        		form.AcceptButton = buttonOk;
-        		form.CancelButton = buttonCancel;
-        		dialogResult = form.ShowDialog();
-        		trans = Convert.ToInt32(numdown.Value);
-        	}
-        	return dialogResult;
+            DialogResult dialogResult = DialogResult.Cancel;
+            using (Form form = new Form())
+            {
+                Label label = new Label();
+                NumericUpDown numdown = new NumericUpDown();
+                Button buttonOk = new Button();
+                Button buttonCancel = new Button();
+                form.Text = title;
+                label.Text = promptText;
+                numdown.Maximum = uplimit;
+                numdown.Minimum = lowlimit;
+                numdown.Value = trans;
+                numdown.Increment = 1;
+                buttonOk.Text = "OK";
+                buttonCancel.Text = "Cancel";
+                buttonOk.DialogResult = DialogResult.OK;
+                buttonCancel.DialogResult = DialogResult.Cancel;
+                label.SetBounds(9, 10, 372, 13);
+                numdown.SetBounds(12, 36, 372, 20);
+                buttonOk.SetBounds(228, 72, 75, 23);
+                buttonCancel.SetBounds(309, 72, 75, 23);
+                label.AutoSize = true;
+                numdown.Anchor = numdown.Anchor | AnchorStyles.Right;
+                buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                form.ClientSize = new Size(396, 107);
+                form.Controls.AddRange(new Control[] { label, numdown, buttonOk, buttonCancel });
+                form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.AcceptButton = buttonOk;
+                form.CancelButton = buttonCancel;
+                dialogResult = form.ShowDialog();
+                trans = Convert.ToInt32(numdown.Value);
+            }
+            return dialogResult;
         }
         
         /// <summary>
-		/// Temporary input box for floating values
-		/// </summary>
-		private DialogResult InputBox2(string title, string promptText, decimal lowlimit, decimal uplimit, ref decimal trans)
+        /// Temporary input box for floating values
+        /// </summary>
+        private DialogResult InputBox2(string title, string promptText, decimal lowlimit, decimal uplimit, ref decimal trans)
         {
-        	DialogResult dialogResult = DialogResult.Cancel;
-        	using (Form form = new Form())
-        	{
-        		Label label = new Label();
-        		NumericUpDown numdown = new NumericUpDown();
-        		Button buttonOk = new Button();
-        		Button buttonCancel = new Button();
-        		form.Text = title;
-        		label.Text = promptText;
-        		numdown.Maximum = uplimit;
-        		numdown.Minimum = lowlimit;
-        		numdown.Value = trans;
-        		numdown.Increment = 0.1M;
-        		numdown.DecimalPlaces = 1;
-        		buttonOk.Text = "OK";
-        		buttonCancel.Text = "Cancel";
-        		buttonOk.DialogResult = DialogResult.OK;
-        		buttonCancel.DialogResult = DialogResult.Cancel;
-        		label.SetBounds(9, 10, 372, 13);
-        		numdown.SetBounds(12, 36, 372, 20);
-        		buttonOk.SetBounds(228, 72, 75, 23);
-        		buttonCancel.SetBounds(309, 72, 75, 23);
-        		label.AutoSize = true;
-        		numdown.Anchor = numdown.Anchor | AnchorStyles.Right;
-        		buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-        		buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
-        		form.ClientSize = new Size(396, 107);
-        		form.Controls.AddRange(new Control[] { label, numdown, buttonOk, buttonCancel });
-        		form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
-        		form.FormBorderStyle = FormBorderStyle.FixedDialog;
-        		form.StartPosition = FormStartPosition.CenterScreen;
-        		form.MinimizeBox = false;
-        		form.MaximizeBox = false;
-        		form.AcceptButton = buttonOk;
-        		form.CancelButton = buttonCancel;
-        		dialogResult = form.ShowDialog();
-        		trans = numdown.Value;
-        	}
-        	return dialogResult;
+            DialogResult dialogResult = DialogResult.Cancel;
+            using (Form form = new Form())
+            {
+                Label label = new Label();
+                NumericUpDown numdown = new NumericUpDown();
+                Button buttonOk = new Button();
+                Button buttonCancel = new Button();
+                form.Text = title;
+                label.Text = promptText;
+                numdown.Maximum = uplimit;
+                numdown.Minimum = lowlimit;
+                numdown.Value = trans;
+                numdown.Increment = 0.1M;
+                numdown.DecimalPlaces = 1;
+                buttonOk.Text = "OK";
+                buttonCancel.Text = "Cancel";
+                buttonOk.DialogResult = DialogResult.OK;
+                buttonCancel.DialogResult = DialogResult.Cancel;
+                label.SetBounds(9, 10, 372, 13);
+                numdown.SetBounds(12, 36, 372, 20);
+                buttonOk.SetBounds(228, 72, 75, 23);
+                buttonCancel.SetBounds(309, 72, 75, 23);
+                label.AutoSize = true;
+                numdown.Anchor = numdown.Anchor | AnchorStyles.Right;
+                buttonOk.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                buttonCancel.Anchor = AnchorStyles.Bottom | AnchorStyles.Right;
+                form.ClientSize = new Size(396, 107);
+                form.Controls.AddRange(new Control[] { label, numdown, buttonOk, buttonCancel });
+                form.ClientSize = new Size(Math.Max(300, label.Right + 10), form.ClientSize.Height);
+                form.FormBorderStyle = FormBorderStyle.FixedDialog;
+                form.StartPosition = FormStartPosition.CenterScreen;
+                form.MinimizeBox = false;
+                form.MaximizeBox = false;
+                form.AcceptButton = buttonOk;
+                form.CancelButton = buttonCancel;
+                dialogResult = form.ShowDialog();
+                trans = numdown.Value;
+            }
+            return dialogResult;
         }
 
         /// <summary>
@@ -1754,9 +1754,9 @@ namespace Gral
         }
         
         /// <summary>
-		/// Check if the most important input files for a GRAL computation are available and enable/disable GRAL simulations
-		/// </summary>
-		public void Enable_GRAL()
+        /// Check if the most important input files for a GRAL computation are available and enable/disable GRAL simulations
+        /// </summary>
+        public void Enable_GRAL()
         {
             //enable/disable GRAL simulations
             bool enable = true;
@@ -1811,9 +1811,9 @@ namespace Gral
         }
         
         /// <summary>
-		/// Check if all files for a GRAMM computation are available and enable/disable GRAMM simulations
-		/// </summary>
-		public void Enable_GRAMM()
+        /// Check if all files for a GRAMM computation are available and enable/disable GRAMM simulations
+        /// </summary>
+        public void Enable_GRAMM()
         {
             //enable/disable GRAMM simulations
             bool enable = true;
@@ -2050,12 +2050,12 @@ namespace Gral
         /// <param name="e"></param>
         private void Button43_Click(object sender, EventArgs e)
         {
-        	GralMainForms.Amend_Landuse AL = new GralMainForms.Amend_Landuse()
-        	{
-        		Owner = this,
-        		StartPosition = FormStartPosition.Manual,
-        		Location = new System.Drawing.Point(this.Left, this.Top)
-        	};
+            GralMainForms.Amend_Landuse AL = new GralMainForms.Amend_Landuse()
+            {
+                Owner = this,
+                StartPosition = FormStartPosition.Manual,
+                Location = new System.Drawing.Point(this.Left, this.Top)
+            };
             AL.Show();
         }
 
@@ -2584,28 +2584,28 @@ namespace Gral
                 // activate FileSystemWatcher
                 #if __MonoCS__
                 #else
-				if (percentGRAL != null && Directory.Exists(percentGRAL.Path))
-					percentGRAL.EnableRaisingEvents = true;
-				if (dispnrGRAL != null && Directory.Exists(dispnrGRAL.Path))
-					dispnrGRAL.EnableRaisingEvents = true;
-				if (percentGramm != null && Directory.Exists(percentGramm.Path))
-					percentGramm.EnableRaisingEvents = true;
-				if (dispnrGramm != null && Directory.Exists(dispnrGramm.Path))
-					dispnrGramm.EnableRaisingEvents = true;
+                if (percentGRAL != null && Directory.Exists(percentGRAL.Path))
+                    percentGRAL.EnableRaisingEvents = true;
+                if (dispnrGRAL != null && Directory.Exists(dispnrGRAL.Path))
+                    dispnrGRAL.EnableRaisingEvents = true;
+                if (percentGramm != null && Directory.Exists(percentGramm.Path))
+                    percentGramm.EnableRaisingEvents = true;
+                if (dispnrGramm != null && Directory.Exists(dispnrGramm.Path))
+                    dispnrGramm.EnableRaisingEvents = true;
                 #endif
             }
             else  // not the computation tab -> stop FileSystemWatcher
             {
                 #if __MonoCS__
                 #else
-				if (percentGRAL != null)
-					percentGRAL.EnableRaisingEvents = false;
-				if (dispnrGRAL != null)
-					dispnrGRAL.EnableRaisingEvents = false;
-				if (percentGramm != null)
-					percentGramm.EnableRaisingEvents = false;
-				if (dispnrGramm != null)
-					dispnrGramm.EnableRaisingEvents = false;
+                if (percentGRAL != null)
+                    percentGRAL.EnableRaisingEvents = false;
+                if (dispnrGRAL != null)
+                    dispnrGRAL.EnableRaisingEvents = false;
+                if (percentGramm != null)
+                    percentGramm.EnableRaisingEvents = false;
+                if (dispnrGramm != null)
+                    dispnrGramm.EnableRaisingEvents = false;
                 #endif
             }
             // Lock elements because they do not exist if project is loaded
@@ -2616,17 +2616,17 @@ namespace Gral
         /// <summary>
         /// Output to the textbox "meteorological input" in the computation tab
         /// </summary>
-		void Textbox16_Set(string a)
-		{
-			if (listBox2.Items.Count == 0)
-			{
-				textBox16.Text = a;
-			}
-			else
-			{
-				textBox16.Text = GRAMMwindfield;
-			}
-		}
+        void Textbox16_Set(string a)
+        {
+            if (listBox2.Items.Count == 0)
+            {
+                textBox16.Text = a;
+            }
+            else
+            {
+                textBox16.Text = GRAMMwindfield;
+            }
+        }
 
         /// <summary>
         /// Set the bitmap for the vertical stretching factor button
@@ -2647,127 +2647,127 @@ namespace Gral
         /// Load and show comments
         /// </summary>
         void Button44Click(object sender, EventArgs e)
-		{
-		    //loading comments
-		    textBox17.Text = String.Empty;
-		    string name11 = Path.Combine(ProjectName, @"Settings","comments.txt");
-		    try
-		    {
-		        using (StreamReader ready = new StreamReader(name11, false))
-		        {
-		            textBox17.Text = ready.ReadToEnd();
-		        }
-		    }
-		    catch
-		    {
-		        string a = "Project:	" + ProjectName + Environment.NewLine;
-		        a +=       "Machine: 	" + Environment.MachineName + Environment.NewLine;
-		        a +=       "User:    	" + Environment.UserName + Environment.NewLine;
-		        a +=       "Domain:  	" + Environment.UserDomainName + Environment.NewLine;
-		        a +=       "Proc count: " + Environment.ProcessorCount  + Environment.NewLine;
-		        a +=       "GRAMM Windfield: " + GRAMMwindfield;
-		        textBox17.Text = a;
-		    }
-			panel1.Visible = false;
-			panel1.Hide();
-			textBox17.ReadOnly = false;
-			textBox17.Visible = true;
-			textBox17.Show();
-			button38.Visible = true;
-			button38.Show();
-		}
+        {
+            //loading comments
+            textBox17.Text = String.Empty;
+            string name11 = Path.Combine(ProjectName, @"Settings","comments.txt");
+            try
+            {
+                using (StreamReader ready = new StreamReader(name11, false))
+                {
+                    textBox17.Text = ready.ReadToEnd();
+                }
+            }
+            catch
+            {
+                string a = "Project:	" + ProjectName + Environment.NewLine;
+                a +=       "Machine: 	" + Environment.MachineName + Environment.NewLine;
+                a +=       "User:    	" + Environment.UserName + Environment.NewLine;
+                a +=       "Domain:  	" + Environment.UserDomainName + Environment.NewLine;
+                a +=       "Proc count: " + Environment.ProcessorCount  + Environment.NewLine;
+                a +=       "GRAMM Windfield: " + GRAMMwindfield;
+                textBox17.Text = a;
+            }
+            panel1.Visible = false;
+            panel1.Hide();
+            textBox17.ReadOnly = false;
+            textBox17.Visible = true;
+            textBox17.Show();
+            button38.Visible = true;
+            button38.Show();
+        }
 
-		void TabControl1Deselected(object sender, TabControlEventArgs e)
-		{
-			if (tabControl1.SelectedIndex != 1) return;
-			CheckGralInputData(); // check if
-		}
+        void TabControl1Deselected(object sender, TabControlEventArgs e)
+        {
+            if (tabControl1.SelectedIndex != 1) return;
+            CheckGralInputData(); // check if
+        }
 
         /// <summary>
         /// Read and set the number of the processor cores in the file Max_Proc.txt
         /// </summary>
-		void MaxProcFileRead()
-		{
-			//Read the actual number of threads to be used in each parallelized region
-			int prozessoranzahl = Math.Min(63, Environment.ProcessorCount);
-			try
-			{
-				string maxproc = Path.Combine(ProjectName, @"Computation","Max_Proc.txt");
-				if (File.Exists(maxproc))
-				{
-					try
-					{
-						using (StreamReader myreader = new StreamReader(maxproc))
-						{
-							string text = myreader.ReadLine();
-							prozessoranzahl = Math.Min(63, Math.Max(1, Convert.ToInt32(text)));
-						}
-					}
-					catch { }
-				}
-			}
-			catch
-			{}
+        void MaxProcFileRead()
+        {
+            //Read the actual number of threads to be used in each parallelized region
+            int prozessoranzahl = Math.Min(63, Environment.ProcessorCount);
+            try
+            {
+                string maxproc = Path.Combine(ProjectName, @"Computation","Max_Proc.txt");
+                if (File.Exists(maxproc))
+                {
+                    try
+                    {
+                        using (StreamReader myreader = new StreamReader(maxproc))
+                        {
+                            string text = myreader.ReadLine();
+                            prozessoranzahl = Math.Min(63, Math.Max(1, Convert.ToInt32(text)));
+                        }
+                    }
+                    catch { }
+                }
+            }
+            catch
+            {}
             numericUpDown32.Value = prozessoranzahl;
-		}
+        }
 
         /// <summary>
         /// Save the number of the processor cores to the file Max_Proc.txt
         /// </summary>
-		void NumericUpDown32ValueChanged(object sender, EventArgs e)
-		{
-			if (ProjectName.Length >0) // if a project exists
-			{
-				//user defines maximum number of processors to be used in the simulations
-				string maxproc = Path.Combine(ProjectName, @"Computation", "Max_Proc.txt");
-				try
-				{
-					using (StreamWriter procwrite = new StreamWriter(maxproc))
-					{
-						procwrite.WriteLine(Convert.ToString(numericUpDown32.Value));
-					}
-				}
-				catch
-				{
-					MessageBox.Show("Unable to write file 'Max_Proc.txt'","GUI Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
-				}
-			}
-		}
+        void NumericUpDown32ValueChanged(object sender, EventArgs e)
+        {
+            if (ProjectName.Length >0) // if a project exists
+            {
+                //user defines maximum number of processors to be used in the simulations
+                string maxproc = Path.Combine(ProjectName, @"Computation", "Max_Proc.txt");
+                try
+                {
+                    using (StreamWriter procwrite = new StreamWriter(maxproc))
+                    {
+                        procwrite.WriteLine(Convert.ToString(numericUpDown32.Value));
+                    }
+                }
+                catch
+                {
+                    MessageBox.Show("Unable to write file 'Max_Proc.txt'","GUI Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                }
+            }
+        }
 
         /// <summary>
         /// Load the main form
         /// </summary>
-		void MainLoad(object sender, EventArgs e)
-		{
-		}
+        void MainLoad(object sender, EventArgs e)
+        {
+        }
 
         /// <summary>
         /// Write steady state files checkbox changed
         /// </summary>
-		private void CheckBox27_CheckedChanged(object sender, EventArgs e)
-		{
-			//save GRAMM control file "GRAMMin.dat"
-			GRAMMin(EmifileReset);
-		}
+        private void CheckBox27_CheckedChanged(object sender, EventArgs e)
+        {
+            //save GRAMM control file "GRAMMin.dat"
+            GRAMMin(EmifileReset);
+        }
 
         /// <summary>
         /// Open one of the topmost 10 used project files
         /// </summary>
         void Button46Click(object sender, EventArgs e)
         {
-        	using (GralMainForms.MostRecentFiles MRF = new GralMainForms.MostRecentFiles())
-        	{
-        		if (MRF.ShowDialog() == DialogResult.OK)
-        		{
-        			string folder = MRF.SelectedFile;
-        			MRF.Close();
-        			MRF.Dispose();
-        			if (folder.Length > 2) // if a folder is selected
-        			{
-        				LoadProject(folder);
-        			}
-        		}
-        	}
+            using (GralMainForms.MostRecentFiles MRF = new GralMainForms.MostRecentFiles())
+            {
+                if (MRF.ShowDialog() == DialogResult.OK)
+                {
+                    string folder = MRF.SelectedFile;
+                    MRF.Close();
+                    MRF.Dispose();
+                    if (folder.Length > 2) // if a folder is selected
+                    {
+                        LoadProject(folder);
+                    }
+                }
+            }
         }
 
         /// <summary>
@@ -2779,10 +2779,10 @@ namespace Gral
             string name = Path.Combine(ProjectName, @"Settings", "comments.txt");
             try
             {
-				using (StreamWriter write = new StreamWriter(name, false))
-				{
-                	write.WriteLine(Convert.ToString(textBox17.Text));
-				}
+                using (StreamWriter write = new StreamWriter(name, false))
+                {
+                    write.WriteLine(Convert.ToString(textBox17.Text));
+                }
             }
             catch { }
         }
@@ -2801,131 +2801,131 @@ namespace Gral
         /// </summary>
         public void SetEmissionFilesInvalid()
         {
-        	Change_Label(2, 0); // Emission label red
+            Change_Label(2, 0); // Emission label red
         }
         /// <summary>
-		/// Change the label color for the computation buttons
-		/// </summary>
-		/// <param name="button">0 = Control, 1= meteo, 2 = emission, 3 = building</param>
-		/// <param name="mode">0 = red dot, 1 = green dot, 2 = black hook, -1 invisible</param>
-		public void Change_Label(int button, int mode)
+        /// Change the label color for the computation buttons
+        /// </summary>
+        /// <param name="button">0 = Control, 1= meteo, 2 = emission, 3 = building</param>
+        /// <param name="mode">0 = red dot, 1 = green dot, 2 = black hook, -1 invisible</param>
+        public void Change_Label(int button, int mode)
         {
-        	// button: 0 = Control, 1= meteo, 2 = emission, 3 = building
-        	// mode: 0 = red dot, 1 = green dot, 2 = black hook, -1 invisible
-        	if (button == 0)
-        	{
-        		if (mode == -1)
-				{
-					pictureBox1.Visible = false;
-					Control_OK  = false;
-				}
-        		else
-        			pictureBox1.Visible = true;
-        		if (mode == 0)
-        		{
-        	      	pictureBox1.Image = Gral.Properties.Resources.RedDot;
-        	      	Control_OK = false;
-        	    }
-        		if (mode == 1)
-        		{
-        	      	pictureBox1.Image = Gral.Properties.Resources.GreenDot;
-					Control_OK = false;
-        		}
-        		if (mode == 2)
-        		{
-        	      	pictureBox1.Image = Gral.Properties.Resources.BlackHook;
-        	      	Control_OK = true;
-        		}
-        	}
-        	if (button == 1)
-        	{
-        		if (mode == -1)
-				{
-					pictureBox2.Visible = false;
-					Meteo_OK = false;
-				}
-        		else
-        			pictureBox2.Visible = true;
-        		if (mode == 0)
-        		{
-        	      	pictureBox2.Image = Gral.Properties.Resources.RedDot;
-        	      	Meteo_OK = false;
-        		}
-        		if (mode == 1)
-        		{
-        	      	pictureBox2.Image = Gral.Properties.Resources.GreenDot;
-					Meteo_OK = false;
-        		}
-        		if (mode == 2)
-        		{
-        	      	pictureBox2.Image = Gral.Properties.Resources.BlackHook;
-        	      	Meteo_OK = true;
-        		}
-        	}
-        	if (button == 2)
-        	{
-				if (mode == -1)
-				{
-					pictureBox3.Visible = false;
-					Emission_OK = false;
-				}
-				else
-					pictureBox3.Visible = true;
-        		if (mode == 0)
-        		{
-					pictureBox3.Image = Gral.Properties.Resources.RedDot;
-        	      	Emission_OK = false;
-        		}
-        		if (mode == 1)
-        		{
-					pictureBox3.Image = Gral.Properties.Resources.GreenDot;
-        	      	Emission_OK = false;
-        		}
-        		if (mode == 2)
-        		{
-					pictureBox3.Image = Gral.Properties.Resources.BlackHook;
-        	      	Emission_OK = true;
-        		}
-        	}
-        	if (button == 3)
-        	{
-				if (mode == -1)
-				{
-					pictureBox4.Visible = false;
-					Building_OK = true; // no buildings!
-				}
-				else
-					pictureBox4.Visible = true;
-        		if (mode == 0)
-        		{
-					pictureBox4.Image = Gral.Properties.Resources.RedDot;
-        	      	Building_OK = false;
-        	      	try // delete buildings.dat if file exists
-        	      	{
-        	      		string newPath1 = Path.Combine(ProjectName, @"Computation", "buildings.dat");
-        	      		if (Project_Locked == false)
-							File.Delete(newPath1);
-					}
-					catch {}
-					try // delete vegetation.dat if file exists
-        	      	{
-					    string newPath1 = Path.Combine(ProjectName, @"Computation", "vegetation.dat");
-        	      		if (Project_Locked == false)
-							File.Delete(newPath1);
-					}
-					catch {}
-        		}
-        		if (mode == 1)
-        		{
-					pictureBox4.Image = Gral.Properties.Resources.GreenDot;
-        	      	Building_OK = false;
-        		}
-        		if (mode == 2)
-        		{
-					pictureBox4.Image = Gral.Properties.Resources.BlackHook;
-        	      	Building_OK = true;
-        		}
-        	}
+            // button: 0 = Control, 1= meteo, 2 = emission, 3 = building
+            // mode: 0 = red dot, 1 = green dot, 2 = black hook, -1 invisible
+            if (button == 0)
+            {
+                if (mode == -1)
+                {
+                    pictureBox1.Visible = false;
+                    Control_OK  = false;
+                }
+                else
+                    pictureBox1.Visible = true;
+                if (mode == 0)
+                {
+                    pictureBox1.Image = Gral.Properties.Resources.RedDot;
+                    Control_OK = false;
+                }
+                if (mode == 1)
+                {
+                    pictureBox1.Image = Gral.Properties.Resources.GreenDot;
+                    Control_OK = false;
+                }
+                if (mode == 2)
+                {
+                    pictureBox1.Image = Gral.Properties.Resources.BlackHook;
+                    Control_OK = true;
+                }
+            }
+            if (button == 1)
+            {
+                if (mode == -1)
+                {
+                    pictureBox2.Visible = false;
+                    Meteo_OK = false;
+                }
+                else
+                    pictureBox2.Visible = true;
+                if (mode == 0)
+                {
+                    pictureBox2.Image = Gral.Properties.Resources.RedDot;
+                    Meteo_OK = false;
+                }
+                if (mode == 1)
+                {
+                    pictureBox2.Image = Gral.Properties.Resources.GreenDot;
+                    Meteo_OK = false;
+                }
+                if (mode == 2)
+                {
+                    pictureBox2.Image = Gral.Properties.Resources.BlackHook;
+                    Meteo_OK = true;
+                }
+            }
+            if (button == 2)
+            {
+                if (mode == -1)
+                {
+                    pictureBox3.Visible = false;
+                    Emission_OK = false;
+                }
+                else
+                    pictureBox3.Visible = true;
+                if (mode == 0)
+                {
+                    pictureBox3.Image = Gral.Properties.Resources.RedDot;
+                    Emission_OK = false;
+                }
+                if (mode == 1)
+                {
+                    pictureBox3.Image = Gral.Properties.Resources.GreenDot;
+                    Emission_OK = false;
+                }
+                if (mode == 2)
+                {
+                    pictureBox3.Image = Gral.Properties.Resources.BlackHook;
+                    Emission_OK = true;
+                }
+            }
+            if (button == 3)
+            {
+                if (mode == -1)
+                {
+                    pictureBox4.Visible = false;
+                    Building_OK = true; // no buildings!
+                }
+                else
+                    pictureBox4.Visible = true;
+                if (mode == 0)
+                {
+                    pictureBox4.Image = Gral.Properties.Resources.RedDot;
+                    Building_OK = false;
+                    try // delete buildings.dat if file exists
+                    {
+                        string newPath1 = Path.Combine(ProjectName, @"Computation", "buildings.dat");
+                        if (Project_Locked == false)
+                            File.Delete(newPath1);
+                    }
+                    catch {}
+                    try // delete vegetation.dat if file exists
+                    {
+                        string newPath1 = Path.Combine(ProjectName, @"Computation", "vegetation.dat");
+                        if (Project_Locked == false)
+                            File.Delete(newPath1);
+                    }
+                    catch {}
+                }
+                if (mode == 1)
+                {
+                    pictureBox4.Image = Gral.Properties.Resources.GreenDot;
+                    Building_OK = false;
+                }
+                if (mode == 2)
+                {
+                    pictureBox4.Image = Gral.Properties.Resources.BlackHook;
+                    Building_OK = true;
+                }
+            }
         }
 
         /// <summary>
@@ -2937,35 +2937,35 @@ namespace Gral
         {
             if (EmifileReset == true)
             {
-            	if (checkBox32.Checked == false || MessageBox.Show(this, "Enable GRAL transient mode? Caution: the computation slows down" + Environment.NewLine + "and GRAL version 18.03 or higher is needed!",
-            	                    "GRAL GUI", MessageBoxButtons.OKCancel , MessageBoxIcon.Question) == DialogResult.OK)
-            	{
-            		if (checkBox32.Checked == true)
-            		{
-            			label13.Enabled = true;
-            			numericUpDown34.Enabled = true;
-            			checkBox34.Enabled = true;
-            			groupBox21.Visible = true; // Wet Deposition settings
-            			groupBox24.Visible = true; // Decay rate
-            			numericUpDown5.Value = 1;  // lock setting of start dispersion situtation
+                if (checkBox32.Checked == false || MessageBox.Show(this, "Enable GRAL transient mode? Caution: the computation slows down" + Environment.NewLine + "and GRAL version 18.03 or higher is needed!",
+                                    "GRAL GUI", MessageBoxButtons.OKCancel , MessageBoxIcon.Question) == DialogResult.OK)
+                {
+                    if (checkBox32.Checked == true)
+                    {
+                        label13.Enabled = true;
+                        numericUpDown34.Enabled = true;
+                        checkBox34.Enabled = true;
+                        groupBox21.Visible = true; // Wet Deposition settings
+                        groupBox24.Visible = true; // Decay rate
+                        numericUpDown5.Value = 1;  // lock setting of start dispersion situtation
                         numericUpDown5.Enabled = false; // lock setting of start dispersion situtation
-            		}
-            		else
-            		{
-            		    numericUpDown5.Enabled = true; // release setting of start dispersion situtation
-            			label13.Enabled = false;
-            			numericUpDown34.Enabled = false;
-            			checkBox34.Enabled = false;
-            			groupBox21.Visible = false; // Wet Deposition settings
-            			groupBox24.Visible = false; // Decay rate
-            		}
-            		ResetInDat();
-            	}
-            	else
-            	{
-            		checkBox32.Checked = false;
-            		checkBox34.Checked = false;
-            	}
+                    }
+                    else
+                    {
+                        numericUpDown5.Enabled = true; // release setting of start dispersion situtation
+                        label13.Enabled = false;
+                        numericUpDown34.Enabled = false;
+                        checkBox34.Enabled = false;
+                        groupBox21.Visible = false; // Wet Deposition settings
+                        groupBox24.Visible = false; // Decay rate
+                    }
+                    ResetInDat();
+                }
+                else
+                {
+                    checkBox32.Checked = false;
+                    checkBox34.Checked = false;
+                }
             }
         }
 
@@ -2976,7 +2976,7 @@ namespace Gral
         /// <param name="e"></param>
         private void NumericUpDown34_ValueChanged(object sender, EventArgs e)
         {
-        	CultureInfo ic = CultureInfo.InvariantCulture;
+            CultureInfo ic = CultureInfo.InvariantCulture;
             try
             {
                 // write set cut-off concentration to file
@@ -3038,7 +3038,7 @@ namespace Gral
         /// <param name="e"></param>
         void NumericUpDown35ValueChanged(object sender, EventArgs e)
         {
-        	ListBox5_SelectedIndexChanged(sender, null);
+            ListBox5_SelectedIndexChanged(sender, null);
         }
 
         /// <summary>
@@ -3048,26 +3048,26 @@ namespace Gral
         /// <param name="e"></param>
         void CheckBox34Click(object sender, EventArgs e)
         {
-        	if (checkBox32.Checked == true)
-        	{
-        		string name = Path.Combine(ProjectName, @"Computation", "GRAL_Vert_Conc.txt");
-        		try
-        		{
-        			if (checkBox34.Checked)
-        			{
-        				File.Create(name).Close();
-        			}
-        			else
-        			{
-        				File.Delete(name);
-        			}
-        		}
-        		catch{}
-        	}
-        	else
-        	{
-        		checkBox34.Checked = false;
-        	}
+            if (checkBox32.Checked == true)
+            {
+                string name = Path.Combine(ProjectName, @"Computation", "GRAL_Vert_Conc.txt");
+                try
+                {
+                    if (checkBox34.Checked)
+                    {
+                        File.Create(name).Close();
+                    }
+                    else
+                    {
+                        File.Delete(name);
+                    }
+                }
+                catch{}
+            }
+            else
+            {
+                checkBox34.Checked = false;
+            }
         }
 
         /// <summary>
@@ -3079,9 +3079,9 @@ namespace Gral
         {
             GralMainForms.GUI_Settings settings = new GralMainForms.GUI_Settings
             {
-            	StartPosition = FormStartPosition.Manual,
-            	Location = new System.Drawing.Point(this.Left, this.Top),
-            	Owner = this
+                StartPosition = FormStartPosition.Manual,
+                Location = new System.Drawing.Point(this.Left, this.Top),
+                Owner = this
             };
             settings.Show();
         }

--- a/Source/Gral/Main.cs
+++ b/Source/Gral/Main.cs
@@ -1188,6 +1188,10 @@ namespace Gral
         {
             ShowWindVelocityClasses(sender, e);
         }
+        private void ShowWindVelocityClassesDistr_Click(object sender, EventArgs e)
+        {
+            ShowWindVelocityDistribution(sender, e);
+        }
         private void ShowWindStabilityClasses_Click(object sender, EventArgs e)
         {
             ShowWindStabilityClasses(sender, e);

--- a/Source/Gral/Main.cs
+++ b/Source/Gral/Main.cs
@@ -1642,11 +1642,17 @@ namespace Gral
                 {
                     groupBox13.Visible = true;
                     groupBox14.Visible = false;
-                    string receptorfile = Path.Combine(ProjectName, @"Computation", "zeitreihe.dat");
-                    if (File.Exists(receptorfile))
+
+                    if (File.Exists(Path.Combine(ProjectName, @"Computation", "zeitreihe.dat")) ||
+                        File.Exists(Path.Combine(ProjectName, @"Computation", "ReceptorConcentrations.dat")))
+                    {
                         button37.Visible = true;
+                    }
                     else
+                    {
                         button37.Visible = false;
+                    }
+
                     //check transient GRAL simulation
                     InDatVariables data = new InDatVariables();
                     InDatFileIO ReadInData = new InDatFileIO();

--- a/Source/Gral/Main.resx
+++ b/Source/Gral/Main.resx
@@ -120,6 +120,15 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="button52.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Source/Gral/Main.resx
+++ b/Source/Gral/Main.resx
@@ -120,15 +120,6 @@
   <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
-  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-    <value>17, 17</value>
-  </metadata>
   <assembly alias="System.Drawing" name="System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a" />
   <data name="button52.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>

--- a/Source/Gral/Properties/AssemblyInfo.cs
+++ b/Source/Gral/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Resources;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("20.01.1.0")]
-[assembly: AssemblyFileVersion("20.01.1.0")]
+[assembly: AssemblyVersion("20.01.2.0")]
+[assembly: AssemblyFileVersion("20.01.2.0")]
 [assembly: NeutralResourcesLanguageAttribute("")]


### PR DESCRIPTION
The new GRAL output files GRAL_Meteozeitreihe.dat and ReceptorConcetration.dat (replaces the file zeitreihe.dat) got headers with information about the receptor names, the rec. coordinates and the source group
The new GUI evaluation function produces *.met files with the new header (geografical referenced) and new output files (Receptor_Timeseries_XXX.dat) using the local culture with unicode encoding. The output files got an additional header with receptor names, rec. coordinates and the source group number.
The GUI evaluation function should be compatible with outputs of former GRAL version before V20.01. The corrupt V20.01 GRAL_Meteozeitreihe.dat files are not readable, but due to changes in the evaluation function, the V20.01 zeitreihe.dat should be readable and the concentration evaluation for GRAL V20.01 files should be possible.