### PR TITLE
Improve and fix meteo zeitreihe

### DIFF
--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -337,6 +337,25 @@ namespace GralBackgroundworkers
                             {
                                 NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
 
+                                //check all source groups within the file ReceptorConcentrations.dat
+                                List<int> containedSourceGroups = new List<int>();
+                                string[] headerSourceGroups = ConcentrationHeader[0].Split(new char[] { ':', '\t'});
+                                for(int i = 1; i < headerSourceGroups.Length; i += 2) 
+                                {
+                                    int _sg = 0;
+                                    if (Int32.TryParse(headerSourceGroups[i], out _sg))
+                                    {
+                                        if (!containedSourceGroups.Contains(_sg))
+                                        {
+                                            containedSourceGroups.Add(_sg);
+                                        }
+                                    }
+                                }
+                                if (containedSourceGroups.Count() != sg_names.Count())
+                                {
+                                    BackgroundThreadMessageBox("The number of source groups between calculation and current project does not match!");
+                                }
+
                                 //if the project has been changed - who knows what user are doing...
                                 if (NumberOfReceptors > xrec.Count)
                                 {
@@ -386,9 +405,9 @@ namespace GralBackgroundworkers
             string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
             int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
             
-            double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-            double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-            int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_u = new double[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_v = new double[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            int[,] GRAL_SC = new int[NumberOfReceptors, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
             string[] ReceptorMeteoCoors = new string[5];
             
             if (File.Exists(GRAL_metfile))
@@ -818,12 +837,13 @@ namespace GralBackgroundworkers
                     {
                         string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                         int numberOfReceptors = (int)(columns.Length / columnOffset);
+                        
                         int count = 0;
                         
                         for (int numbrec = 0; numbrec < numberOfReceptors; numbrec++)
                         {
                             //check if this situation has been computed, otherwise this line is 0
-                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= numberOfReceptors)
+                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= (numberOfReceptors - 1))
                             {
                                 GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
                                 GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -30,7 +30,7 @@ namespace GralBackgroundworkers
     {
         private string decsep;
         private List<double> xrec = new List<double>();
-        
+
         /// <summary>
         /// Calculate receptor concentrations and GRAL flow field receptor wind fields 
         /// </summary>
@@ -41,23 +41,23 @@ namespace GralBackgroundworkers
             int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
             int maxcomputedsourcegroup = mydata.MaxSourceComputed;
             decsep = mydata.Decsep;
-            
+
             double[,] emifac_day = new double[24, maxsource];
             double[,] emifac_mon = new double[12, maxsource];
             string[] text = new string[15];
-            for (int k=0; k <15; k++) text[k] = "";
-            
-            string dummy;
-            string newpath="";
-            int[]  sg_numbers = new int[maxsource];
+            for (int k = 0; k < 15; k++) text[k] = "";
+
+            string dummy = string.Empty;
+            string newpath = "";
+            int[] sg_numbers = new int[maxsource];
             string[] sg_names = mydata.Sel_Source_Grp.Split(',');
             string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
-            
+
             //in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
             bool transient = false;
             InDatVariables data = new InDatVariables();
             InDatFileIO ReadInData = new InDatFileIO();
-            data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
+            data.InDatPath = Path.Combine(mydata.Projectname, "Computation", "in.dat");
             ReadInData.Data = data;
             if (ReadInData.ReadInDat() == true)
             {
@@ -65,8 +65,8 @@ namespace GralBackgroundworkers
                 {
                     transient = true;
                 }
-            }	
-            
+            }
+
             //get variation for source group
             if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
             {
@@ -75,14 +75,14 @@ namespace GralBackgroundworkers
                 {
                     try
                     {
-                        for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
+                        for (int sg = 0; sg < sg_names.Length; sg++) // check all selected source groups
                         {
                             if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
                             {
                                 sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
                                 // MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
                                 // Read modulation of that source-group
-                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
+                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3, '0') + ".dat");
                                 using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
                                 {
                                     for (int j = 0; j < 24; j++)
@@ -107,13 +107,13 @@ namespace GralBackgroundworkers
                             }
                         }
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
-                        BackgroundThreadMessageBox (ex.Message);
+                        BackgroundThreadMessageBox(ex.Message);
                     }
                 }
             }
-            
+
             //read mettimeseries.dat to get file length necessary to define some array lengths
             newpath = Path.Combine("Computation", "mettimeseries.dat");
             int mettimefilelength = 0;
@@ -129,11 +129,11 @@ namespace GralBackgroundworkers
             }
             if (mettimefilelength == 0) // File-lenght must > 0
             {
-                BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
+                BackgroundThreadMessageBox("Error reading mettimeseries.txt");
                 return; // leave method
             }
             //mettimefilelength--;
-            
+
             //if file emissions_timeseries.txt exists, these modulation factors will be used
             int[] sg_time = new int[maxsource];
             double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
@@ -150,7 +150,7 @@ namespace GralBackgroundworkers
                 }
 
                 // read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
-                newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
+                newpath = Path.Combine(mydata.Projectname, "Computation", "emissions_timeseries.txt");
                 if (File.Exists(newpath) == true)
                 {
                     try
@@ -199,16 +199,16 @@ namespace GralBackgroundworkers
                                 }
                             }
                         }
-                        
+
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
-                        BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
+                        BackgroundThreadMessageBox(ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
                         return;
                     }
                 } // read value from emissions_timeseries.txt
             }
-            
+
             List<string> wgmet = new List<string>();
             List<string> wrmet = new List<string>();
             List<string> akmet = new List<string>();
@@ -220,41 +220,41 @@ namespace GralBackgroundworkers
             string month;
             string hour;
             string day;
-            
-            List<string> rec_names=new List<string>();
-            
+
+            List<string> rec_names = new List<string>();
+
             //get number of receptor points and names of receptors
-            string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
-            if(File.Exists(receptorfile))
+            string receptorfile = Path.Combine(mydata.Projectname, "Computation", "Receptor.dat");
+            if (File.Exists(receptorfile))
             {
                 try
                 {
-                    using(StreamReader read=new StreamReader(receptorfile))
+                    using (StreamReader read = new StreamReader(receptorfile))
                     {
-                        dummy=read.ReadLine(); // 1st line with number of receptor points
-                        
+                        dummy = read.ReadLine(); // 1st line with number of receptor points
+
                         while (read.EndOfStream == false)
                         {
                             text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-                            
+
                             if (text.Length > 1) // valid line?
                             {
                                 xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
-                                
+
                                 string a = text[0]; 	// take number as name
                                 if (text.Length > 4) 	// get name from line
-                                    a = text[4];   
-                                
+                                    a = text[4];
+
                                 if (text.Length >= 5) // if the Receptor-Name contains ","
                                 {
-                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
+                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is part of the Receptor point name
                                     {
                                         if (text[k] != "") a = a + "_" + text[k];
                                     }
                                 }
-                                
+
                                 // if the receptor name contains invalid characters for a file!
-                                a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
+                                a = string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
                                 rec_names.Add(a);
                             }
                         }
@@ -262,16 +262,16 @@ namespace GralBackgroundworkers
                 }
                 catch
                 {
-                    BackgroundThreadMessageBox ("Error reading Receptor.dat");
+                    BackgroundThreadMessageBox("Error reading Receptor.dat");
                     return;
                 }
-                
+
             }
-            
+
             //MessageBox.Show(Convert.ToString(rec_names.Count));
-            
+
             //read meteopgt.all
-            newpath = Path.Combine("Computation","meteopgt.all");
+            newpath = Path.Combine("Computation", "meteopgt.all");
             using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
             {
                 text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
@@ -287,21 +287,23 @@ namespace GralBackgroundworkers
                     }
                     catch
                     {
-                        BackgroundThreadMessageBox ("Error reading meteopgt.all");
+                        BackgroundThreadMessageBox("Error reading meteopgt.all");
                         return;
                     }
                 }
             }
-            
+
+            //BackgroundThreadMessageBox(wrmet[0] + "/" + wgmet[0] + "/" + akmet[0]);
             double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
                                                         => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
                                                                                  => new double[wrmet.Count]));
             double fmod = 1;
 
             //read all computed concentrations from file zeitreihe.dat or ReceptorConcentration.dat
-            bool zeitflag = false;
+            bool writeConcentrationFiles = false;
             string[] text5 = new string[xrec.Count * sg_names.Length];
-            int numbwet = 0;
+            //number of existing weather situations
+            int existingWeatherSituations = 0;
 
             //switch between new (V21.01) and old GRAL concentration files
             receptorfile = Path.Combine(mydata.Projectname, "Computation", "ReceptorConcentrations.dat");
@@ -315,12 +317,13 @@ namespace GralBackgroundworkers
                 receptorfile = Path.Combine(mydata.Projectname, "Computation", "zeitreihe.dat");
             }
 
+            // Read concentration file into conc[][][]
             string[] ConcentrationHeader = new string[6];
             int NumberOfReceptors = xrec.Count;
 
             if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
             {
-                zeitflag = true;
+                writeConcentrationFiles = true;
                 try
                 {
                     using (StreamReader read = new StreamReader(receptorfile))
@@ -367,7 +370,7 @@ namespace GralBackgroundworkers
                         }
 
                         // read concentration file
-                        numbwet = 0;
+                        existingWeatherSituations = 0;
                         while (read.EndOfStream == false)
                         {
                             text5 = read.ReadLine().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
@@ -382,12 +385,13 @@ namespace GralBackgroundworkers
                                     //check if this situation has been computed, otherwise this line is 0
                                     if (text5.Length > count)
                                     {
-                                        conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
+                                        conc[numbrec][sg_number][existingWeatherSituations] = Convert.ToDouble(text5[count].Replace(".", decsep));
                                     }
                                     count++;
                                 }
                             }
-                            numbwet++;
+
+                            existingWeatherSituations++; // use weather situations from ReceptorConcentrations.dat
                         }
                     }
                 }
@@ -400,7 +404,7 @@ namespace GralBackgroundworkers
             }
             
             //read all wind speeds from file GRAL_Meteozeitreihe.dat
-            bool metflag = false;
+            bool meteoDataAvailable = false;
             bool local_SCL = false;
             string[] text7 = new string[xrec.Count];
             
@@ -414,18 +418,23 @@ namespace GralBackgroundworkers
             
             if (File.Exists(GRAL_metfile))
             {
-                metflag = true;
-                numbwet = 0;
-                
-                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
+                meteoDataAvailable = true;
+                int weatherSit = 0;         
+                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref weatherSit, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
                 {
-                    metflag = false;
+                    meteoDataAvailable = false;
+                }
+                else
+                {
+                    existingWeatherSituations = weatherSit; // use number of weather situations from MeteoTimeseries
                 }
             }
 
+            //BackgroundThreadMessageBox(numbwet.ToString());
+
             if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
             {
-                if (zeitflag == true) // write mettime series for all receptor points
+                if (writeConcentrationFiles == true) // write mettime series for all receptor points
                 {
                     try
                     {
@@ -439,8 +448,8 @@ namespace GralBackgroundworkers
                             catch{}
                         }
 
-                        //write results to file receptor_timeseries.txt
-                        using (StreamWriter recwrite = new StreamWriter(writerRecTimeSeries))
+                        //write results to file ReceptorTimeSeries.txt in Unicode encoding
+                        using (StreamWriter recwrite = new StreamWriter(writerRecTimeSeries, false, System.Text.Encoding.Unicode))
                         {
                             //write header line
                             if (NewFileFormat)
@@ -448,6 +457,7 @@ namespace GralBackgroundworkers
                                 string[] headerInfo = {"Name", "Source group", "X", "Y", "Z", "-----"};
 
                                 System.Globalization.CultureInfo ci = System.Threading.Thread.CurrentThread.CurrentCulture;
+
                                 for (int ianz = 0; ianz < 6; ianz++)
                                 {
                                     // use local culture for user files
@@ -483,7 +493,7 @@ namespace GralBackgroundworkers
                                 //consider, if meteopgt.all represents a time series or a statistics
                                 int dispersionsituations = 0;
                                 if (mydata.Checkbox19 == true)
-                                    dispersionsituations = numbwet + 1;
+                                    dispersionsituations = existingWeatherSituations + 1;
                                 else
                                     dispersionsituations = wrmet.Count;
 
@@ -495,7 +505,7 @@ namespace GralBackgroundworkers
                                     count_ws++;
                                     count_dispsit_in_mettime += 1;
 
-                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
+                                    if ((count_dispsit_in_mettime >= existingWeatherSituations) && (mydata.Checkbox19 == true))
                                         break;
 
                                     month = text3[1];
@@ -514,7 +524,7 @@ namespace GralBackgroundworkers
                                         if ((wgmet[n].Equals(wgmettime)) && (wrmet[n].Equals(wrmettime)) && (akmet[n].Equals(akmettime)))
                                         {
                                             //take care if not all dispersion situations have been computed
-                                            if (n >= numbwet - 1)
+                                            if (n >= existingWeatherSituations)
                                             {
                                                 //write results
                                                 recwrite.WriteLine(string.Empty);
@@ -586,7 +596,7 @@ namespace GralBackgroundworkers
                 }
             }
             
-            if (metflag == true) // write meteorological data for all receptor points
+            if (meteoDataAvailable == true) // write meteorological data for all receptor points
             {
                 try
                 {
@@ -609,41 +619,39 @@ namespace GralBackgroundworkers
                         double windspeed_GRAL = 0;
                         double winddirection_GRAL = 0;
 
-                        string file = Path.Combine(mydata.Projectname, @"Metfiles", "GRAL" + Convert.ToString(k + 1) + "_" + rec_names[k] + ".met");
-                        if (File.Exists(file))
+                        string meteoFile = Path.Combine(mydata.Projectname, @"Metfiles", "GRAL" + Convert.ToString(k + 1) + "_" + rec_names[k] + ".met");
+                        if (File.Exists(meteoFile))
                         {
                             try
                             {
-                                File.Delete(file);
+                                File.Delete(meteoFile);
                             }
                             catch { }
                         }
 
-                        using (StreamWriter recwrite = new StreamWriter(file))
+                        using (StreamWriter meteoWriter = new StreamWriter(meteoFile))
                         {
                             //write header lines
                             if (string.IsNullOrEmpty(ReceptorMeteoCoors[0]) || k >= recname.Length)
                             {
-                                recwrite.WriteLine("//" + Path.GetFileName(file));
+                                meteoWriter.WriteLine("//" + Path.GetFileName(meteoFile));
                             }
                             else
                             {
                                 try
                                 {
-                                    recwrite.WriteLine(recname[k]);
-                                    recwrite.WriteLine(@"\\X=" + recX[k]);
-                                    recwrite.WriteLine(@"\\Y=" + recY[k]);
-                                    recwrite.WriteLine(@"\\Z=" + recZ[k]);
+                                    meteoWriter.WriteLine(recname[k]);
+                                    meteoWriter.WriteLine(@"\\X=" + recX[k]);
+                                    meteoWriter.WriteLine(@"\\Y=" + recY[k]);
+                                    meteoWriter.WriteLine(@"\\Z=" + recZ[k]);
                                 }
                                 catch { }
                             }
 
                             string[] text6 = new string[2];
-
-                            //read mettimeseries.dat
-                            newpath = Path.Combine("Computation", "mettimeseries.dat");
                             
-                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                            //read mettimeseries.dat
+                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, "Computation", "mettimeseries.dat")))
                             {
                                 text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                                 text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
@@ -654,23 +662,27 @@ namespace GralBackgroundworkers
                                 //consider, if meteopgt.all represents a time series or a statistics
                                 int dispersionsituations = 0;
                                 if (mydata.Checkbox19 == true || transient == true)
-                                    dispersionsituations = numbwet + 1;
+                                    dispersionsituations = existingWeatherSituations + 1;
                                 else
                                     dispersionsituations = wrmet.Count;
                                 
-                                int count_dispsit_in_mettime = 0;
+                                int count_dispsit_in_mettime = -1;
 
                                 while (!string.IsNullOrEmpty(text2[0]))
                                 {
                                     count_dispsit_in_mettime++;
-                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
+                                    
+                                    if ((count_dispsit_in_mettime >= existingWeatherSituations) && (mydata.Checkbox19 == true || transient == true))
+                                    {
                                         break;
+                                    }
 
                                     month = text3[1];
                                     day = text3[0];
                                     hour = text2[1];
                                     if (hour == "24")
                                         hourplus = 1;
+
                                     wgmettime = text2[2];
                                     wrmettime = text2[3];
                                     akmettime = text2[4];
@@ -680,26 +692,26 @@ namespace GralBackgroundworkers
                                         year_increase += 1;
                                     monthold = Convert.ToInt32(text3[1]);
 
-                                    int corr_situation = 0;
-                                    
+                                    int corr_situation = -2;
                                     if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
                                     {
                                         //search in file meteopgt.all for the corresponding dispersion situation
                                         for (int n = 0; n < dispersionsituations; n++)
                                         {
-                                            if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                            if ((wgmet[n].Equals(wgmettime)) && (wrmet[n].Equals(wrmettime)) && (akmet[n].Equals(akmettime)))
                                             {
                                                 //take care if not all dispersion situations have been computed
-                                                if (n >= numbwet)
+                                                if (n >= existingWeatherSituations)
                                                 {
                                                     //write results
-                                                    //dummy = "";
-                                                    //recwrite.WriteLine(dummy);
+                                                    //recwrite.WriteLine(string.Empty);
+                                                    corr_situation = -3;
+                                                    n = dispersionsituations;
                                                 }
                                                 else
                                                 {
                                                     corr_situation = n;
-                                                    break;
+                                                    n = dispersionsituations; // // situation found -> stop searching
                                                 }
                                             }
                                         }
@@ -708,55 +720,67 @@ namespace GralBackgroundworkers
                                     {
                                         corr_situation = count_dispsit_in_mettime;
                                     }
-                                    
-                                    if (corr_situation > 0)
+
+                                    if (corr_situation > -1)
                                     {
                                         int n  = corr_situation;
                                         SetText("Day.Month: " + day + "." + month);
                                         
-                                        int std = Convert.ToInt32(hour);
-                                        int mon = Convert.ToInt32(month) - 1;
-
                                         //write results
-                                        dummy = "";
                                         dummy_year = Convert.ToString(1990 + year_increase);
-                                        dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
+                                        dummy = day + "." + month + "." + dummy_year + "," + hour + ":00,";
+                                        
                                         //compute wind speed and direction
                                         windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
-                                        if (GRAL_v[k,n] == 0)
-                                            winddirection_GRAL = 90;
-                                        else
-                                            winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
-                                        if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
-                                            winddirection_GRAL = 180 - winddirection_GRAL;
-                                        if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
-                                            winddirection_GRAL = 180 + winddirection_GRAL;
-                                        if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
-                                            winddirection_GRAL = 360 - winddirection_GRAL;
 
-                                        dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
-
-                                        if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
+                                        if (windspeed_GRAL == 0) // wind speed 0 => this sit was not calculated
                                         {
-                                            if (GRAL_SC[k, n] > 0) // if this situation is not available yet
+                                            winddirection_GRAL = 0;
+                                            dummy += "0,0,4";
+                                        }
+                                        else
+                                        {
+                                            if (GRAL_v[k, n] == 0)
+                                                winddirection_GRAL = 90;
+                                            else
+                                                winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / Math.PI);
+
+                                            if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
+                                                winddirection_GRAL = 180 - winddirection_GRAL;
+                                            if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
+                                                winddirection_GRAL = 180 + winddirection_GRAL;
+                                            if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
+                                                winddirection_GRAL = 360 - winddirection_GRAL;
+
+                                            dummy += Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0), ic);
+
+                                            if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
                                             {
-                                                dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
+                                                if (GRAL_SC[k, n] > 0 && GRAL_SC[k, n] < 8) // if this situation is not available yet
+                                                {
+                                                    dummy += "," + Convert.ToString(GRAL_SC[k, n], ic);
+                                                }
+                                                else
+                                                {
+                                                    dummy += "," + Convert.ToString(akmettime, ic);
+                                                }
                                             }
                                             else
                                             {
-                                                dummy = dummy + "," + Convert.ToString(akmettime);
+                                                dummy += "," + Convert.ToString(akmettime, ic);
                                             }
                                         }
-                                        else
-                                        {
-                                            dummy = dummy + "," + Convert.ToString(akmettime);
-                                        }
-                                        
-                                        recwrite.WriteLine(dummy);
-                                        //consider, if meteopgt.all represents a time series or a statistics
-//										if (mydata.Checkbox19 == true || transient == true)
-//											break;
+                                        meteoWriter.WriteLine(dummy);
                                     }
+                                    else if (corr_situation > -3) // found no corresponding situation but end of numbwet not reached
+                                    {
+                                        dummy_year = Convert.ToString(1990 + year_increase);
+                                        dummy = day + "." + month + "." + dummy_year + "," + hour + ":00,";
+                                        dummy = dummy + Convert.ToString(0, ic) + "," + Convert.ToString(0, ic) + "," + Convert.ToString(4);
+                                        //BackgroundThreadMessageBox(dummy);
+                                        meteoWriter.WriteLine(dummy);
+                                    }
+
                                     try
                                     {
                                         if (read.EndOfStream)
@@ -771,7 +795,7 @@ namespace GralBackgroundworkers
                                     }
                                     catch
                                     {
-                                        break;
+                                        text2[0] = string.Empty; //quit reading
                                     }
                                 }
                             } // using read
@@ -788,12 +812,13 @@ namespace GralBackgroundworkers
             {
                 //MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
             }
+            Computation_Completed = true; // set flag, that computation was successful
         }
         
         private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
         {
-            numbwet = 1;
+            numbwet = 0;
             int columnOffset = 2; // old file format
             int headerLineNumber = 0;
 
@@ -881,9 +906,7 @@ namespace GralBackgroundworkers
                     BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
                     return false;
                 }
-            }
-            
-            Computation_Completed = true; // set flag, that computation was successful
+            } 
             return true;
         } // Read_GRAL_Meteozeitreihe
         

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -332,18 +332,18 @@ namespace GralBackgroundworkers
                             {
                                 ConcentrationHeader[ianz] = read.ReadLine();
                             }
-                        }
 
-                        if (sg_names.Count() > 0)
-                        {
-                            NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
-
-                            //if the project has been changed - who knows what user are doing...
-                            if (NumberOfReceptors > xrec.Count)
+                            if (sg_names.Count() > 0)
                             {
-                                conc = GralIO.Landuse.CreateArray<double[][]>(NumberOfReceptors, ()
-                                                        => GralIO.Landuse.CreateArray<double[]>(maxsource, ()
-                                                                                 => new double[wrmet.Count]));
+                                NumberOfReceptors = (int)ConcentrationHeader[0].Count(ch => ch == '\t') / sg_names.Count();
+
+                                //if the project has been changed - who knows what user are doing...
+                                if (NumberOfReceptors > xrec.Count)
+                                {
+                                    conc = GralIO.Landuse.CreateArray<double[][]>(NumberOfReceptors, ()
+                                                            => GralIO.Landuse.CreateArray<double[]>(maxsource, ()
+                                                                                     => new double[wrmet.Count]));
+                                }
                             }
                         }
 

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -25,289 +25,289 @@ using System.IO;
 
 namespace GralBackgroundworkers
 {
-	public partial class ProgressFormBackgroundworker
-	{
-    	private string decsep;
-    	private List<double> xrec = new List<double>();
-    	
-		/// <summary>
+    public partial class ProgressFormBackgroundworker
+    {
+        private string decsep;
+        private List<double> xrec = new List<double>();
+        
+        /// <summary>
         /// Calculate receptor concentrations and GRAL flow field receptor wind fields 
         /// </summary>
-		private void ReceptorConcentration(GralBackgroundworkers.BackgroundworkerData mydata,
+        private void ReceptorConcentration(GralBackgroundworkers.BackgroundworkerData mydata,
                                            System.ComponentModel.DoWorkEventArgs e)
         {
-			//reading emission variations
-			int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
-			int maxcomputedsourcegroup = mydata.MaxSourceComputed;
-			decsep = mydata.Decsep;
-			
-			double[,] emifac_day = new double[24, maxsource];
-			double[,] emifac_mon = new double[12, maxsource];
-			string[] text = new string[15];
-			for (int k=0; k <15; k++) text[k] = "";
-			
-			string dummy;
-			string newpath="";
-			int[]  sg_numbers = new int[maxsource];
-			string[] sg_names = mydata.Sel_Source_Grp.Split(',');
-			string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
-			
-			//in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
-			bool transient = false;
-			InDatVariables data = new InDatVariables();
-			InDatFileIO ReadInData = new InDatFileIO();
-			data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
-			ReadInData.Data = data;
-			if (ReadInData.ReadInDat() == true)
-			{
-				if (data.Transientflag == 0)
-				{
-					transient = true;
-				}
-			}	
-			
-			//get variation for source group
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				// Read the emission factors of all selected source-groups
-				for (int itm = 0; itm < maxsource; itm++)
-				{
-					try
-					{
-						for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
-						{
-							if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
-							{
-								sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
-								// MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
-								// Read modulation of that source-group
-								newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
-								using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-								{
-									for (int j = 0; j < 24; j++)
-									{
-										text = myreader.ReadLine().Split(new char[] { ',' });
-										emifac_day[j, itm] = Convert.ToDouble(text[1].Replace(".", decsep));
-										if (j < 12)
-											emifac_mon[j, itm] = Convert.ToDouble(text[2].Replace(".", decsep));
-									}
-								}
-								sg = sg_names.Length + 1; // break
-							}
-							else // source group not selected
-							{
-								for (int j = 0; j < 24; j++)
-								{
-									emifac_day[j, itm] = 0;
-									if (j < 12)
-										emifac_mon[j, itm] = 0;
-								}
-								sg_numbers[itm] = -1;
-							}
-						}
-					}
-					catch(Exception ex)
-					{
-						BackgroundThreadMessageBox (ex.Message);
-					}
-				}
-			}
-			
-			//read mettimeseries.dat to get file length necessary to define some array lengths
-			newpath = Path.Combine("Computation", "mettimeseries.dat");
-			int mettimefilelength = 0;
-			string[] text2 = new string[5];
-			using (StreamReader sr = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-			{
-				//text2 = sr.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				while (sr.EndOfStream == false)
-				{
-					mettimefilelength++;
-					sr.ReadLine();
-				}
-			}
-			if (mettimefilelength == 0) // File-lenght must > 0
-			{
-				BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
-				return; // leave method
-			}
-			//mettimefilelength--;
-			
-			//if file emissions_timeseries.txt exists, these modulation factors will be used
-			int[] sg_time = new int[maxsource];
-			double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
+            //reading emission variations
+            int maxsource = 100; //mydata.MaxSource; allow all source-group numbers!
+            int maxcomputedsourcegroup = mydata.MaxSourceComputed;
+            decsep = mydata.Decsep;
+            
+            double[,] emifac_day = new double[24, maxsource];
+            double[,] emifac_mon = new double[12, maxsource];
+            string[] text = new string[15];
+            for (int k=0; k <15; k++) text[k] = "";
+            
+            string dummy;
+            string newpath="";
+            int[]  sg_numbers = new int[maxsource];
+            string[] sg_names = mydata.Sel_Source_Grp.Split(',');
+            string[] computed_sourcegroups = mydata.Comp_Source_Grp.Split(',');
+            
+            //in transient GRAL mode, it is simply to read the File GRAL_meteozeitreihe.dat and convert it to .met files
+            bool transient = false;
+            InDatVariables data = new InDatVariables();
+            InDatFileIO ReadInData = new InDatFileIO();
+            data.InDatPath = Path.Combine(mydata.Projectname, "Computation","in.dat");
+            ReadInData.Data = data;
+            if (ReadInData.ReadInDat() == true)
+            {
+                if (data.Transientflag == 0)
+                {
+                    transient = true;
+                }
+            }	
+            
+            //get variation for source group
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                // Read the emission factors of all selected source-groups
+                for (int itm = 0; itm < maxsource; itm++)
+                {
+                    try
+                    {
+                        for (int sg = 0; sg <sg_names.Length; sg++) // check all selected source groups
+                        {
+                            if ((itm + 1) == Convert.ToInt32(GetSgNumbers(sg_names[sg]))) // sourcegroup selected?
+                            {
+                                sg_numbers[itm] = Convert.ToInt32(GetSgNumbers(sg_names[sg])); // Get number of the Source-group
+                                // MessageBox.Show(itm.ToString()+"/"+sg_numbers[itm]);
+                                // Read modulation of that source-group
+                                newpath = Path.Combine("Computation", "emissions" + Convert.ToString(itm + 1).PadLeft(3,'0') + ".dat");
+                                using (StreamReader myreader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                                {
+                                    for (int j = 0; j < 24; j++)
+                                    {
+                                        text = myreader.ReadLine().Split(new char[] { ',' });
+                                        emifac_day[j, itm] = Convert.ToDouble(text[1].Replace(".", decsep));
+                                        if (j < 12)
+                                            emifac_mon[j, itm] = Convert.ToDouble(text[2].Replace(".", decsep));
+                                    }
+                                }
+                                sg = sg_names.Length + 1; // break
+                            }
+                            else // source group not selected
+                            {
+                                for (int j = 0; j < 24; j++)
+                                {
+                                    emifac_day[j, itm] = 0;
+                                    if (j < 12)
+                                        emifac_mon[j, itm] = 0;
+                                }
+                                sg_numbers[itm] = -1;
+                            }
+                        }
+                    }
+                    catch(Exception ex)
+                    {
+                        BackgroundThreadMessageBox (ex.Message);
+                    }
+                }
+            }
+            
+            //read mettimeseries.dat to get file length necessary to define some array lengths
+            newpath = Path.Combine("Computation", "mettimeseries.dat");
+            int mettimefilelength = 0;
+            string[] text2 = new string[5];
+            using (StreamReader sr = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+            {
+                //text2 = sr.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                while (sr.EndOfStream == false)
+                {
+                    mettimefilelength++;
+                    sr.ReadLine();
+                }
+            }
+            if (mettimefilelength == 0) // File-lenght must > 0
+            {
+                BackgroundThreadMessageBox ("Error reading mettimeseries.txt");
+                return; // leave method
+            }
+            //mettimefilelength--;
+            
+            //if file emissions_timeseries.txt exists, these modulation factors will be used
+            int[] sg_time = new int[maxsource];
+            double[,] emifac_timeseries = new double[mettimefilelength + 1, maxsource];
 
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				//it is necessary to set all values of the array emifac_timeseries equal to 1
-				for (int i = 0; i < mettimefilelength + 1; i++)
-				{
-					for (int n = 0; n < maxsource; n++)
-					{
-						emifac_timeseries[i, n] = 1;
-					}
-				}
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                //it is necessary to set all values of the array emifac_timeseries equal to 1
+                for (int i = 0; i < mettimefilelength + 1; i++)
+                {
+                    for (int n = 0; n < maxsource; n++)
+                    {
+                        emifac_timeseries[i, n] = 1;
+                    }
+                }
 
-				// read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
-				newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
-				if (File.Exists(newpath) == true)
-				{
-					try
-					{
-						//read timeseries of emissions
-						string[] text10 = new string[1];
-						using (StreamReader read1 = new StreamReader(newpath))
-						{
-							//get source group numbers
-							text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
-							for (int i = 2; i < text10.Length; i++)
-							{
-								//get the column corresponding with the source group number stored in sg_numbers
-								string sg_temp = text10[i];
-								for (int itm1 = 0; itm1 < maxsource; itm1++)
-								{
-									if (sg_numbers[itm1] == Convert.ToInt32(sg_temp))
-									{
-										sg_time[itm1] = i;
+                // read value from emissions_timeseries.txt -> emifac_day[] and emifac_mon[] not used
+                newpath = Path.Combine(mydata.Projectname, "Computation","emissions_timeseries.txt");
+                if (File.Exists(newpath) == true)
+                {
+                    try
+                    {
+                        //read timeseries of emissions
+                        string[] text10 = new string[1];
+                        using (StreamReader read1 = new StreamReader(newpath))
+                        {
+                            //get source group numbers
+                            text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
+                            for (int i = 2; i < text10.Length; i++)
+                            {
+                                //get the column corresponding with the source group number stored in sg_numbers
+                                string sg_temp = text10[i];
+                                for (int itm1 = 0; itm1 < maxsource; itm1++)
+                                {
+                                    if (sg_numbers[itm1] == Convert.ToInt32(sg_temp))
+                                    {
+                                        sg_time[itm1] = i;
 
-										//set emifac_day and emifac_mon equal one -> only for those source groups that are defined in emissions_timeseries.txt
-										for (int j = 0; j < 24; j++)
-										{
-											emifac_day[j, itm1] = 1;
-											if (j < 12)
-												emifac_mon[j, itm1] = 1;
-										}
-									}
-								}
+                                        //set emifac_day and emifac_mon equal one -> only for those source groups that are defined in emissions_timeseries.txt
+                                        for (int j = 0; j < 24; j++)
+                                        {
+                                            emifac_day[j, itm1] = 1;
+                                            if (j < 12)
+                                                emifac_mon[j, itm1] = 1;
+                                        }
+                                    }
+                                }
 
-							}
+                            }
 
-							for (int i = 0; i < mettimefilelength; i++)
-							{
-								text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
-								for (int n = 0; n < maxsource; n++)
-								{
-									if (sg_time[n] == 0)
-									{
-										emifac_timeseries[i, n] = 1;
-									}
-									else
-									{
-										emifac_timeseries[i, n] = Convert.ToDouble(text10[sg_time[n]].Replace(".", decsep));
-									}
-								}
-							}
-						}
-						
-					}
-					catch(Exception ex)
-					{
-						BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
-						return;
-					}
-				} // read value from emissions_timeseries.txt
-			}
-			
-			List<string> wgmet = new List<string>();
-			List<string> wrmet = new List<string>();
-			List<string> akmet = new List<string>();
-			string[] text3 = new string[2];
-			int hourplus = 0;
-			string wgmettime;
-			string wrmettime;
-			string akmettime;
-			string month;
-			string hour;
-			string day;
-			
-			List<string> rec_names=new List<string>();
-			
-			//get number of receptor points and names of receptors
-			string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
-			if(File.Exists(receptorfile))
-			{
-				try
-				{
-					using(StreamReader read=new StreamReader(receptorfile))
-					{
-						dummy=read.ReadLine(); // 1st line with number of receptor points
-						
-						while (read.EndOfStream == false)
-						{
-							text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
-							
-							if (text.Length > 1) // valid line?
-							{
-								xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
-								
-								string a = text[0]; 	// take number as name
-								if (text.Length > 4) 	// get name from line
-									a = text[4];   
-								
-								if (text.Length >= 5) // if the Receptor-Name contains ","
-								{
-									for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
-									{
-										if (text[k] != "") a = a + "_" + text[k];
-									}
-								}
-								
-								// if the receptor name contains invalid characters for a file!
-								a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
-								rec_names.Add(a);
-							}
-						}
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error reading Receptor.dat");
-					return;
-				}
-				
-			}
-			
-			//MessageBox.Show(Convert.ToString(rec_names.Count));
-			
-			//read meteopgt.all
-			newpath = Path.Combine("Computation","meteopgt.all");
-			using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-			{
-				text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-				while (myReader.EndOfStream == false)
-				{
-					try
-					{
-						text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-						wrmet.Add(text[0]);
-						wgmet.Add(text[1]);
-						akmet.Add(text[2]);
-					}
-					catch
-					{
-						BackgroundThreadMessageBox ("Error reading meteopgt.all");
-						return;
-					}
-				}
-			}
-			
-			double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
-			                                            => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
-			                                                                     => new double[wrmet.Count]));
-			double fmod = 1;
+                            for (int i = 0; i < mettimefilelength; i++)
+                            {
+                                text10 = read1.ReadLine().Split(new char[] { ' ', ':', '-', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
+                                for (int n = 0; n < maxsource; n++)
+                                {
+                                    if (sg_time[n] == 0)
+                                    {
+                                        emifac_timeseries[i, n] = 1;
+                                    }
+                                    else
+                                    {
+                                        emifac_timeseries[i, n] = Convert.ToDouble(text10[sg_time[n]].Replace(".", decsep));
+                                    }
+                                }
+                            }
+                        }
+                        
+                    }
+                    catch(Exception ex)
+                    {
+                        BackgroundThreadMessageBox (ex.Message + " Error reading emissions_timeseries.txt - evaluation stopped");
+                        return;
+                    }
+                } // read value from emissions_timeseries.txt
+            }
+            
+            List<string> wgmet = new List<string>();
+            List<string> wrmet = new List<string>();
+            List<string> akmet = new List<string>();
+            string[] text3 = new string[2];
+            int hourplus = 0;
+            string wgmettime;
+            string wrmettime;
+            string akmettime;
+            string month;
+            string hour;
+            string day;
+            
+            List<string> rec_names=new List<string>();
+            
+            //get number of receptor points and names of receptors
+            string receptorfile=Path.Combine(mydata.Projectname, "Computation","Receptor.dat");
+            if(File.Exists(receptorfile))
+            {
+                try
+                {
+                    using(StreamReader read=new StreamReader(receptorfile))
+                    {
+                        dummy=read.ReadLine(); // 1st line with number of receptor points
+                        
+                        while (read.EndOfStream == false)
+                        {
+                            text = read.ReadLine().Split(new char[] { ',' }, StringSplitOptions.RemoveEmptyEntries);
+                            
+                            if (text.Length > 1) // valid line?
+                            {
+                                xrec.Add(Convert.ToDouble(text[1].Replace(".", decsep)));
+                                
+                                string a = text[0]; 	// take number as name
+                                if (text.Length > 4) 	// get name from line
+                                    a = text[4];   
+                                
+                                if (text.Length >= 5) // if the Receptor-Name contains ","
+                                {
+                                    for (int k = 5; k < text.Length; k++) // make it possible, that "," is in the Receptor point
+                                    {
+                                        if (text[k] != "") a = a + "_" + text[k];
+                                    }
+                                }
+                                
+                                // if the receptor name contains invalid characters for a file!
+                                a =string.Join("_", a.Split(Path.GetInvalidFileNameChars()));
+                                rec_names.Add(a);
+                            }
+                        }
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error reading Receptor.dat");
+                    return;
+                }
+                
+            }
+            
+            //MessageBox.Show(Convert.ToString(rec_names.Count));
+            
+            //read meteopgt.all
+            newpath = Path.Combine("Computation","meteopgt.all");
+            using (StreamReader myReader = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+            {
+                text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                while (myReader.EndOfStream == false)
+                {
+                    try
+                    {
+                        text = myReader.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        wrmet.Add(text[0]);
+                        wgmet.Add(text[1]);
+                        akmet.Add(text[2]);
+                    }
+                    catch
+                    {
+                        BackgroundThreadMessageBox ("Error reading meteopgt.all");
+                        return;
+                    }
+                }
+            }
+            
+            double[][][] conc = GralIO.Landuse.CreateArray<double[][]>(xrec.Count, () 
+                                                        => GralIO.Landuse.CreateArray<double[]>(maxsource, () 
+                                                                                 => new double[wrmet.Count]));
+            double fmod = 1;
 
-			//read all computed concentrations from file zeitreihe.dat
-			bool zeitflag = false;
-			string[] text5 = new string[xrec.Count * sg_names.Length];
-			int numbwet = 0;
-			receptorfile=Path.Combine(mydata.Projectname, "Computation","zeitreihe.dat");
-			if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
-			{
-				zeitflag = true;
-				
-				try
-				{
+            //read all computed concentrations from file zeitreihe.dat
+            bool zeitflag = false;
+            string[] text5 = new string[xrec.Count * sg_names.Length];
+            int numbwet = 0;
+            receptorfile=Path.Combine(mydata.Projectname, "Computation","zeitreihe.dat");
+            if (File.Exists(receptorfile) && mydata.Sel_Source_Grp != string.Empty)
+            {
+                zeitflag = true;
+                
+                try
+                {
                     using (StreamReader read = new StreamReader(receptorfile))
                     {
                         while (read.EndOfStream == false)
@@ -321,8 +321,12 @@ namespace GralBackgroundworkers
 
                                 for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
                                 {
-                                    conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
-                                    count++;
+                                    //check if this situation has been computed, otherwise this line is 0
+                                    if (text5.Length > count)
+                                    {
+                                        conc[numbrec][sg_number][numbwet] = Convert.ToDouble(text5[count].Replace(".", decsep));
+                                        count++;
+                                    }
                                 }
                             }
                             numbwet++;
@@ -330,185 +334,182 @@ namespace GralBackgroundworkers
                     }
                 }
                 catch
-				{
-					BackgroundThreadMessageBox ("Error reading zeitreihe.dat. Is this file available?" + Environment.NewLine +
-												"Has the number of receptors or source groups changed?");
-					return;
-				}
-				
-				
-			}
-			
-			//read all wind speeds from file GRAL_Meteozeitreihe.dat
-			bool metflag = false;
-			bool local_SCL = false;
-			string[] text7 = new string[xrec.Count];
-			
-			string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
-			int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
-			
-			double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-			double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
-			int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+                {
+                    BackgroundThreadMessageBox ("Error reading zeitreihe.dat. Is this file available?" + Environment.NewLine +
+                                                "Has the number of receptors or source groups changed?");
+                    return;
+                }			
+            }
+            
+            //read all wind speeds from file GRAL_Meteozeitreihe.dat
+            bool metflag = false;
+            bool local_SCL = false;
+            string[] text7 = new string[xrec.Count];
+            
+            string GRAL_metfile = Path.Combine(mydata.Projectname, "Computation","GRAL_Meteozeitreihe.dat");
+            int zeitreihe_lenght = (int) GralStaticFunctions.St_F.CountLinesInFile(GRAL_metfile);
+            
+            double[,] GRAL_u = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            double[,] GRAL_v = new double[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
+            int[,] GRAL_SC = new int[xrec.Count, Math.Max(zeitreihe_lenght, wrmet.Count) + 1];
             string[] ReceptorMeteoCoors = new string[5];
-			
-			if (File.Exists(GRAL_metfile))
-			{
-				metflag = true;
-				numbwet = 0;
-				
-				if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
-				{
+            
+            if (File.Exists(GRAL_metfile))
+            {
+                metflag = true;
+                numbwet = 0;
+                
+                if (Read_Meteo_Zeitreihe(GRAL_metfile, ref numbwet, ref local_SCL, ref GRAL_u, ref GRAL_v, ref GRAL_SC, ref ReceptorMeteoCoors) == false)
+                {
                     metflag = false;
-				}
-			}
+                }
+            }
 
-			if (mydata.Sel_Source_Grp != string.Empty) // otherwise just analyze the wind data
-			{
-				if (zeitflag == true) // write mettime series for all receptor points
-				{
-					try
-					{
-						string file = Path.Combine(mydata.Projectname, "Computation","Receptor_timeseries_"+ mydata.Prefix + mydata.Pollutant + ".txt");
-						if (File.Exists(file))
-						{
-							try
-							{
-								File.Delete(file);
-							}
-							catch{}
-						}
+            if (!string.IsNullOrEmpty(mydata.Sel_Source_Grp)) // otherwise just analyze the wind data
+            {
+                if (zeitflag == true) // write mettime series for all receptor points
+                {
+                    try
+                    {
+                        string file = Path.Combine(mydata.Projectname, "Computation","Receptor_timeseries_"+ mydata.Prefix + mydata.Pollutant + ".txt");
+                        if (File.Exists(file))
+                        {
+                            try
+                            {
+                                File.Delete(file);
+                            }
+                            catch{}
+                        }
 
-						//write results to file receptor_timeseries.txt
-						using (StreamWriter recwrite = new StreamWriter(file))
-						{
-							//write header line
-							string[] text6 = new string[2];
-							//write source groups
-							recwrite.Write("Date \t Time \t"); // Header Date, Time
-							
-							foreach (string hy in sg_names)
-							{
-								for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-								{
-									text6 = hy.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
-									recwrite.Write(text6[0]+"-Rec:"+Convert.ToString(numbrec+1) + "\t"); // Header source-groups use Tabulator
-								}
-							}
-							recwrite.WriteLine();
-							
-							//read mettimeseries.dat
-							newpath = Path.Combine("Computation", "mettimeseries.dat");
-							StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath));
-							text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-							text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                        //write results to file receptor_timeseries.txt
+                        using (StreamWriter recwrite = new StreamWriter(file))
+                        {
+                            //write header line
+                            string[] text6 = new string[2];
+                            //write source groups
+                            recwrite.Write("Date \t Time \t"); // Header Date, Time
+                            
+                            foreach (string hy in sg_names)
+                            {
+                                for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                                {
+                                    text6 = hy.Split(new char[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+                                    recwrite.Write(text6[0]+"-Rec:"+Convert.ToString(numbrec+1) + "\t"); // Header source-groups use Tabulator
+                                }
+                            }
+                            recwrite.WriteLine();
+                            
+                            //read mettimeseries.dat
+                            newpath = Path.Combine("Computation", "mettimeseries.dat");
+                            StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath));
+                            text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                            text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
 
-							//consider, if meteopgt.all represents a time series or a statistics
-							int dispersionsituations = 0;
-							if (mydata.Checkbox19 == true)
-								dispersionsituations = numbwet + 1;
-							else
-								dispersionsituations = wrmet.Count;
-							
-							int count_dispsit_in_mettime = 0;
-							int count_ws = -1;
+                            //consider, if meteopgt.all represents a time series or a statistics
+                            int dispersionsituations = 0;
+                            if (mydata.Checkbox19 == true)
+                                dispersionsituations = numbwet + 1;
+                            else
+                                dispersionsituations = wrmet.Count;
+                            
+                            int count_dispsit_in_mettime = 0;
+                            int count_ws = -1;
 
-							while (text2[0] != "")
-							{
-								count_ws++;
-								count_dispsit_in_mettime += 1;
-								
-								if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
-									break;
+                            while (text2[0] != "")
+                            {
+                                count_ws++;
+                                count_dispsit_in_mettime += 1;
+                                
+                                if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true))
+                                    break;
 
-								month = text3[1];
-								day = text3[0];
-								hour = text2[1];
-								if (hour == "24")
-									hourplus = 1;
-								wgmettime = text2[2];
-								wrmettime = text2[3];
-								akmettime = text2[4];
+                                month = text3[1];
+                                day = text3[0];
+                                hour = text2[1];
+                                if (hour == "24")
+                                    hourplus = 1;
+                                wgmettime = text2[2];
+                                wrmettime = text2[3];
+                                akmettime = text2[4];
 
-								//search in file meteopgt.all for the corresponding dispersion situation
+                                //search in file meteopgt.all for the corresponding dispersion situation
 
-								for (int n = 0; n < dispersionsituations; n++)
-								{
-									if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
-									{
-										//take care if not all dispersion situations have been computed
-										if (n >= numbwet)
-										{
-											//write results
-											dummy = "";
-											recwrite.WriteLine(dummy);
-										}
-										else
-										{
-											SetText("Day.Month: " + day + "." + month);
-											
-											int std = Convert.ToInt32(hour);
-											int mon = Convert.ToInt32(month) - 1;
+                                for (int n = 0; n < dispersionsituations; n++)
+                                {
+                                    if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                    {
+                                        //take care if not all dispersion situations have been computed
+                                        if (n >= numbwet)
+                                        {
+                                            //write results
+                                            dummy = "";
+                                            recwrite.WriteLine(dummy);
+                                        }
+                                        else
+                                        {
+                                            SetText("Day.Month: " + day + "." + month);
+                                            
+                                            int std = Convert.ToInt32(hour);
+                                            int mon = Convert.ToInt32(month) - 1;
 
-											//write results
-											dummy = "";
-											dummy = day + "." + month + "\t" + hour+":00\t";
-											fmod = 1;
-											foreach (string hy in sg_names)
-											{
-												{
-													int itm = Convert.ToInt32(GetSgNumbers(hy)) - 1;
-													
-													//compute emission modulation factor
-													fmod = emifac_day[std - hourplus, itm] * emifac_mon[mon, itm] * emifac_timeseries[count_ws, itm];
-													
-													for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-													{
-													    dummy = dummy + Convert.ToString(conc[numbrec][itm][n] * fmod) + "\t";
-													}
-												}
-												
-											}
-											recwrite.WriteLine(dummy);
-											//consider, if meteopgt.all represents a time series or a statistics
-											if (mydata.Checkbox19 == true)
-												break;
-										}
-									}
-								}
-								try
-								{
-									text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-									text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-								}
-								catch
-								{
-									break;
-								}
-							}
-							
-						} // using
-					}
-					catch
-					{
-						BackgroundThreadMessageBox ("Error writing the file receptor_timeseries.txt");
-						return;
-					}
-				}
-				else
-				{
-					BackgroundThreadMessageBox ("File zeitreihe.dat not found");
-				}
-			}
-			
-			if (metflag == true) // write meteorological data for all receptor points
-			{
+                                            //write results
+                                            dummy = "";
+                                            dummy = day + "." + month + "\t" + hour+":00\t";
+                                            fmod = 1;
+                                            foreach (string hy in sg_names)
+                                            {
+                                                {
+                                                    int itm = Convert.ToInt32(GetSgNumbers(hy)) - 1;
+                                                    
+                                                    //compute emission modulation factor
+                                                    fmod = emifac_day[std - hourplus, itm] * emifac_mon[mon, itm] * emifac_timeseries[count_ws, itm];
+                                                    
+                                                    for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                                                    {
+                                                        dummy = dummy + Convert.ToString(conc[numbrec][itm][n] * fmod) + "\t";
+                                                    }
+                                                }										
+                                            }
+                                            recwrite.WriteLine(dummy);
+                                            //consider, if meteopgt.all represents a time series or a statistics
+                                            if (mydata.Checkbox19 == true)
+                                                break;
+                                        }
+                                    }
+                                }
+                                try
+                                {
+                                    text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                    text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                }
+                                catch
+                                {
+                                    break;
+                                }
+                            }
+                            
+                        } // using
+                    }
+                    catch
+                    {
+                        BackgroundThreadMessageBox ("Error writing the file receptor_timeseries.txt");
+                        return;
+                    }
+                }
+                else
+                {
+                    BackgroundThreadMessageBox ("File zeitreihe.dat not found");
+                }
+            }
+            
+            if (metflag == true) // write meteorological data for all receptor points
+            {
                 try
                 {
-                    string[] recname = new string[0];
-                    string[] recX = new string[0];
-                    string[] recY = new string[0];
-                    string[] recZ = new string[0];
+                    string[] recname = Array.Empty<string>();
+                    string[] recX = Array.Empty<string>();
+                    string[] recY = Array.Empty<string>();
+                    string[] recZ = Array.Empty<string>();
                    
                     if (!string.IsNullOrEmpty(ReceptorMeteoCoors[0]))
                     {
@@ -553,171 +554,170 @@ namespace GralBackgroundworkers
                                 catch { }
                             }
 
-							string[] text6 = new string[2];
+                            string[] text6 = new string[2];
 
-							//read mettimeseries.dat
-							newpath = Path.Combine("Computation", "mettimeseries.dat");
-							
-							using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
-							{
-								text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-								text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-								string dummy_year = "1990";
-								int year_increase=0;
-								int monthold = -1;
+                            //read mettimeseries.dat
+                            newpath = Path.Combine("Computation", "mettimeseries.dat");
+                            
+                            using (StreamReader read = new StreamReader(Path.Combine(mydata.Projectname, newpath)))
+                            {
+                                text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                string dummy_year = "1990";
+                                int year_increase=0;
+                                int monthold = -1;
 
-								//consider, if meteopgt.all represents a time series or a statistics
-								int dispersionsituations = 0;
-								if (mydata.Checkbox19 == true || transient == true)
-									dispersionsituations = numbwet + 1;
-								else
-									dispersionsituations = wrmet.Count;
-								
-								int count_dispsit_in_mettime = 0;
+                                //consider, if meteopgt.all represents a time series or a statistics
+                                int dispersionsituations = 0;
+                                if (mydata.Checkbox19 == true || transient == true)
+                                    dispersionsituations = numbwet + 1;
+                                else
+                                    dispersionsituations = wrmet.Count;
+                                
+                                int count_dispsit_in_mettime = 0;
 
-								while (text2[0] != "")
-								{
-									count_dispsit_in_mettime++;
-									if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
-										break;
+                                while (!string.IsNullOrEmpty(text2[0]))
+                                {
+                                    count_dispsit_in_mettime++;
+                                    if ((count_dispsit_in_mettime > numbwet) && (mydata.Checkbox19 == true || transient == true))
+                                        break;
 
-									month = text3[1];
-									day = text3[0];
-									hour = text2[1];
-									if (hour == "24")
-										hourplus = 1;
-									wgmettime = text2[2];
-									wrmettime = text2[3];
-									akmettime = text2[4];
+                                    month = text3[1];
+                                    day = text3[0];
+                                    hour = text2[1];
+                                    if (hour == "24")
+                                        hourplus = 1;
+                                    wgmettime = text2[2];
+                                    wrmettime = text2[3];
+                                    akmettime = text2[4];
 
-									//artificially increase year by one
-									if (Convert.ToInt32(month) < monthold)
-										year_increase += 1;
-									monthold = Convert.ToInt32(text3[1]);
+                                    //artificially increase year by one
+                                    if (Convert.ToInt32(month) < monthold)
+                                        year_increase += 1;
+                                    monthold = Convert.ToInt32(text3[1]);
 
-									int corr_situation = 0;
-									
-									if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
-									{
-										//search in file meteopgt.all for the corresponding dispersion situation
-										for (int n = 0; n < dispersionsituations; n++)
-										{
-											if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
-											{
-												//take care if not all dispersion situations have been computed
-												if (n >= numbwet)
-												{
-													//write results
-													//dummy = "";
-													//recwrite.WriteLine(dummy);
-												}
-												else
-												{
-													corr_situation = n;
-													break;
-												}
-											}
-										}
-									}
-									else // transient mode: situation = line number of mettimeseries 
-									{
-										corr_situation = count_dispsit_in_mettime;
-									}
-									
-									if (corr_situation > 0)
-									{
-										int n  = corr_situation;
-										SetText("Day.Month: " + day + "." + month);
-										
-										int std = Convert.ToInt32(hour);
-										int mon = Convert.ToInt32(month) - 1;
+                                    int corr_situation = 0;
+                                    
+                                    if (transient == false) // non - transient mode: search for corr. situation in meteopgt.all
+                                    {
+                                        //search in file meteopgt.all for the corresponding dispersion situation
+                                        for (int n = 0; n < dispersionsituations; n++)
+                                        {
+                                            if ((wgmet[n] == wgmettime) && (wrmet[n] == wrmettime) && (akmet[n] == akmettime))
+                                            {
+                                                //take care if not all dispersion situations have been computed
+                                                if (n >= numbwet)
+                                                {
+                                                    //write results
+                                                    //dummy = "";
+                                                    //recwrite.WriteLine(dummy);
+                                                }
+                                                else
+                                                {
+                                                    corr_situation = n;
+                                                    break;
+                                                }
+                                            }
+                                        }
+                                    }
+                                    else // transient mode: situation = line number of mettimeseries 
+                                    {
+                                        corr_situation = count_dispsit_in_mettime;
+                                    }
+                                    
+                                    if (corr_situation > 0)
+                                    {
+                                        int n  = corr_situation;
+                                        SetText("Day.Month: " + day + "." + month);
+                                        
+                                        int std = Convert.ToInt32(hour);
+                                        int mon = Convert.ToInt32(month) - 1;
 
-										//write results
-										dummy = "";
-										dummy_year = Convert.ToString(1990 + year_increase);
-										dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
-										//compute wind speed and direction
-										windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
-										if (GRAL_v[k,n] == 0)
-											winddirection_GRAL = 90;
-										else
-											winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
-										if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
-											winddirection_GRAL = 180 - winddirection_GRAL;
-										if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
-											winddirection_GRAL = 180 + winddirection_GRAL;
-										if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
-											winddirection_GRAL = 360 - winddirection_GRAL;
+                                        //write results
+                                        dummy = "";
+                                        dummy_year = Convert.ToString(1990 + year_increase);
+                                        dummy = day + "." + month + "." +dummy_year + "," + hour + ":00,";
+                                        //compute wind speed and direction
+                                        windspeed_GRAL = Math.Round(Math.Pow(Math.Pow(GRAL_u[k,n], 2) + Math.Pow(GRAL_v[k,n], 2), 0.5),2);
+                                        if (GRAL_v[k,n] == 0)
+                                            winddirection_GRAL = 90;
+                                        else
+                                            winddirection_GRAL = Convert.ToInt32(Math.Abs(Math.Atan(GRAL_u[k, n] / GRAL_v[k, n])) * 180 / 3.14);
+                                        if ((GRAL_v[k, n] > 0) && (GRAL_u[k, n] <= 0))
+                                            winddirection_GRAL = 180 - winddirection_GRAL;
+                                        if ((GRAL_v[k, n] >= 0) && (GRAL_u[k, n] > 0))
+                                            winddirection_GRAL = 180 + winddirection_GRAL;
+                                        if ((GRAL_v[k, n] < 0) && (GRAL_u[k, n] >= 0))
+                                            winddirection_GRAL = 360 - winddirection_GRAL;
 
-										dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
+                                        dummy = dummy + Convert.ToString(windspeed_GRAL, ic) + "," + Convert.ToString(Math.Round(winddirection_GRAL, 0));
 
-										if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
-										{
-											if (GRAL_SC[k, n] > 0) // if this situation is not available yet
-											{
-												dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
-											}
-											else
-											{
-												dummy = dummy + "," + Convert.ToString(akmettime);
-											}
-										}
-										else
-										{
-											dummy = dummy + "," + Convert.ToString(akmettime);
-										}
-										
-										recwrite.WriteLine(dummy);
-										//consider, if meteopgt.all represents a time series or a statistics
+                                        if (local_SCL == true) // 11.9.2017 Kuntner -> new File format?
+                                        {
+                                            if (GRAL_SC[k, n] > 0) // if this situation is not available yet
+                                            {
+                                                dummy = dummy + "," + Convert.ToString(GRAL_SC[k, n]);
+                                            }
+                                            else
+                                            {
+                                                dummy = dummy + "," + Convert.ToString(akmettime);
+                                            }
+                                        }
+                                        else
+                                        {
+                                            dummy = dummy + "," + Convert.ToString(akmettime);
+                                        }
+                                        
+                                        recwrite.WriteLine(dummy);
+                                        //consider, if meteopgt.all represents a time series or a statistics
 //										if (mydata.Checkbox19 == true || transient == true)
 //											break;
-									}
-									try
-									{
-										text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-										text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
-									}
-									catch
-									{
-										break;
-									}
-								}
-							} // using read
-						} // using recwrite
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error writing GRAL-Metfiles");
-					return;
-				}
-				
-			}
-			else
-			{
-				//MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
-			}
-		}
-		
-		private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
+                                    }
+                                    try
+                                    {
+                                        text2 = read.ReadLine().Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                        text3 = text2[0].Split(new char[] { '.', ':', '-' }, StringSplitOptions.RemoveEmptyEntries);
+                                    }
+                                    catch
+                                    {
+                                        break;
+                                    }
+                                }
+                            } // using read
+                        } // using recwrite
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error writing GRAL-Metfiles");
+                    return;
+                }
+                
+            }
+            else
+            {
+                //MessageBox.Show("File GRAL_Meteozeitreihe.dat not found", "Receptor Concentrations", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+        
+        private bool Read_Meteo_Zeitreihe(string GRAL_metfile, ref int numbwet, ref bool local_SCL, 
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
-		{
-			string[] text7 = new string[1];
-			numbwet = 1;
+        {
+            numbwet = 1;
             int ParamOffset = 2; // old file format
             int headerLineNumber = 0;
 
-			try // 11.9.2017 Kuntner -> new File format?
-			{
-				using(StreamReader read1 = new StreamReader(GRAL_metfile))
-				{
+            try // 11.9.2017 Kuntner -> new File format?
+            {
+                using(StreamReader read1 = new StreamReader(GRAL_metfile))
+                {
                     string header = read1.ReadLine().Trim();
                     if (header.Equals("U,V,SC"))
-					{
-						local_SCL = true;
+                    {
+                        local_SCL = true;
                         ParamOffset = 3; // U,V,SC
                         headerLineNumber = 1;
-					}
+                    }
                     else if (header.StartsWith("U,V,SC,BLH"))
                     {
                         local_SCL = true;
@@ -732,17 +732,17 @@ namespace GralBackgroundworkers
                     }
                     if (header.EndsWith("+")) // Additional header lines for name and coordinates of receptors
                     {
-                        headerLineNumber = 5;
+                        headerLineNumber = 6;
                     }
                 }
-			}
-			catch{}
-				
-			using (StreamReader read = new StreamReader(GRAL_metfile))
-			{
-				try
-				{
-					if (headerLineNumber > 0) // Read header lines
+            }
+            catch{}
+                
+            using (StreamReader read = new StreamReader(GRAL_metfile))
+            {
+                 try
+                {
+                    if (headerLineNumber > 0) // Read header lines
                     {
                         ReceptorHeader = new string[headerLineNumber + 1];
 
@@ -760,39 +760,43 @@ namespace GralBackgroundworkers
                             }
                         }
                     }
-					
+                    
                     // read entire file
-					while (read.EndOfStream == false)
-					{
-						text7 = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-						int count = 0;
-						for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
-						{
-							GRAL_u[numbrec, numbwet] = Convert.ToDouble(text7[count], ic);
-							GRAL_v[numbrec, numbwet] = Convert.ToDouble(text7[count + 1], ic);
-							if (local_SCL) // 11.9.2017 Kuntner -> new File format
-							{
-								GRAL_SC[numbrec, numbwet] = Convert.ToInt32(text7[count + 2], ic);
-								count += ParamOffset;
-							}
-							else
-							{
-								count += ParamOffset;
-							}
-						}
-						numbwet++;
-					}
-				}
-				catch
-				{
-					BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
-					return false;
-				}
-			}
-			
-			Computation_Completed = true; // set flag, that computation was successful
-			return true;
-		} // Read_GRAL_Meteozeitreihe
-		
-	}
+                    while (read.EndOfStream == false)
+                    {
+                        string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        int count = 0;
+                        for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                        {
+                            //check if this situation has been computed, otherwise this line is 0
+                            if (columns.Length > count + 2)
+                            {
+                                GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
+                                GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);
+                                if (local_SCL) // 11.9.2017 Kuntner -> new File format
+                                {
+                                    GRAL_SC[numbrec, numbwet] = Convert.ToInt32(columns[count + 2], ic);
+                                    count += ParamOffset;
+                                }
+                                else
+                                {
+                                    count += ParamOffset;
+                                }
+                            }
+                        }
+                        numbwet++;
+                    }
+                }
+                catch
+                {
+                    BackgroundThreadMessageBox ("Error reading GRAL_Meteozeitreihe.dat");
+                    return false;
+                }
+            }
+            
+            Computation_Completed = true; // set flag, that computation was successful
+            return true;
+        } // Read_GRAL_Meteozeitreihe
+        
+    }
 }

--- a/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
+++ b/Source/Gral/GRALBackgroundworkers/Background_ReceptorConcentration.cs
@@ -704,7 +704,7 @@ namespace GralBackgroundworkers
                                           ref double[,] GRAL_u, ref double[,] GRAL_v, ref int[,] GRAL_SC, ref string[] ReceptorHeader)
         {
             numbwet = 1;
-            int ParamOffset = 2; // old file format
+            int columnOffset = 2; // old file format
             int headerLineNumber = 0;
 
             try // 11.9.2017 Kuntner -> new File format?
@@ -715,19 +715,19 @@ namespace GralBackgroundworkers
                     if (header.Equals("U,V,SC"))
                     {
                         local_SCL = true;
-                        ParamOffset = 3; // U,V,SC
+                        columnOffset = 3; // U,V,SC
                         headerLineNumber = 1;
                     }
                     else if (header.StartsWith("U,V,SC,BLH"))
                     {
                         local_SCL = true;
-                        ParamOffset = 4; // U,V,SC,BLH
+                        columnOffset = 4; // U,V,SC,BLH
                         headerLineNumber = 1;
                     }
                     else if (header.StartsWith("U,V,BLH"))
                     {
                         local_SCL = false;
-                        ParamOffset = 3; //U,V,BLH
+                        columnOffset = 3; //U,V,BLH
                         headerLineNumber = 1;
                     }
                     if (header.EndsWith("+")) // Additional header lines for name and coordinates of receptors
@@ -765,23 +765,21 @@ namespace GralBackgroundworkers
                     while (read.EndOfStream == false)
                     {
                         string[] columns = read.ReadLine().Split(new char[] { ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                        int numberOfReceptors = (int)(columns.Length / columnOffset);
                         int count = 0;
-                        for (int numbrec = 0; numbrec < xrec.Count; numbrec++)
+                        
+                        for (int numbrec = 0; numbrec < numberOfReceptors; numbrec++)
                         {
                             //check if this situation has been computed, otherwise this line is 0
-                            if (columns.Length > count + 2)
+                            if (columns.Length > count + 2 && GRAL_u.GetUpperBound(0) >= numberOfReceptors)
                             {
                                 GRAL_u[numbrec, numbwet] = Convert.ToDouble(columns[count], ic);
                                 GRAL_v[numbrec, numbwet] = Convert.ToDouble(columns[count + 1], ic);
                                 if (local_SCL) // 11.9.2017 Kuntner -> new File format
                                 {
                                     GRAL_SC[numbrec, numbwet] = Convert.ToInt32(columns[count + 2], ic);
-                                    count += ParamOffset;
                                 }
-                                else
-                                {
-                                    count += ParamOffset;
-                                }
+                                count += columnOffset;
                             }
                         }
                         numbwet++;

--- a/Source/Gral/GRALMainFunctions/Main_DeleteFiles.cs
+++ b/Source/Gral/GRALMainFunctions/Main_DeleteFiles.cs
@@ -126,6 +126,18 @@ namespace Gral
                 if (File.Exists(newPath))
                     File.Delete(newPath);
 
+                newPath = Path.Combine(ProjectName, "Computation", "zeitreihe.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
+                newPath = Path.Combine(ProjectName, "Computation", "ReceptorConcentrations.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
+                newPath = Path.Combine(ProjectName, "Computation", "GRAL_Meteozeitreihe.dat");
+                if (File.Exists(newPath))
+                    File.Delete(newPath);
+
                 DispNrChanged(null, null); // change displaynumber
                 GralFileSizes();
             }

--- a/Source/Gral/Main.cs
+++ b/Source/Gral/Main.cs
@@ -1642,11 +1642,17 @@ namespace Gral
                 {
                     groupBox13.Visible = true;
                     groupBox14.Visible = false;
-                    string receptorfile = Path.Combine(ProjectName, @"Computation", "zeitreihe.dat");
-                    if (File.Exists(receptorfile))
+
+                    if (File.Exists(Path.Combine(ProjectName, @"Computation", "zeitreihe.dat")) ||
+                        File.Exists(Path.Combine(ProjectName, @"Computation", "ReceptorConcentrations.dat")))
+                    {
                         button37.Visible = true;
+                    }
                     else
+                    {
                         button37.Visible = false;
+                    }
+
                     //check transient GRAL simulation
                     InDatVariables data = new InDatVariables();
                     InDatFileIO ReadInData = new InDatFileIO();


### PR DESCRIPTION
The new GRAL output files GRAL_Meteozeitreihe.dat and ReceptorConcetration.dat (replaces the file zeitreihe.dat) got headers with information about the receptor names, the rec. coordinates and the source group
The new GUI evaluation function produces *.met files with the new header (geografical referenced) and new output files (Receptor_Timeseries_XXX.dat) using the local culture with unicode encoding. The output files got an additional header with receptor names, rec. coordinates and the source group number.
The GUI evaluation function should be compatible with outputs of former GRAL version before V20.01. The corrupt V20.01 GRAL_Meteozeitreihe.dat files are not readable, but due to changes in the evaluation function, the V20.01 zeitreihe.dat should be readable and the concentration evaluation for GRAL V20.01 files should be possible.