### PR TITLE
V2411

### DIFF
--- a/AutoUpdater.xml
+++ b/AutoUpdater.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
-  <version>2.2.0.3</version>
-  <url>https://github.com/GralDispersionModel/GRAL/releases/download/V22.03/V2203.zip</url>
-  <changelog>https://github.com/GralDispersionModel/GUI/releases</changelog>
+  <version>2.4.0.4</version>
+  <url>https://gral.tugraz.at/</url>
+  <changelog>https://github.com/GralDispersionModel/GRAL/releases</changelog>
   <mandatory>false</mandatory>
 </item>

--- a/runtimeconfig.template.json
+++ b/runtimeconfig.template.json
@@ -1,6 +1,7 @@
 {
   "configProperties": 
   {
-    "System.Net.DisableIPv6": "true" 
+    "System.Net.DisableIPv6": "true",
+    "System.Windows.Forms.DataGridViewUIAStartRowCountAtZero": true
   }
 }

--- a/src/GRALBackgroundworkers/BackgroundWorkerData.cs
+++ b/src/GRALBackgroundworkers/BackgroundWorkerData.cs
@@ -286,6 +286,10 @@ namespace GralBackgroundworkers
         /// Year for meteo time series
         /// </summary>
         public int FictiousYear { get; set; }
+        /// <summary>
+        /// Sum up sub-hourly concentrations to hourly mean concentrations?
+        /// </summary>
+        public bool SubHourlyToMeanHourlyConcentrations { get; set; }
     }
 
     public class CellNumbers

--- a/src/GRALBackgroundworkers/BackgroundWorkerData.cs
+++ b/src/GRALBackgroundworkers/BackgroundWorkerData.cs
@@ -290,6 +290,10 @@ namespace GralBackgroundworkers
         /// Sum up sub-hourly concentrations to hourly mean concentrations?
         /// </summary>
         public bool SubHourlyToMeanHourlyConcentrations { get; set; }
+        /// <summary>
+        /// Time span for the meteorology when using time spans < 3600 s
+        /// </summary>
+        public int SubHourlyTimeSpan { get; set; }
     }
 
     public class CellNumbers

--- a/src/GRALBackgroundworkers/Background_HighPercentiles.cs
+++ b/src/GRALBackgroundworkers/Background_HighPercentiles.cs
@@ -243,6 +243,7 @@ namespace GralBackgroundworkers
                         //new hour -> reset sub concentrations and look, if next hour is new -> the evaluate
                         if (CalculateMeanHourlyValues)
                         {
+                            //new recent date & Time 
                             if (!string.Equals(oldMonth, month) || !string.Equals(oldDay, day) || !string.Equals(oldhour, hour))
                             {
                                 subHourCounter = 0;
@@ -264,24 +265,24 @@ namespace GralBackgroundworkers
                                         }
                                     }
                                 });
-                                //next hour a new value?
-                                if ((count_ws + 1) < data_mettimeseries.Count)
+                            }
+                            //next hour a new value?
+                            if ((count_ws + 1) < data_mettimeseries.Count)
+                            {
+                                string nextMeteo = data_mettimeseries[count_ws + 1];
+                                text2 = nextMeteo.Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
+                                if (text2.Length > 2 && !string.Equals(text2[1], hour))
                                 {
-                                    string nextMeteo = data_mettimeseries[count_ws + 1];
-                                    text2 = nextMeteo.Split(new char[] { ' ', ';', ',', '\t' }, StringSplitOptions.RemoveEmptyEntries);
-                                    if (text2.Length > 2 && !string.Equals(text2[1], hour))
-                                    {
-                                        subHourValueEvaluate = true;
-                                    }
-                                    else
-                                    {
-                                        subHourValueEvaluate = false;
-                                    }
+                                    subHourValueEvaluate = true;
                                 }
                                 else
                                 {
-                                    subHourValueEvaluate = true; // last value
+                                    subHourValueEvaluate = false;
                                 }
+                            }
+                            else
+                            {
+                                subHourValueEvaluate = true; // last value
                             }
                         }
 

--- a/src/GRALData/WindRoseSettings.cs
+++ b/src/GRALData/WindRoseSettings.cs
@@ -77,7 +77,7 @@ namespace GralData
             EndStunde = 23;
             BiasCorrection = true;
             ShowBias = true;
-            ShowFrames = false;
+            ShowFrames = true;
             DrawSmallSectors = false;
             SectorCount = 16;
             Ignore00Values = false;

--- a/src/GRALDomain/Domain.Designer.cs
+++ b/src/GRALDomain/Domain.Designer.cs
@@ -28,2595 +28,2479 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Domain));
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.button6 = new System.Windows.Forms.Button();
-            this.button20 = new System.Windows.Forms.Button();
-            this.button21 = new System.Windows.Forms.Button();
-            this.button19 = new System.Windows.Forms.Button();
-            this.button22 = new System.Windows.Forms.Button();
-            this.button18 = new System.Windows.Forms.Button();
-            this.button25 = new System.Windows.Forms.Button();
-            this.button7 = new System.Windows.Forms.Button();
-            this.button26 = new System.Windows.Forms.Button();
-            this.button5 = new System.Windows.Forms.Button();
-            this.button27 = new System.Windows.Forms.Button();
-            this.button4 = new System.Windows.Forms.Button();
-            this.button28 = new System.Windows.Forms.Button();
-            this.button3 = new System.Windows.Forms.Button();
-            this.button29 = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
-            this.button1 = new System.Windows.Forms.Button();
-            this.button33 = new System.Windows.Forms.Button();
-            this.button8 = new System.Windows.Forms.Button();
-            this.button10 = new System.Windows.Forms.Button();
-            this.button12 = new System.Windows.Forms.Button();
-            this.button14 = new System.Windows.Forms.Button();
-            this.button16 = new System.Windows.Forms.Button();
-            this.button23 = new System.Windows.Forms.Button();
-            this.button30 = new System.Windows.Forms.Button();
-            this.button31 = new System.Windows.Forms.Button();
-            this.button32 = new System.Windows.Forms.Button();
-            this.button9 = new System.Windows.Forms.Button();
-            this.button11 = new System.Windows.Forms.Button();
-            this.button13 = new System.Windows.Forms.Button();
-            this.button15 = new System.Windows.Forms.Button();
-            this.button17 = new System.Windows.Forms.Button();
-            this.button24 = new System.Windows.Forms.Button();
-            this.button34 = new System.Windows.Forms.Button();
-            this.button35 = new System.Windows.Forms.Button();
-            this.button36 = new System.Windows.Forms.Button();
-            this.button37 = new System.Windows.Forms.Button();
-            this.button38 = new System.Windows.Forms.Button();
-            this.button39 = new System.Windows.Forms.Button();
-            this.button40 = new System.Windows.Forms.Button();
-            this.button41 = new System.Windows.Forms.Button();
-            this.button42 = new System.Windows.Forms.Button();
-            this.button43 = new System.Windows.Forms.Button();
-            this.button_section_wind = new System.Windows.Forms.Button();
-            this.domain_clipboard = new System.Windows.Forms.Button();
-            this.button3D = new System.Windows.Forms.Button();
-            this.buttonstabilityclass = new System.Windows.Forms.Button();
-            this.button44 = new System.Windows.Forms.Button();
-            this.button47 = new System.Windows.Forms.Button();
-            this.button48 = new System.Windows.Forms.Button();
-            this.button49 = new System.Windows.Forms.Button();
-            this.button52 = new System.Windows.Forms.Button();
-            this.button50 = new System.Windows.Forms.Button();
-            this.button51 = new System.Windows.Forms.Button();
-            this.button_section_concentration = new System.Windows.Forms.Button();
-            this.button53 = new System.Windows.Forms.Button();
-            this.button54 = new System.Windows.Forms.Button();
-            this.button55 = new System.Windows.Forms.Button();
-            this.button56 = new System.Windows.Forms.Button();
-            this.button57 = new System.Windows.Forms.Button();
-            this.colorDialog1 = new System.Windows.Forms.ColorDialog();
-            this.openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
-            this.fontDialog1 = new System.Windows.Forms.FontDialog();
-            this.saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
-            this.label1 = new System.Windows.Forms.Label();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.toolStrip1 = new System.Windows.Forms.ToolStrip();
-            this.toolStripButton3 = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton4 = new System.Windows.Forms.ToolStripButton();
-            this.toolStripButton1 = new System.Windows.Forms.ToolStripButton();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.checkBox26 = new System.Windows.Forms.CheckBox();
-            this.checkBox25 = new System.Windows.Forms.CheckBox();
-            this.checkBox20 = new System.Windows.Forms.CheckBox();
-            this.checkBox15 = new System.Windows.Forms.CheckBox();
-            this.checkBox12 = new System.Windows.Forms.CheckBox();
-            this.checkBox8 = new System.Windows.Forms.CheckBox();
-            this.checkBox5 = new System.Windows.Forms.CheckBox();
-            this.checkBox4 = new System.Windows.Forms.CheckBox();
-            this.groupBox4 = new System.Windows.Forms.GroupBox();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.groupBox5 = new System.Windows.Forms.GroupBox();
-            this.panel1 = new System.Windows.Forms.Panel();
-            this.label3 = new System.Windows.Forms.Label();
-            this.textBox3 = new System.Windows.Forms.TextBox();
-            this.groupBox7 = new System.Windows.Forms.GroupBox();
-            this.button46 = new System.Windows.Forms.Button();
-            this.button45 = new System.Windows.Forms.Button();
-            this.groupBox6 = new System.Windows.Forms.GroupBox();
-            this.viewtoolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.objectManagerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem7 = new System.Windows.Forms.ToolStripSeparator();
-            this.zoomInToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.zoomOutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.zoomFrameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.originalSizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.arrowCursorToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem18 = new System.Windows.Forms.ToolStripMenuItem();
-            this.shownCellHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.MenuEntryCellHeightsGramm = new System.Windows.Forms.ToolStripMenuItem();
-            this.MenuEntryCellHeightsGrammEdge = new System.Windows.Forms.ToolStripMenuItem();
-            this.MenuEntryCellHeightsGral = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
-            this.sectionViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.dViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem6 = new System.Windows.Forms.ToolStripSeparator();
-            this.toolBoxToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.menuStrip1 = new System.Windows.Forms.MenuStrip();
-            this.importexportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.basMapsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.georeferenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.onePointAndScaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.twoPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.moveAndZoomMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem9 = new System.Windows.Forms.ToolStripSeparator();
-            this.importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.buildingsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.receptorPointsToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.pointSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.areaSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.lineSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
-            this.tunnelPortalsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.wallsToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
-            this.windRosesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.originalGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem16 = new System.Windows.Forms.ToolStripSeparator();
-            this.exitGISWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gRAMMModelDomainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.gRALToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem8 = new System.Windows.Forms.ToolStripSeparator();
-            this.pointSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.areaSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lineSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.tunnelPortalsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.buildingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.receptorPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.wallsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.VegetationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem25 = new System.Windows.Forms.ToolStripSeparator();
-            this.deleteSelectedItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem35 = new System.Windows.Forms.ToolStripSeparator();
-            this.northToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mapScaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.selectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.pointSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.areaSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.lineSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.tunnelPortalsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.buildingsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.receptorPointsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.wallsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.VegetationtToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem17 = new System.Windows.Forms.ToolStripSeparator();
-            this.searchItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.measureLenghtToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.measureAreaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
-            this.modifyTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.lowPassGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.restoreGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
-            this.arrowCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.crossCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.windfieldAnalysisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.windStatisticAtAPointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.verticalProfileAtAPointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem10 = new System.Windows.Forms.ToolStripSeparator();
-            this.meanWindSpeedAtAHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.windFieldAtAHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.analyzeStabilityClassesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem13 = new System.Windows.Forms.ToolStripSeparator();
-            this.sectionWindfieldDrawingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem11 = new System.Windows.Forms.ToolStripSeparator();
-            this.reorderWindFieldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.matchToObservationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.analyzeResultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.loadContourMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.mathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.extractConcentrationAtOnePointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.convertgrzFileToASCIIFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem14 = new System.Windows.Forms.ToolStripSeparator();
-            this.verticalConcentrationProfileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.verticalConcentrationProfileSectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
-            this.sourceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.saveMapToDiscToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.exportMapToTheClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem15 = new System.Windows.Forms.ToolStripSeparator();
-            this.convertconFileToAsciiFormatToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripMenuItem12 = new System.Windows.Forms.ToolStripSeparator();
-            this.pointSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.areaSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.lineSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.receptorPointsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
-            this.contourLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.GRAMMWindFieldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripTextBox3 = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripTextBox2 = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripTextBox1 = new System.Windows.Forms.ToolStripTextBox();
-            this.toolStripComboBox1 = new System.Windows.Forms.ToolStripComboBox();
-            this.BottomToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.TopToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.RightToolStripPanel = new System.Windows.Forms.ToolStripPanel();
-            this.picturebox1 = new System.Windows.Forms.PictureBox();
-            this.groupBox1.SuspendLayout();
-            this.toolStrip1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            this.groupBox4.SuspendLayout();
-            this.groupBox3.SuspendLayout();
-            this.groupBox5.SuspendLayout();
-            this.panel1.SuspendLayout();
-            this.groupBox7.SuspendLayout();
-            this.groupBox6.SuspendLayout();
-            this.menuStrip1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.picturebox1)).BeginInit();
-            this.SuspendLayout();
+            toolTip1 = new System.Windows.Forms.ToolTip(components);
+            button6 = new System.Windows.Forms.Button();
+            button20 = new System.Windows.Forms.Button();
+            button21 = new System.Windows.Forms.Button();
+            button19 = new System.Windows.Forms.Button();
+            button22 = new System.Windows.Forms.Button();
+            button18 = new System.Windows.Forms.Button();
+            button25 = new System.Windows.Forms.Button();
+            button7 = new System.Windows.Forms.Button();
+            button26 = new System.Windows.Forms.Button();
+            button5 = new System.Windows.Forms.Button();
+            button27 = new System.Windows.Forms.Button();
+            button4 = new System.Windows.Forms.Button();
+            button28 = new System.Windows.Forms.Button();
+            button3 = new System.Windows.Forms.Button();
+            button29 = new System.Windows.Forms.Button();
+            button2 = new System.Windows.Forms.Button();
+            button1 = new System.Windows.Forms.Button();
+            button33 = new System.Windows.Forms.Button();
+            button8 = new System.Windows.Forms.Button();
+            button10 = new System.Windows.Forms.Button();
+            button12 = new System.Windows.Forms.Button();
+            button14 = new System.Windows.Forms.Button();
+            button16 = new System.Windows.Forms.Button();
+            button23 = new System.Windows.Forms.Button();
+            button30 = new System.Windows.Forms.Button();
+            button31 = new System.Windows.Forms.Button();
+            button32 = new System.Windows.Forms.Button();
+            button9 = new System.Windows.Forms.Button();
+            button11 = new System.Windows.Forms.Button();
+            button13 = new System.Windows.Forms.Button();
+            button15 = new System.Windows.Forms.Button();
+            button17 = new System.Windows.Forms.Button();
+            button24 = new System.Windows.Forms.Button();
+            button34 = new System.Windows.Forms.Button();
+            button35 = new System.Windows.Forms.Button();
+            button36 = new System.Windows.Forms.Button();
+            button37 = new System.Windows.Forms.Button();
+            button38 = new System.Windows.Forms.Button();
+            button39 = new System.Windows.Forms.Button();
+            button40 = new System.Windows.Forms.Button();
+            button41 = new System.Windows.Forms.Button();
+            button42 = new System.Windows.Forms.Button();
+            button43 = new System.Windows.Forms.Button();
+            button_section_wind = new System.Windows.Forms.Button();
+            domain_clipboard = new System.Windows.Forms.Button();
+            button3D = new System.Windows.Forms.Button();
+            buttonstabilityclass = new System.Windows.Forms.Button();
+            button44 = new System.Windows.Forms.Button();
+            button47 = new System.Windows.Forms.Button();
+            button48 = new System.Windows.Forms.Button();
+            button49 = new System.Windows.Forms.Button();
+            button52 = new System.Windows.Forms.Button();
+            button50 = new System.Windows.Forms.Button();
+            button51 = new System.Windows.Forms.Button();
+            button_section_concentration = new System.Windows.Forms.Button();
+            button53 = new System.Windows.Forms.Button();
+            button54 = new System.Windows.Forms.Button();
+            button55 = new System.Windows.Forms.Button();
+            button56 = new System.Windows.Forms.Button();
+            button57 = new System.Windows.Forms.Button();
+            button58 = new System.Windows.Forms.Button();
+            colorDialog1 = new System.Windows.Forms.ColorDialog();
+            openFileDialog1 = new System.Windows.Forms.OpenFileDialog();
+            fontDialog1 = new System.Windows.Forms.FontDialog();
+            saveFileDialog1 = new System.Windows.Forms.SaveFileDialog();
+            label1 = new System.Windows.Forms.Label();
+            textBox2 = new System.Windows.Forms.TextBox();
+            label2 = new System.Windows.Forms.Label();
+            textBox1 = new System.Windows.Forms.TextBox();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            toolStrip1 = new System.Windows.Forms.ToolStrip();
+            toolStripButton3 = new System.Windows.Forms.ToolStripButton();
+            toolStripButton4 = new System.Windows.Forms.ToolStripButton();
+            toolStripButton1 = new System.Windows.Forms.ToolStripButton();
+            groupBox2 = new System.Windows.Forms.GroupBox();
+            checkBox26 = new System.Windows.Forms.CheckBox();
+            checkBox25 = new System.Windows.Forms.CheckBox();
+            checkBox20 = new System.Windows.Forms.CheckBox();
+            checkBox15 = new System.Windows.Forms.CheckBox();
+            checkBox12 = new System.Windows.Forms.CheckBox();
+            checkBox8 = new System.Windows.Forms.CheckBox();
+            checkBox5 = new System.Windows.Forms.CheckBox();
+            checkBox4 = new System.Windows.Forms.CheckBox();
+            groupBox4 = new System.Windows.Forms.GroupBox();
+            groupBox3 = new System.Windows.Forms.GroupBox();
+            groupBox5 = new System.Windows.Forms.GroupBox();
+            panel1 = new System.Windows.Forms.Panel();
+            label3 = new System.Windows.Forms.Label();
+            textBox3 = new System.Windows.Forms.TextBox();
+            groupBox7 = new System.Windows.Forms.GroupBox();
+            button46 = new System.Windows.Forms.Button();
+            button45 = new System.Windows.Forms.Button();
+            groupBox6 = new System.Windows.Forms.GroupBox();
+            viewtoolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            objectManagerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+            toolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem7 = new System.Windows.Forms.ToolStripSeparator();
+            zoomInToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            zoomOutToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            zoomFrameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            originalSizeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            moveMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            arrowCursorToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem18 = new System.Windows.Forms.ToolStripMenuItem();
+            shownCellHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            MenuEntryCellHeightsGramm = new System.Windows.Forms.ToolStripMenuItem();
+            MenuEntryCellHeightsGrammEdge = new System.Windows.Forms.ToolStripMenuItem();
+            MenuEntryCellHeightsGral = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem5 = new System.Windows.Forms.ToolStripSeparator();
+            sectionViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            dViewToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem6 = new System.Windows.Forms.ToolStripSeparator();
+            toolBoxToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            menuStrip1 = new System.Windows.Forms.MenuStrip();
+            importexportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            basMapsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            georeferenceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            onePointAndScaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            twoPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            moveAndZoomMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem9 = new System.Windows.Forms.ToolStripSeparator();
+            importToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            buildingsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            receptorPointsToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            pointSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            areaSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            lineSourcesToolStripMenuItem4 = new System.Windows.Forms.ToolStripMenuItem();
+            tunnelPortalsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            wallsToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            windRosesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            originalGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem16 = new System.Windows.Forms.ToolStripSeparator();
+            exitGISWindowToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            editToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            gRAMMModelDomainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            gRALToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem8 = new System.Windows.Forms.ToolStripSeparator();
+            pointSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            areaSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            lineSourcesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            tunnelPortalsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            buildingsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            receptorPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            wallsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            VegetationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem25 = new System.Windows.Forms.ToolStripSeparator();
+            deleteSelectedItemsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            deleteBuildingsAtTheGRALBorderToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem35 = new System.Windows.Forms.ToolStripSeparator();
+            northToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            mapScaleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            selectToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            pointSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            areaSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            lineSourcesToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            tunnelPortalsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            buildingsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            receptorPointsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            wallsToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            VegetationtToolStripMenuItem1 = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem17 = new System.Windows.Forms.ToolStripSeparator();
+            searchItemToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            measureLenghtToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            measureAreaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem4 = new System.Windows.Forms.ToolStripSeparator();
+            modifyTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            lowPassGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            restoreGRALTopographyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem1 = new System.Windows.Forms.ToolStripSeparator();
+            arrowCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            crossCursorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            windfieldAnalysisToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            windStatisticAtAPointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            verticalProfileAtAPointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem10 = new System.Windows.Forms.ToolStripSeparator();
+            meanWindSpeedAtAHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            windFieldAtAHeightToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            analyzeStabilityClassesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem13 = new System.Windows.Forms.ToolStripSeparator();
+            sectionWindfieldDrawingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem11 = new System.Windows.Forms.ToolStripSeparator();
+            reorderWindFieldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            matchToObservationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            analyzeResultsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            loadContourMapToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            mathToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            extractConcentrationAtOnePointToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            convertgrzFileToASCIIFileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            createAnAnimatedGIFFromgrzFilesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem14 = new System.Windows.Forms.ToolStripSeparator();
+            verticalConcentrationProfileToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            verticalConcentrationProfileSectionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem2 = new System.Windows.Forms.ToolStripSeparator();
+            sourceToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            exportToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            saveMapToDiscToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            exportMapToTheClipboardToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem15 = new System.Windows.Forms.ToolStripSeparator();
+            convertconFileToAsciiFormatToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripMenuItem12 = new System.Windows.Forms.ToolStripSeparator();
+            pointSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            areaSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            lineSourcesToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            receptorPointsToolStripMenuItem3 = new System.Windows.Forms.ToolStripMenuItem();
+            contourLinesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            GRAMMWindFieldsToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            buildingsToolStripMenuItem2 = new System.Windows.Forms.ToolStripMenuItem();
+            domainAreaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            toolStripTextBox3 = new System.Windows.Forms.ToolStripTextBox();
+            toolStripTextBox2 = new System.Windows.Forms.ToolStripTextBox();
+            toolStripTextBox1 = new System.Windows.Forms.ToolStripTextBox();
+            toolStripComboBox1 = new System.Windows.Forms.ToolStripComboBox();
+            BottomToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            TopToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            RightToolStripPanel = new System.Windows.Forms.ToolStripPanel();
+            picturebox1 = new System.Windows.Forms.PictureBox();
+            groupBox1.SuspendLayout();
+            toolStrip1.SuspendLayout();
+            groupBox2.SuspendLayout();
+            groupBox4.SuspendLayout();
+            groupBox3.SuspendLayout();
+            groupBox5.SuspendLayout();
+            panel1.SuspendLayout();
+            groupBox7.SuspendLayout();
+            groupBox6.SuspendLayout();
+            menuStrip1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)picturebox1).BeginInit();
+            SuspendLayout();
             // 
             // button6
             // 
-            this.button6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button6.AutoSize = true;
-            this.button6.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button6.BackgroundImage")));
-            this.button6.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button6.ForeColor = System.Drawing.Color.Blue;
-            this.button6.Location = new System.Drawing.Point(5, 195);
-            this.button6.Name = "button6";
-            this.button6.Size = new System.Drawing.Size(26, 25);
-            this.button6.TabIndex = 17;
-            this.toolTip1.SetToolTip(this.button6, "Define GRAL \r\nmodel domain");
-            this.button6.UseVisualStyleBackColor = true;
-            this.button6.Visible = false;
-            this.button6.Click += new System.EventHandler(this.Button6_Click_1);
+            button6.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button6.AutoSize = true;
+            button6.BackgroundImage = (System.Drawing.Image)resources.GetObject("button6.BackgroundImage");
+            button6.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button6.ForeColor = System.Drawing.Color.Blue;
+            button6.Location = new System.Drawing.Point(5, 195);
+            button6.Name = "button6";
+            button6.Size = new System.Drawing.Size(26, 25);
+            button6.TabIndex = 17;
+            toolTip1.SetToolTip(button6, "Define GRAL \r\nmodel domain");
+            button6.UseVisualStyleBackColor = true;
+            button6.Visible = false;
+            button6.Click += Button6_Click_1;
             // 
             // button20
             // 
-            this.button20.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button20.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button20.Font = new System.Drawing.Font("Microsoft Sans Serif", 5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button20.Location = new System.Drawing.Point(85, 50);
-            this.button20.Name = "button20";
-            this.button20.Size = new System.Drawing.Size(26, 25);
-            this.button20.TabIndex = 12;
-            this.button20.Text = "[m]";
-            this.toolTip1.SetToolTip(this.button20, "Measure distances:\r\nLeft click:\r\nContinue to measure along a\r\npolyline.\r\n\r\nRight " +
-        "click:\r\nStop measuring.");
-            this.button20.UseVisualStyleBackColor = true;
-            this.button20.Visible = false;
-            this.button20.Click += new System.EventHandler(this.Button20_Click);
+            button20.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button20.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button20.Font = new System.Drawing.Font("Microsoft Sans Serif", 5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            button20.Location = new System.Drawing.Point(85, 50);
+            button20.Name = "button20";
+            button20.Size = new System.Drawing.Size(26, 25);
+            button20.TabIndex = 12;
+            button20.Text = "[m]";
+            toolTip1.SetToolTip(button20, "Measure distances:\r\nLeft click:\r\nContinue to measure along a\r\npolyline.\r\n\r\nRight click:\r\nStop measuring.");
+            button20.UseVisualStyleBackColor = true;
+            button20.Visible = false;
+            button20.Click += Button20_Click;
             // 
             // button21
             // 
-            this.button21.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button21.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button21.Font = new System.Drawing.Font("Microsoft Sans Serif", 5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button21.Location = new System.Drawing.Point(112, 50);
-            this.button21.Name = "button21";
-            this.button21.Size = new System.Drawing.Size(26, 25);
-            this.button21.TabIndex = 13;
-            this.button21.Text = "[m²]";
-            this.toolTip1.SetToolTip(this.button21, "Measure areas:\r\nLeft click:\r\nSet vertices of the polygon.\r\n\r\nRight click:\r\nClose " +
-        "the polygon.");
-            this.button21.UseVisualStyleBackColor = true;
-            this.button21.Visible = false;
-            this.button21.Click += new System.EventHandler(this.Button21_Click);
+            button21.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button21.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button21.Font = new System.Drawing.Font("Microsoft Sans Serif", 5F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            button21.Location = new System.Drawing.Point(112, 50);
+            button21.Name = "button21";
+            button21.Size = new System.Drawing.Size(26, 25);
+            button21.TabIndex = 13;
+            button21.Text = "[m²]";
+            toolTip1.SetToolTip(button21, "Measure areas:\r\nLeft click:\r\nSet vertices of the polygon.\r\n\r\nRight click:\r\nClose the polygon.");
+            button21.UseVisualStyleBackColor = true;
+            button21.Visible = false;
+            button21.Click += Button21_Click;
             // 
             // button19
             // 
-            this.button19.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button19.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button19.BackgroundImage")));
-            this.button19.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button19.Location = new System.Drawing.Point(58, 50);
-            this.button19.Name = "button19";
-            this.button19.Size = new System.Drawing.Size(26, 25);
-            this.button19.TabIndex = 11;
-            this.toolTip1.SetToolTip(this.button19, "Define position (center)\r\nof map scale.");
-            this.button19.UseVisualStyleBackColor = true;
-            this.button19.Visible = false;
-            this.button19.Click += new System.EventHandler(this.Button19_Click);
+            button19.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button19.BackgroundImage = (System.Drawing.Image)resources.GetObject("button19.BackgroundImage");
+            button19.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button19.Location = new System.Drawing.Point(58, 50);
+            button19.Name = "button19";
+            button19.Size = new System.Drawing.Size(26, 25);
+            button19.TabIndex = 11;
+            toolTip1.SetToolTip(button19, "Define position (center)\r\nof map scale.");
+            button19.UseVisualStyleBackColor = true;
+            button19.Visible = false;
+            button19.Click += Button19_Click;
             // 
             // button22
             // 
-            this.button22.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button22.AutoSize = true;
-            this.button22.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button22.BackgroundImage")));
-            this.button22.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.button22.ForeColor = System.Drawing.Color.Blue;
-            this.button22.Location = new System.Drawing.Point(59, 221);
-            this.button22.Name = "button22";
-            this.button22.Size = new System.Drawing.Size(26, 25);
-            this.button22.TabIndex = 24;
-            this.toolTip1.SetToolTip(this.button22, "Save current map.");
-            this.button22.UseVisualStyleBackColor = true;
-            this.button22.Click += new System.EventHandler(this.Button22_Click);
+            button22.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button22.AutoSize = true;
+            button22.BackgroundImage = (System.Drawing.Image)resources.GetObject("button22.BackgroundImage");
+            button22.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            button22.ForeColor = System.Drawing.Color.Blue;
+            button22.Location = new System.Drawing.Point(59, 221);
+            button22.Name = "button22";
+            button22.Size = new System.Drawing.Size(26, 25);
+            button22.TabIndex = 24;
+            toolTip1.SetToolTip(button22, "Save current map.");
+            button22.UseVisualStyleBackColor = true;
+            button22.Click += Button22_Click;
             // 
             // button18
             // 
-            this.button18.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button18.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button18.BackgroundImage")));
-            this.button18.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button18.Location = new System.Drawing.Point(32, 50);
-            this.button18.Name = "button18";
-            this.button18.Size = new System.Drawing.Size(26, 25);
-            this.button18.TabIndex = 10;
-            this.toolTip1.SetToolTip(this.button18, "Define position (center)\r\nof north arrow.");
-            this.button18.UseVisualStyleBackColor = true;
-            this.button18.Visible = false;
-            this.button18.Click += new System.EventHandler(this.Button18_Click);
+            button18.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button18.BackgroundImage = (System.Drawing.Image)resources.GetObject("button18.BackgroundImage");
+            button18.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button18.Location = new System.Drawing.Point(32, 50);
+            button18.Name = "button18";
+            button18.Size = new System.Drawing.Size(26, 25);
+            button18.TabIndex = 10;
+            toolTip1.SetToolTip(button18, "Define position (center)\r\nof north arrow.");
+            button18.UseVisualStyleBackColor = true;
+            button18.Visible = false;
+            button18.Click += Button18_Click;
             // 
             // button25
             // 
-            this.button25.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button25.AutoSize = true;
-            this.button25.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button25.BackgroundImage")));
-            this.button25.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
-            this.button25.ForeColor = System.Drawing.Color.Blue;
-            this.button25.Location = new System.Drawing.Point(5, 221);
-            this.button25.Name = "button25";
-            this.button25.Size = new System.Drawing.Size(26, 25);
-            this.button25.TabIndex = 22;
-            this.toolTip1.SetToolTip(this.button25, "Object manager");
-            this.button25.UseVisualStyleBackColor = true;
-            this.button25.Click += new System.EventHandler(this.Button25_Click);
+            button25.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button25.AutoSize = true;
+            button25.BackgroundImage = (System.Drawing.Image)resources.GetObject("button25.BackgroundImage");
+            button25.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Center;
+            button25.ForeColor = System.Drawing.Color.Blue;
+            button25.Location = new System.Drawing.Point(5, 221);
+            button25.Name = "button25";
+            button25.Size = new System.Drawing.Size(26, 25);
+            button25.TabIndex = 22;
+            toolTip1.SetToolTip(button25, "Object manager");
+            button25.UseVisualStyleBackColor = true;
+            button25.Click += Button25_Click;
             // 
             // button7
             // 
-            this.button7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button7.AutoSize = true;
-            this.button7.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button7.BackgroundImage")));
-            this.button7.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button7.Location = new System.Drawing.Point(112, 25);
-            this.button7.Name = "button7";
-            this.button7.Size = new System.Drawing.Size(26, 25);
-            this.button7.TabIndex = 8;
-            this.toolTip1.SetToolTip(this.button7, "Zoom in by rectangle");
-            this.button7.UseVisualStyleBackColor = true;
-            this.button7.Click += new System.EventHandler(this.Button7_Click);
+            button7.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button7.AutoSize = true;
+            button7.BackgroundImage = (System.Drawing.Image)resources.GetObject("button7.BackgroundImage");
+            button7.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button7.Location = new System.Drawing.Point(112, 25);
+            button7.Name = "button7";
+            button7.Size = new System.Drawing.Size(26, 25);
+            button7.TabIndex = 8;
+            toolTip1.SetToolTip(button7, "Zoom in by rectangle");
+            button7.UseVisualStyleBackColor = true;
+            button7.Click += Button7_Click;
             // 
             // button26
             // 
-            this.button26.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button26.AutoSize = true;
-            this.button26.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button26.BackgroundImage")));
-            this.button26.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button26.ForeColor = System.Drawing.Color.Blue;
-            this.button26.Location = new System.Drawing.Point(32, 221);
-            this.button26.Name = "button26";
-            this.button26.Size = new System.Drawing.Size(26, 25);
-            this.button26.TabIndex = 23;
-            this.toolTip1.SetToolTip(this.button26, "Add base map");
-            this.button26.UseVisualStyleBackColor = true;
-            this.button26.Click += new System.EventHandler(this.Button26_Click);
+            button26.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button26.AutoSize = true;
+            button26.BackgroundImage = (System.Drawing.Image)resources.GetObject("button26.BackgroundImage");
+            button26.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button26.ForeColor = System.Drawing.Color.Blue;
+            button26.Location = new System.Drawing.Point(32, 221);
+            button26.Name = "button26";
+            button26.Size = new System.Drawing.Size(26, 25);
+            button26.TabIndex = 23;
+            toolTip1.SetToolTip(button26, "Add base map");
+            button26.UseVisualStyleBackColor = true;
+            button26.Click += Button26_Click;
             // 
             // button5
             // 
-            this.button5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button5.AutoSize = true;
-            this.button5.BackgroundImage = global::Gral.Properties.Resources.Zeiger;
-            this.button5.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button5.Location = new System.Drawing.Point(6, 50);
-            this.button5.Name = "button5";
-            this.button5.Size = new System.Drawing.Size(26, 25);
-            this.button5.TabIndex = 9;
-            this.toolTip1.SetToolTip(this.button5, "Change to arrow cursor\r\n(no specific function).");
-            this.button5.UseVisualStyleBackColor = true;
-            this.button5.Click += new System.EventHandler(this.Button5_Click);
+            button5.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button5.AutoSize = true;
+            button5.BackgroundImage = Gral.Properties.Resources.Zeiger;
+            button5.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button5.Location = new System.Drawing.Point(6, 50);
+            button5.Name = "button5";
+            button5.Size = new System.Drawing.Size(26, 25);
+            button5.TabIndex = 9;
+            toolTip1.SetToolTip(button5, "Change to arrow cursor\r\n(no specific function).");
+            button5.UseVisualStyleBackColor = true;
+            button5.Click += Button5_Click;
             // 
             // button27
             // 
-            this.button27.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button27.AutoSize = true;
-            this.button27.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button27.BackgroundImage")));
-            this.button27.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button27.ForeColor = System.Drawing.Color.Blue;
-            this.button27.Location = new System.Drawing.Point(5, 246);
-            this.button27.Name = "button27";
-            this.button27.Size = new System.Drawing.Size(26, 25);
-            this.button27.TabIndex = 27;
-            this.toolTip1.SetToolTip(this.button27, "Load a contour map");
-            this.button27.UseVisualStyleBackColor = true;
-            this.button27.Visible = false;
-            this.button27.Click += new System.EventHandler(this.Button27_Click);
+            button27.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button27.AutoSize = true;
+            button27.BackgroundImage = (System.Drawing.Image)resources.GetObject("button27.BackgroundImage");
+            button27.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button27.ForeColor = System.Drawing.Color.Blue;
+            button27.Location = new System.Drawing.Point(5, 246);
+            button27.Name = "button27";
+            button27.Size = new System.Drawing.Size(26, 25);
+            button27.TabIndex = 27;
+            toolTip1.SetToolTip(button27, "Load a contour map");
+            button27.UseVisualStyleBackColor = true;
+            button27.Visible = false;
+            button27.Click += Button27_Click;
             // 
             // button4
             // 
-            this.button4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button4.AutoSize = true;
-            this.button4.BackgroundImage = global::Gral.Properties.Resources.Hand;
-            this.button4.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button4.Location = new System.Drawing.Point(85, 25);
-            this.button4.Name = "button4";
-            this.button4.Size = new System.Drawing.Size(26, 25);
-            this.button4.TabIndex = 7;
-            this.toolTip1.SetToolTip(this.button4, "Move map");
-            this.button4.UseVisualStyleBackColor = true;
-            this.button4.Click += new System.EventHandler(this.Button4Click);
+            button4.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button4.AutoSize = true;
+            button4.BackgroundImage = Gral.Properties.Resources.Hand;
+            button4.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button4.Location = new System.Drawing.Point(85, 25);
+            button4.Name = "button4";
+            button4.Size = new System.Drawing.Size(26, 25);
+            button4.TabIndex = 7;
+            toolTip1.SetToolTip(button4, "Move map");
+            button4.UseVisualStyleBackColor = true;
+            button4.Click += Button4Click;
             // 
             // button28
             // 
-            this.button28.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button28.AutoSize = true;
-            this.button28.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button28.BackgroundImage")));
-            this.button28.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button28.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
-            this.button28.ForeColor = System.Drawing.Color.Blue;
-            this.button28.Location = new System.Drawing.Point(32, 246);
-            this.button28.Name = "button28";
-            this.button28.Size = new System.Drawing.Size(26, 25);
-            this.button28.TabIndex = 28;
-            this.toolTip1.SetToolTip(this.button28, "Simple mathematical\r\noperations for contour\r\nmaps.");
-            this.button28.UseVisualStyleBackColor = true;
-            this.button28.Visible = false;
-            this.button28.Click += new System.EventHandler(this.Button28_Click);
+            button28.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button28.AutoSize = true;
+            button28.BackgroundImage = (System.Drawing.Image)resources.GetObject("button28.BackgroundImage");
+            button28.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button28.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 2);
+            button28.ForeColor = System.Drawing.Color.Blue;
+            button28.Location = new System.Drawing.Point(32, 246);
+            button28.Name = "button28";
+            button28.Size = new System.Drawing.Size(26, 25);
+            button28.TabIndex = 28;
+            toolTip1.SetToolTip(button28, "Simple mathematical\r\noperations for contour\r\nmaps.");
+            button28.UseVisualStyleBackColor = true;
+            button28.Visible = false;
+            button28.Click += Button28_Click;
             // 
             // button3
             // 
-            this.button3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button3.AutoSize = true;
-            this.button3.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button3.BackgroundImage")));
-            this.button3.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.button3.Location = new System.Drawing.Point(58, 25);
-            this.button3.Name = "button3";
-            this.button3.Size = new System.Drawing.Size(26, 25);
-            this.button3.TabIndex = 6;
-            this.toolTip1.SetToolTip(this.button3, "Zoom to full extent\r\nof currently loaded base map.");
-            this.button3.UseVisualStyleBackColor = true;
-            this.button3.Click += new System.EventHandler(this.Button3_Click_1);
+            button3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button3.AutoSize = true;
+            button3.BackgroundImage = (System.Drawing.Image)resources.GetObject("button3.BackgroundImage");
+            button3.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            button3.Location = new System.Drawing.Point(58, 25);
+            button3.Name = "button3";
+            button3.Size = new System.Drawing.Size(26, 25);
+            button3.TabIndex = 6;
+            toolTip1.SetToolTip(button3, "Zoom to full extent\r\nof currently loaded base map.");
+            button3.UseVisualStyleBackColor = true;
+            button3.Click += Button3_Click_1;
             // 
             // button29
             // 
-            this.button29.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button29.AutoSize = true;
-            this.button29.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button29.BackgroundImage")));
-            this.button29.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button29.ForeColor = System.Drawing.Color.Blue;
-            this.button29.Location = new System.Drawing.Point(32, 195);
-            this.button29.Name = "button29";
-            this.button29.Size = new System.Drawing.Size(26, 25);
-            this.button29.TabIndex = 18;
-            this.toolTip1.SetToolTip(this.button29, "Define GRAMM\r\nmodel domain");
-            this.button29.UseVisualStyleBackColor = true;
-            this.button29.Visible = false;
-            this.button29.Click += new System.EventHandler(this.Button29_Click);
+            button29.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button29.AutoSize = true;
+            button29.BackgroundImage = (System.Drawing.Image)resources.GetObject("button29.BackgroundImage");
+            button29.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button29.ForeColor = System.Drawing.Color.Blue;
+            button29.Location = new System.Drawing.Point(32, 195);
+            button29.Name = "button29";
+            button29.Size = new System.Drawing.Size(26, 25);
+            button29.TabIndex = 18;
+            toolTip1.SetToolTip(button29, "Define GRAMM\r\nmodel domain");
+            button29.UseVisualStyleBackColor = true;
+            button29.Visible = false;
+            button29.Click += Button29_Click;
             // 
             // button2
             // 
-            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button2.AutoSize = true;
-            this.button2.BackgroundImage = global::Gral.Properties.Resources.Lupe_minus;
-            this.button2.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button2.Location = new System.Drawing.Point(32, 25);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(26, 25);
-            this.button2.TabIndex = 5;
-            this.toolTip1.SetToolTip(this.button2, "Zoom out");
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.Button2_Click);
+            button2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button2.AutoSize = true;
+            button2.BackgroundImage = Gral.Properties.Resources.Lupe_minus;
+            button2.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button2.Location = new System.Drawing.Point(32, 25);
+            button2.Name = "button2";
+            button2.Size = new System.Drawing.Size(26, 25);
+            button2.TabIndex = 5;
+            toolTip1.SetToolTip(button2, "Zoom out");
+            button2.UseVisualStyleBackColor = true;
+            button2.Click += Button2_Click;
             // 
             // button1
             // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button1.AutoSize = true;
-            this.button1.BackgroundImage = global::Gral.Properties.Resources.Lupe2;
-            this.button1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button1.Location = new System.Drawing.Point(6, 25);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(26, 25);
-            this.button1.TabIndex = 4;
-            this.toolTip1.SetToolTip(this.button1, "Zoom in");
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.Button1_Click);
+            button1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button1.AutoSize = true;
+            button1.BackgroundImage = Gral.Properties.Resources.Lupe2;
+            button1.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button1.Location = new System.Drawing.Point(6, 25);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(26, 25);
+            button1.TabIndex = 4;
+            toolTip1.SetToolTip(button1, "Zoom in");
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += Button1_Click;
             // 
             // button33
             // 
-            this.button33.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button33.AutoSize = true;
-            this.button33.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button33.BackgroundImage")));
-            this.button33.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button33.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
-            this.button33.ForeColor = System.Drawing.Color.Blue;
-            this.button33.Location = new System.Drawing.Point(58, 246);
-            this.button33.Name = "button33";
-            this.button33.Size = new System.Drawing.Size(26, 25);
-            this.button33.TabIndex = 29;
-            this.toolTip1.SetToolTip(this.button33, "Source apportionment.");
-            this.button33.UseVisualStyleBackColor = true;
-            this.button33.Visible = false;
-            this.button33.Click += new System.EventHandler(this.Button33_Click);
+            button33.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button33.AutoSize = true;
+            button33.BackgroundImage = (System.Drawing.Image)resources.GetObject("button33.BackgroundImage");
+            button33.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button33.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 2);
+            button33.ForeColor = System.Drawing.Color.Blue;
+            button33.Location = new System.Drawing.Point(58, 246);
+            button33.Name = "button33";
+            button33.Size = new System.Drawing.Size(26, 25);
+            button33.TabIndex = 29;
+            toolTip1.SetToolTip(button33, "Source apportionment.");
+            button33.UseVisualStyleBackColor = true;
+            button33.Visible = false;
+            button33.Click += Button33_Click;
             // 
             // button8
             // 
-            this.button8.BackgroundImage = global::Gral.Properties.Resources.Pointsource1;
-            this.button8.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button8.Location = new System.Drawing.Point(6, 16);
-            this.button8.Name = "button8";
-            this.button8.Size = new System.Drawing.Size(26, 25);
-            this.button8.TabIndex = 48;
-            this.toolTip1.SetToolTip(this.button8, "Select point sources");
-            this.button8.UseVisualStyleBackColor = true;
-            this.button8.Visible = false;
-            this.button8.Click += new System.EventHandler(this.Button8_Click);
+            button8.BackgroundImage = Gral.Properties.Resources.Pointsource1;
+            button8.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button8.Location = new System.Drawing.Point(6, 16);
+            button8.Name = "button8";
+            button8.Size = new System.Drawing.Size(26, 25);
+            button8.TabIndex = 48;
+            toolTip1.SetToolTip(button8, "Select point sources");
+            button8.UseVisualStyleBackColor = true;
+            button8.Visible = false;
+            button8.Click += Button8_Click;
             // 
             // button10
             // 
-            this.button10.BackgroundImage = global::Gral.Properties.Resources.AreaSource;
-            this.button10.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button10.Location = new System.Drawing.Point(38, 16);
-            this.button10.Name = "button10";
-            this.button10.Size = new System.Drawing.Size(26, 25);
-            this.button10.TabIndex = 49;
-            this.toolTip1.SetToolTip(this.button10, "Select area sources");
-            this.button10.UseVisualStyleBackColor = true;
-            this.button10.Visible = false;
-            this.button10.Click += new System.EventHandler(this.Button10_Click);
+            button10.BackgroundImage = Gral.Properties.Resources.AreaSource;
+            button10.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button10.Location = new System.Drawing.Point(38, 16);
+            button10.Name = "button10";
+            button10.Size = new System.Drawing.Size(26, 25);
+            button10.TabIndex = 49;
+            toolTip1.SetToolTip(button10, "Select area sources");
+            button10.UseVisualStyleBackColor = true;
+            button10.Visible = false;
+            button10.Click += Button10_Click;
             // 
             // button12
             // 
-            this.button12.BackgroundImage = global::Gral.Properties.Resources.Linesource;
-            this.button12.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button12.Location = new System.Drawing.Point(70, 16);
-            this.button12.Name = "button12";
-            this.button12.Size = new System.Drawing.Size(26, 25);
-            this.button12.TabIndex = 50;
-            this.toolTip1.SetToolTip(this.button12, "Select line sources");
-            this.button12.UseVisualStyleBackColor = true;
-            this.button12.Visible = false;
-            this.button12.Click += new System.EventHandler(this.Button12_Click);
+            button12.BackgroundImage = Gral.Properties.Resources.Linesource;
+            button12.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button12.Location = new System.Drawing.Point(70, 16);
+            button12.Name = "button12";
+            button12.Size = new System.Drawing.Size(26, 25);
+            button12.TabIndex = 50;
+            toolTip1.SetToolTip(button12, "Select line sources");
+            button12.UseVisualStyleBackColor = true;
+            button12.Visible = false;
+            button12.Click += Button12_Click;
             // 
             // button14
             // 
-            this.button14.BackgroundImage = global::Gral.Properties.Resources.Portal1;
-            this.button14.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button14.Location = new System.Drawing.Point(6, 42);
-            this.button14.Name = "button14";
-            this.button14.Size = new System.Drawing.Size(26, 25);
-            this.button14.TabIndex = 52;
-            this.toolTip1.SetToolTip(this.button14, "Select tunnel portals");
-            this.button14.UseVisualStyleBackColor = true;
-            this.button14.Visible = false;
-            this.button14.Click += new System.EventHandler(this.Button14_Click);
+            button14.BackgroundImage = Gral.Properties.Resources.Portal1;
+            button14.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button14.Location = new System.Drawing.Point(6, 42);
+            button14.Name = "button14";
+            button14.Size = new System.Drawing.Size(26, 25);
+            button14.TabIndex = 52;
+            toolTip1.SetToolTip(button14, "Select tunnel portals");
+            button14.UseVisualStyleBackColor = true;
+            button14.Visible = false;
+            button14.Click += Button14_Click;
             // 
             // button16
             // 
-            this.button16.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button16.BackgroundImage")));
-            this.button16.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button16.Location = new System.Drawing.Point(38, 42);
-            this.button16.Name = "button16";
-            this.button16.Size = new System.Drawing.Size(26, 25);
-            this.button16.TabIndex = 53;
-            this.toolTip1.SetToolTip(this.button16, "Select buildings");
-            this.button16.UseVisualStyleBackColor = true;
-            this.button16.Visible = false;
-            this.button16.Click += new System.EventHandler(this.Button16_Click);
+            button16.BackgroundImage = (System.Drawing.Image)resources.GetObject("button16.BackgroundImage");
+            button16.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button16.Location = new System.Drawing.Point(38, 42);
+            button16.Name = "button16";
+            button16.Size = new System.Drawing.Size(26, 25);
+            button16.TabIndex = 53;
+            toolTip1.SetToolTip(button16, "Select buildings");
+            button16.UseVisualStyleBackColor = true;
+            button16.Visible = false;
+            button16.Click += Button16_Click;
             // 
             // button23
             // 
-            this.button23.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button23.BackgroundImage")));
-            this.button23.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button23.Location = new System.Drawing.Point(70, 42);
-            this.button23.Name = "button23";
-            this.button23.Size = new System.Drawing.Size(26, 25);
-            this.button23.TabIndex = 54;
-            this.toolTip1.SetToolTip(this.button23, "Select receptor points");
-            this.button23.UseVisualStyleBackColor = true;
-            this.button23.Visible = false;
-            this.button23.Click += new System.EventHandler(this.Button23_Click);
+            button23.BackgroundImage = (System.Drawing.Image)resources.GetObject("button23.BackgroundImage");
+            button23.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button23.Location = new System.Drawing.Point(70, 42);
+            button23.Name = "button23";
+            button23.Size = new System.Drawing.Size(26, 25);
+            button23.TabIndex = 54;
+            toolTip1.SetToolTip(button23, "Select receptor points");
+            button23.UseVisualStyleBackColor = true;
+            button23.Visible = false;
+            button23.Click += Button23_Click;
             // 
             // button30
             // 
-            this.button30.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button30.BackgroundImage")));
-            this.button30.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button30.Location = new System.Drawing.Point(6, 14);
-            this.button30.Name = "button30";
-            this.button30.Size = new System.Drawing.Size(26, 25);
-            this.button30.TabIndex = 40;
-            this.toolTip1.SetToolTip(this.button30, "Calculate wind statistics at\r\na specific point.\r\nWindroses etc. can be viewed\r\nin t" +
-        "he menu tab \"Meteorology\"");
-            this.button30.UseVisualStyleBackColor = true;
-            this.button30.Click += new System.EventHandler(this.Button30_Click);
+            button30.BackgroundImage = (System.Drawing.Image)resources.GetObject("button30.BackgroundImage");
+            button30.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button30.Location = new System.Drawing.Point(6, 14);
+            button30.Name = "button30";
+            button30.Size = new System.Drawing.Size(26, 25);
+            button30.TabIndex = 40;
+            toolTip1.SetToolTip(button30, "Calculate wind statistics at\r\na specific point.\r\nWindroses etc. can be viewed\r\nin the menu tab \"Meteorology\"");
+            button30.UseVisualStyleBackColor = true;
+            button30.Click += Button30_Click;
             // 
             // button31
             // 
-            this.button31.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button31.BackgroundImage")));
-            this.button31.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button31.Location = new System.Drawing.Point(38, 14);
-            this.button31.Name = "button31";
-            this.button31.Size = new System.Drawing.Size(26, 25);
-            this.button31.TabIndex = 41;
-            this.toolTip1.SetToolTip(this.button31, "Calculate mean wind\r\nspeed at a given height.");
-            this.button31.UseVisualStyleBackColor = true;
-            this.button31.Click += new System.EventHandler(this.Button31_Click);
+            button31.BackgroundImage = (System.Drawing.Image)resources.GetObject("button31.BackgroundImage");
+            button31.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button31.Location = new System.Drawing.Point(38, 14);
+            button31.Name = "button31";
+            button31.Size = new System.Drawing.Size(26, 25);
+            button31.TabIndex = 41;
+            toolTip1.SetToolTip(button31, "Calculate mean wind\r\nspeed at a given height.");
+            button31.UseVisualStyleBackColor = true;
+            button31.Click += Button31_Click;
             // 
             // button32
             // 
-            this.button32.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button32.BackgroundImage")));
-            this.button32.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button32.Location = new System.Drawing.Point(70, 14);
-            this.button32.Name = "button32";
-            this.button32.Size = new System.Drawing.Size(26, 25);
-            this.button32.TabIndex = 42;
-            this.toolTip1.SetToolTip(this.button32, "Calculate horizontal\r\nwind field at a given height.");
-            this.button32.UseVisualStyleBackColor = true;
-            this.button32.Click += new System.EventHandler(this.Button32_Click);
+            button32.BackgroundImage = (System.Drawing.Image)resources.GetObject("button32.BackgroundImage");
+            button32.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button32.Location = new System.Drawing.Point(70, 14);
+            button32.Name = "button32";
+            button32.Size = new System.Drawing.Size(26, 25);
+            button32.TabIndex = 42;
+            toolTip1.SetToolTip(button32, "Calculate horizontal\r\nwind field at a given height.");
+            button32.UseVisualStyleBackColor = true;
+            button32.Click += Button32_Click;
             // 
             // button9
             // 
-            this.button9.BackgroundImage = global::Gral.Properties.Resources.Pointsource1;
-            this.button9.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button9.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button9.Location = new System.Drawing.Point(6, 14);
-            this.button9.Name = "button9";
-            this.button9.Size = new System.Drawing.Size(26, 25);
-            this.button9.TabIndex = 57;
-            this.toolTip1.SetToolTip(this.button9, "Import point sources.\r\nImport is only possible after\r\nthe model domain has been\r\n" +
-        "defined.");
-            this.button9.UseVisualStyleBackColor = true;
-            this.button9.Click += new System.EventHandler(this.Button9_Click);
+            button9.BackgroundImage = Gral.Properties.Resources.Pointsource1;
+            button9.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button9.Location = new System.Drawing.Point(6, 14);
+            button9.Name = "button9";
+            button9.Size = new System.Drawing.Size(26, 25);
+            button9.TabIndex = 57;
+            toolTip1.SetToolTip(button9, "Import point sources.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button9.UseVisualStyleBackColor = true;
+            button9.Click += Button9_Click;
             // 
             // button11
             // 
-            this.button11.BackgroundImage = global::Gral.Properties.Resources.AreaSource;
-            this.button11.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button11.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button11.Location = new System.Drawing.Point(38, 14);
-            this.button11.Name = "button11";
-            this.button11.Size = new System.Drawing.Size(26, 25);
-            this.button11.TabIndex = 58;
-            this.toolTip1.SetToolTip(this.button11, "Import area sources.\r\nImport is only possible after\r\nthe model domain has been\r\nd" +
-        "efined.");
-            this.button11.UseVisualStyleBackColor = true;
-            this.button11.Click += new System.EventHandler(this.Button11_Click);
+            button11.BackgroundImage = Gral.Properties.Resources.AreaSource;
+            button11.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button11.Location = new System.Drawing.Point(38, 14);
+            button11.Name = "button11";
+            button11.Size = new System.Drawing.Size(26, 25);
+            button11.TabIndex = 58;
+            toolTip1.SetToolTip(button11, "Import area sources.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button11.UseVisualStyleBackColor = true;
+            button11.Click += Button11_Click;
             // 
             // button13
             // 
-            this.button13.BackgroundImage = global::Gral.Properties.Resources.Linesource;
-            this.button13.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button13.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button13.Location = new System.Drawing.Point(70, 14);
-            this.button13.Name = "button13";
-            this.button13.Size = new System.Drawing.Size(26, 25);
-            this.button13.TabIndex = 59;
-            this.toolTip1.SetToolTip(this.button13, "Import line sources.\r\nImport is only possible after\r\nthe model domain has been\r\nd" +
-        "efined.");
-            this.button13.UseVisualStyleBackColor = true;
-            this.button13.Click += new System.EventHandler(this.Button13_Click);
+            button13.BackgroundImage = Gral.Properties.Resources.Linesource;
+            button13.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button13.Location = new System.Drawing.Point(70, 14);
+            button13.Name = "button13";
+            button13.Size = new System.Drawing.Size(26, 25);
+            button13.TabIndex = 59;
+            toolTip1.SetToolTip(button13, "Import line sources.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button13.UseVisualStyleBackColor = true;
+            button13.Click += Button13_Click;
             // 
             // button15
             // 
-            this.button15.BackgroundImage = global::Gral.Properties.Resources.Portal;
-            this.button15.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button15.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button15.Location = new System.Drawing.Point(6, 42);
-            this.button15.Name = "button15";
-            this.button15.Size = new System.Drawing.Size(26, 25);
-            this.button15.TabIndex = 61;
-            this.toolTip1.SetToolTip(this.button15, "Import portal sources.\r\nImport is only possible after\r\nthe model domain has been\r" +
-        "\ndefined.");
-            this.button15.UseVisualStyleBackColor = true;
-            this.button15.Click += new System.EventHandler(this.Button15_Click);
+            button15.BackgroundImage = Gral.Properties.Resources.Portal;
+            button15.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button15.Location = new System.Drawing.Point(6, 42);
+            button15.Name = "button15";
+            button15.Size = new System.Drawing.Size(26, 25);
+            button15.TabIndex = 61;
+            toolTip1.SetToolTip(button15, "Import portal sources.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button15.UseVisualStyleBackColor = true;
+            button15.Click += Button15_Click;
             // 
             // button17
             // 
-            this.button17.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button17.BackgroundImage")));
-            this.button17.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button17.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button17.Location = new System.Drawing.Point(38, 42);
-            this.button17.Name = "button17";
-            this.button17.Size = new System.Drawing.Size(26, 25);
-            this.button17.TabIndex = 62;
-            this.toolTip1.SetToolTip(this.button17, "Import buildings.\r\nImport is only possible after\r\nthe model domain has been\r\ndefi" +
-        "ned.");
-            this.button17.UseVisualStyleBackColor = true;
-            this.button17.Click += new System.EventHandler(this.Button17_Click);
+            button17.BackgroundImage = (System.Drawing.Image)resources.GetObject("button17.BackgroundImage");
+            button17.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button17.Location = new System.Drawing.Point(38, 42);
+            button17.Name = "button17";
+            button17.Size = new System.Drawing.Size(26, 25);
+            button17.TabIndex = 62;
+            toolTip1.SetToolTip(button17, "Import buildings.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button17.UseVisualStyleBackColor = true;
+            button17.Click += Button17_Click;
             // 
             // button24
             // 
-            this.button24.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button24.BackgroundImage")));
-            this.button24.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button24.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button24.Location = new System.Drawing.Point(70, 42);
-            this.button24.Name = "button24";
-            this.button24.Size = new System.Drawing.Size(26, 25);
-            this.button24.TabIndex = 63;
-            this.toolTip1.SetToolTip(this.button24, "Import receptor points.\r\nImport is only possible after\r\nthe model domain has been" +
-        "\r\ndefined.");
-            this.button24.UseVisualStyleBackColor = true;
-            this.button24.Click += new System.EventHandler(this.Button24_Click);
+            button24.BackgroundImage = (System.Drawing.Image)resources.GetObject("button24.BackgroundImage");
+            button24.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button24.Location = new System.Drawing.Point(70, 42);
+            button24.Name = "button24";
+            button24.Size = new System.Drawing.Size(26, 25);
+            button24.TabIndex = 63;
+            toolTip1.SetToolTip(button24, "Import receptor points.\r\nImport is only possible after\r\nthe model domain has been\r\ndefined.");
+            button24.UseVisualStyleBackColor = true;
+            button24.Click += Button24_Click;
             // 
             // button34
             // 
-            this.button34.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button34.AutoSize = true;
-            this.button34.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button34.BackgroundImage")));
-            this.button34.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button34.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(2)));
-            this.button34.ForeColor = System.Drawing.Color.Blue;
-            this.button34.Location = new System.Drawing.Point(112, 246);
-            this.button34.Name = "button34";
-            this.button34.Size = new System.Drawing.Size(26, 25);
-            this.button34.TabIndex = 31;
-            this.toolTip1.SetToolTip(this.button34, "Show vertical profile");
-            this.button34.UseVisualStyleBackColor = true;
-            this.button34.Visible = false;
-            this.button34.Click += new System.EventHandler(this.Button34_Click);
+            button34.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button34.AutoSize = true;
+            button34.BackgroundImage = (System.Drawing.Image)resources.GetObject("button34.BackgroundImage");
+            button34.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button34.Font = new System.Drawing.Font("Symbol", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 2);
+            button34.ForeColor = System.Drawing.Color.Blue;
+            button34.Location = new System.Drawing.Point(112, 246);
+            button34.Name = "button34";
+            button34.Size = new System.Drawing.Size(26, 25);
+            button34.TabIndex = 31;
+            toolTip1.SetToolTip(button34, "Show vertical profile");
+            button34.UseVisualStyleBackColor = true;
+            button34.Visible = false;
+            button34.Click += Button34_Click;
             // 
             // button35
             // 
-            this.button35.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button35.AutoSize = true;
-            this.button35.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button35.BackgroundImage")));
-            this.button35.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button35.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button35.ForeColor = System.Drawing.Color.Blue;
-            this.button35.Location = new System.Drawing.Point(85, 246);
-            this.button35.Name = "button35";
-            this.button35.Size = new System.Drawing.Size(26, 25);
-            this.button35.TabIndex = 30;
-            this.toolTip1.SetToolTip(this.button35, "Extract concentration\r\nvalue for a selected\r\nlocation.");
-            this.button35.UseVisualStyleBackColor = true;
-            this.button35.Visible = false;
-            this.button35.Click += new System.EventHandler(this.Button35_Click);
+            button35.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button35.AutoSize = true;
+            button35.BackgroundImage = (System.Drawing.Image)resources.GetObject("button35.BackgroundImage");
+            button35.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button35.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
+            button35.ForeColor = System.Drawing.Color.Blue;
+            button35.Location = new System.Drawing.Point(85, 246);
+            button35.Name = "button35";
+            button35.Size = new System.Drawing.Size(26, 25);
+            button35.TabIndex = 30;
+            toolTip1.SetToolTip(button35, "Extract concentration\r\nvalue for a selected\r\nlocation.");
+            button35.UseVisualStyleBackColor = true;
+            button35.Visible = false;
+            button35.Click += Button35_Click;
             // 
             // button36
             // 
-            this.button36.BackgroundImage = global::Gral.Properties.Resources.Linesource;
-            this.button36.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button36.Location = new System.Drawing.Point(70, 14);
-            this.button36.Name = "button36";
-            this.button36.Size = new System.Drawing.Size(26, 25);
-            this.button36.TabIndex = 68;
-            this.toolTip1.SetToolTip(this.button36, "Export line sources\r\nas ESRI-.shp file");
-            this.button36.UseVisualStyleBackColor = true;
-            this.button36.Visible = false;
-            this.button36.Click += new System.EventHandler(this.Button36_Click);
+            button36.BackgroundImage = Gral.Properties.Resources.Linesource;
+            button36.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button36.Location = new System.Drawing.Point(70, 14);
+            button36.Name = "button36";
+            button36.Size = new System.Drawing.Size(26, 25);
+            button36.TabIndex = 68;
+            toolTip1.SetToolTip(button36, "Export line sources\r\nas ESRI-.shp file");
+            button36.UseVisualStyleBackColor = true;
+            button36.Visible = false;
+            button36.Click += Button36_Click;
             // 
             // button37
             // 
-            this.button37.BackgroundImage = global::Gral.Properties.Resources.AreaSource;
-            this.button37.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button37.Location = new System.Drawing.Point(38, 14);
-            this.button37.Name = "button37";
-            this.button37.Size = new System.Drawing.Size(26, 25);
-            this.button37.TabIndex = 67;
-            this.toolTip1.SetToolTip(this.button37, "Export area sources\r\nas ESRI-.shp file.");
-            this.button37.UseVisualStyleBackColor = true;
-            this.button37.Visible = false;
-            this.button37.Click += new System.EventHandler(this.Button37_Click);
+            button37.BackgroundImage = Gral.Properties.Resources.AreaSource;
+            button37.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button37.Location = new System.Drawing.Point(38, 14);
+            button37.Name = "button37";
+            button37.Size = new System.Drawing.Size(26, 25);
+            button37.TabIndex = 67;
+            toolTip1.SetToolTip(button37, "Export area sources\r\nas ESRI-.shp file.");
+            button37.UseVisualStyleBackColor = true;
+            button37.Visible = false;
+            button37.Click += Button37_Click;
             // 
             // button38
             // 
-            this.button38.BackgroundImage = global::Gral.Properties.Resources.Pointsource1;
-            this.button38.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button38.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button38.Location = new System.Drawing.Point(6, 14);
-            this.button38.Name = "button38";
-            this.button38.Size = new System.Drawing.Size(26, 25);
-            this.button38.TabIndex = 66;
-            this.toolTip1.SetToolTip(this.button38, "Export point sources\r\nas ESRI-.shp file.");
-            this.button38.UseVisualStyleBackColor = true;
-            this.button38.Visible = false;
-            this.button38.Click += new System.EventHandler(this.Button38_Click);
+            button38.BackgroundImage = Gral.Properties.Resources.Pointsource1;
+            button38.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button38.Location = new System.Drawing.Point(6, 14);
+            button38.Name = "button38";
+            button38.Size = new System.Drawing.Size(26, 25);
+            button38.TabIndex = 66;
+            toolTip1.SetToolTip(button38, "Export point sources\r\nas ESRI-.shp file.");
+            button38.UseVisualStyleBackColor = true;
+            button38.Visible = false;
+            button38.Click += Button38_Click;
             // 
             // button39
             // 
-            this.button39.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button39.BackgroundImage")));
-            this.button39.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button39.Location = new System.Drawing.Point(70, 42);
-            this.button39.Name = "button39";
-            this.button39.Size = new System.Drawing.Size(26, 25);
-            this.button39.TabIndex = 71;
-            this.toolTip1.SetToolTip(this.button39, "Export receptor points\r\nas ESRI-.shp file.");
-            this.button39.UseVisualStyleBackColor = true;
-            this.button39.Visible = false;
-            this.button39.Click += new System.EventHandler(this.Button39_Click);
+            button39.BackgroundImage = (System.Drawing.Image)resources.GetObject("button39.BackgroundImage");
+            button39.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button39.Location = new System.Drawing.Point(70, 42);
+            button39.Name = "button39";
+            button39.Size = new System.Drawing.Size(26, 25);
+            button39.TabIndex = 71;
+            toolTip1.SetToolTip(button39, "Export receptor points\r\nas ESRI-.shp file.");
+            button39.UseVisualStyleBackColor = true;
+            button39.Visible = false;
+            button39.Click += Button39_Click;
             // 
             // button40
             // 
-            this.button40.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button40.AutoSize = true;
-            this.button40.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button40.BackgroundImage")));
-            this.button40.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button40.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button40.ForeColor = System.Drawing.Color.Blue;
-            this.button40.Location = new System.Drawing.Point(111, 221);
-            this.button40.Name = "button40";
-            this.button40.Size = new System.Drawing.Size(26, 25);
-            this.button40.TabIndex = 26;
-            this.toolTip1.SetToolTip(this.button40, "Convert GRAL *.con file\r\nto ASCII Raster format.");
-            this.button40.UseVisualStyleBackColor = true;
-            this.button40.Click += new System.EventHandler(this.Button40_Click);
+            button40.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button40.AutoSize = true;
+            button40.BackgroundImage = (System.Drawing.Image)resources.GetObject("button40.BackgroundImage");
+            button40.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button40.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
+            button40.ForeColor = System.Drawing.Color.Blue;
+            button40.Location = new System.Drawing.Point(111, 221);
+            button40.Name = "button40";
+            button40.Size = new System.Drawing.Size(26, 25);
+            button40.TabIndex = 26;
+            toolTip1.SetToolTip(button40, "Convert GRAL *.con file\r\nto ASCII Raster format.");
+            button40.UseVisualStyleBackColor = true;
+            button40.Click += Button40_Click;
             // 
             // button41
             // 
-            this.button41.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button41.BackgroundImage")));
-            this.button41.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button41.Location = new System.Drawing.Point(101, 14);
-            this.button41.Name = "button41";
-            this.button41.Size = new System.Drawing.Size(26, 25);
-            this.button41.TabIndex = 43;
-            this.toolTip1.SetToolTip(this.button41, "Extract vertical profiles of\r\nwind fields.");
-            this.button41.UseVisualStyleBackColor = true;
-            this.button41.Click += new System.EventHandler(this.Button41_Click);
+            button41.BackgroundImage = (System.Drawing.Image)resources.GetObject("button41.BackgroundImage");
+            button41.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button41.Location = new System.Drawing.Point(101, 14);
+            button41.Name = "button41";
+            button41.Size = new System.Drawing.Size(26, 25);
+            button41.TabIndex = 43;
+            toolTip1.SetToolTip(button41, "Extract vertical profiles of\r\nwind fields.");
+            button41.UseVisualStyleBackColor = true;
+            button41.Click += Button41_Click;
             // 
             // button42
             // 
-            this.button42.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button42.BackgroundImage")));
-            this.button42.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button42.Location = new System.Drawing.Point(70, 45);
-            this.button42.Name = "button42";
-            this.button42.Size = new System.Drawing.Size(26, 25);
-            this.button42.TabIndex = 46;
-            this.toolTip1.SetToolTip(this.button42, "Re-order wind fields to match\r\nobserved wind data better.\r\nLeft click on the map " +
-        "to define\r\nthe position of the meteorological\r\nmeasurements used for the wind fi" +
-        "eld\r\nsimulations.");
-            this.button42.UseVisualStyleBackColor = true;
-            this.button42.Click += new System.EventHandler(this.Button42_Click);
+            button42.BackgroundImage = (System.Drawing.Image)resources.GetObject("button42.BackgroundImage");
+            button42.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button42.Location = new System.Drawing.Point(70, 45);
+            button42.Name = "button42";
+            button42.Size = new System.Drawing.Size(26, 25);
+            button42.TabIndex = 46;
+            toolTip1.SetToolTip(button42, "Re-order wind fields to match\r\nobserved wind data better.\r\nLeft click on the map to define\r\nthe position of the meteorological\r\nmeasurements used for the wind field\r\nsimulations.");
+            button42.UseVisualStyleBackColor = true;
+            button42.Click += Button42_Click;
             // 
             // button43
             // 
-            this.button43.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button43.BackgroundImage")));
-            this.button43.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button43.Location = new System.Drawing.Point(101, 46);
-            this.button43.Name = "button43";
-            this.button43.Size = new System.Drawing.Size(26, 25);
-            this.button43.TabIndex = 47;
-            this.toolTip1.SetToolTip(this.button43, "Match-to-Observation:\r\nReorder wind fields to match\r\nnewly observed wind and stab" +
-        "ility data\r\nat any location.\r\nLeft click on the map to define\r\nthe position of t" +
-        "he new meteorological\r\nmeasurements.");
-            this.button43.UseVisualStyleBackColor = true;
-            this.button43.Click += new System.EventHandler(this.Button43_Click);
+            button43.BackgroundImage = (System.Drawing.Image)resources.GetObject("button43.BackgroundImage");
+            button43.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button43.Location = new System.Drawing.Point(101, 46);
+            button43.Name = "button43";
+            button43.Size = new System.Drawing.Size(26, 25);
+            button43.TabIndex = 47;
+            toolTip1.SetToolTip(button43, "Match-to-Observation:\r\nReorder wind fields to match\r\nnewly observed wind and stability data\r\nat any location.\r\nLeft click on the map to define\r\nthe position of the new meteorological\r\nmeasurements.");
+            button43.UseVisualStyleBackColor = true;
+            button43.Click += Button43_Click;
             // 
             // button_section_wind
             // 
-            this.button_section_wind.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button_section_wind.BackgroundImage")));
-            this.button_section_wind.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button_section_wind.Location = new System.Drawing.Point(38, 45);
-            this.button_section_wind.Name = "button_section_wind";
-            this.button_section_wind.Size = new System.Drawing.Size(26, 25);
-            this.button_section_wind.TabIndex = 45;
-            this.toolTip1.SetToolTip(this.button_section_wind, "Section wind field drawing ");
-            this.button_section_wind.UseVisualStyleBackColor = true;
-            this.button_section_wind.Click += new System.EventHandler(this.Button_section_windMouseClick);
+            button_section_wind.BackgroundImage = (System.Drawing.Image)resources.GetObject("button_section_wind.BackgroundImage");
+            button_section_wind.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button_section_wind.Location = new System.Drawing.Point(38, 45);
+            button_section_wind.Name = "button_section_wind";
+            button_section_wind.Size = new System.Drawing.Size(26, 25);
+            button_section_wind.TabIndex = 45;
+            toolTip1.SetToolTip(button_section_wind, "Section wind field drawing ");
+            button_section_wind.UseVisualStyleBackColor = true;
+            button_section_wind.Click += Button_section_windMouseClick;
             // 
             // domain_clipboard
             // 
-            this.domain_clipboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.domain_clipboard.AutoSize = true;
-            this.domain_clipboard.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("domain_clipboard.BackgroundImage")));
-            this.domain_clipboard.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.domain_clipboard.Location = new System.Drawing.Point(85, 221);
-            this.domain_clipboard.Name = "domain_clipboard";
-            this.domain_clipboard.Size = new System.Drawing.Size(26, 25);
-            this.domain_clipboard.TabIndex = 25;
-            this.toolTip1.SetToolTip(this.domain_clipboard, "Copy to Clipboard");
-            this.domain_clipboard.UseVisualStyleBackColor = true;
-            this.domain_clipboard.Click += new System.EventHandler(this.Domain_clipboardClick);
+            domain_clipboard.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            domain_clipboard.AutoSize = true;
+            domain_clipboard.BackgroundImage = (System.Drawing.Image)resources.GetObject("domain_clipboard.BackgroundImage");
+            domain_clipboard.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            domain_clipboard.Location = new System.Drawing.Point(85, 221);
+            domain_clipboard.Name = "domain_clipboard";
+            domain_clipboard.Size = new System.Drawing.Size(26, 25);
+            domain_clipboard.TabIndex = 25;
+            toolTip1.SetToolTip(domain_clipboard, "Copy to Clipboard");
+            domain_clipboard.UseVisualStyleBackColor = true;
+            domain_clipboard.Click += Domain_clipboardClick;
             // 
             // button3D
             // 
-            this.button3D.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button3D.AutoSize = true;
-            this.button3D.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button3D.BackgroundImage")));
-            this.button3D.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button3D.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button3D.ForeColor = System.Drawing.Color.Blue;
-            this.button3D.Location = new System.Drawing.Point(85, 195);
-            this.button3D.Name = "button3D";
-            this.button3D.Size = new System.Drawing.Size(26, 25);
-            this.button3D.TabIndex = 20;
-            this.toolTip1.SetToolTip(this.button3D, "Open 3D viewer");
-            this.button3D.UseVisualStyleBackColor = true;
-            this.button3D.Click += new System.EventHandler(this.Button3DClick);
+            button3D.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button3D.AutoSize = true;
+            button3D.BackgroundImage = (System.Drawing.Image)resources.GetObject("button3D.BackgroundImage");
+            button3D.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button3D.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
+            button3D.ForeColor = System.Drawing.Color.Blue;
+            button3D.Location = new System.Drawing.Point(85, 195);
+            button3D.Name = "button3D";
+            button3D.Size = new System.Drawing.Size(26, 25);
+            button3D.TabIndex = 20;
+            toolTip1.SetToolTip(button3D, "Open 3D viewer");
+            button3D.UseVisualStyleBackColor = true;
+            button3D.Click += Button3DClick;
             // 
             // buttonstabilityclass
             // 
-            this.buttonstabilityclass.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("buttonstabilityclass.BackgroundImage")));
-            this.buttonstabilityclass.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.buttonstabilityclass.Location = new System.Drawing.Point(6, 44);
-            this.buttonstabilityclass.Name = "buttonstabilityclass";
-            this.buttonstabilityclass.Size = new System.Drawing.Size(26, 25);
-            this.buttonstabilityclass.TabIndex = 44;
-            this.toolTip1.SetToolTip(this.buttonstabilityclass, "Analyze stability classes");
-            this.buttonstabilityclass.UseVisualStyleBackColor = true;
-            this.buttonstabilityclass.Click += new System.EventHandler(this.ButtonstabilityclassClick);
+            buttonstabilityclass.BackgroundImage = (System.Drawing.Image)resources.GetObject("buttonstabilityclass.BackgroundImage");
+            buttonstabilityclass.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            buttonstabilityclass.Location = new System.Drawing.Point(6, 44);
+            buttonstabilityclass.Name = "buttonstabilityclass";
+            buttonstabilityclass.Size = new System.Drawing.Size(26, 25);
+            buttonstabilityclass.TabIndex = 44;
+            toolTip1.SetToolTip(buttonstabilityclass, "Analyze stability classes");
+            buttonstabilityclass.UseVisualStyleBackColor = true;
+            buttonstabilityclass.Click += ButtonstabilityclassClick;
             // 
             // button44
             // 
-            this.button44.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button44.AutoSize = true;
-            this.button44.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button44.BackgroundImage")));
-            this.button44.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button44.Location = new System.Drawing.Point(59, 195);
-            this.button44.Name = "button44";
-            this.button44.Size = new System.Drawing.Size(26, 25);
-            this.button44.TabIndex = 19;
-            this.toolTip1.SetToolTip(this.button44, "Delete buildings outside the GRAL domain area");
-            this.button44.UseVisualStyleBackColor = true;
-            this.button44.Click += new System.EventHandler(this.Button44Click);
+            button44.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button44.AutoSize = true;
+            button44.BackgroundImage = (System.Drawing.Image)resources.GetObject("button44.BackgroundImage");
+            button44.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button44.Location = new System.Drawing.Point(59, 195);
+            button44.Name = "button44";
+            button44.Size = new System.Drawing.Size(26, 25);
+            button44.TabIndex = 19;
+            toolTip1.SetToolTip(button44, "Delete buildings outside the GRAL domain area");
+            button44.UseVisualStyleBackColor = true;
+            button44.Click += Button44Click;
             // 
             // button47
             // 
-            this.button47.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button47.BackgroundImage")));
-            this.button47.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button47.Location = new System.Drawing.Point(101, 16);
-            this.button47.Name = "button47";
-            this.button47.Size = new System.Drawing.Size(26, 25);
-            this.button47.TabIndex = 51;
-            this.toolTip1.SetToolTip(this.button47, "Search & filter items");
-            this.button47.UseVisualStyleBackColor = true;
-            this.button47.Click += new System.EventHandler(this.SearchItemToolStripMenuItemClick);
+            button47.BackgroundImage = (System.Drawing.Image)resources.GetObject("button47.BackgroundImage");
+            button47.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button47.Location = new System.Drawing.Point(101, 16);
+            button47.Name = "button47";
+            button47.Size = new System.Drawing.Size(26, 25);
+            button47.TabIndex = 51;
+            toolTip1.SetToolTip(button47, "Search & filter items");
+            button47.UseVisualStyleBackColor = true;
+            button47.Click += SearchItemToolStripMenuItemClick;
             // 
             // button48
             // 
-            this.button48.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button48.BackgroundImage")));
-            this.button48.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button48.Location = new System.Drawing.Point(101, 14);
-            this.button48.Name = "button48";
-            this.button48.Size = new System.Drawing.Size(26, 25);
-            this.button48.TabIndex = 69;
-            this.toolTip1.SetToolTip(this.button48, "Export GRAMM windfields.");
-            this.button48.UseVisualStyleBackColor = true;
-            this.button48.Visible = false;
-            this.button48.Click += new System.EventHandler(this.Button48_Click);
+            button48.BackgroundImage = (System.Drawing.Image)resources.GetObject("button48.BackgroundImage");
+            button48.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button48.Location = new System.Drawing.Point(101, 14);
+            button48.Name = "button48";
+            button48.Size = new System.Drawing.Size(26, 25);
+            button48.TabIndex = 69;
+            toolTip1.SetToolTip(button48, "Export GRAMM windfields.");
+            button48.UseVisualStyleBackColor = true;
+            button48.Visible = false;
+            button48.Click += Button48_Click;
             // 
             // button49
             // 
-            this.button49.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button49.BackgroundImage")));
-            this.button49.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button49.Location = new System.Drawing.Point(101, 42);
-            this.button49.Name = "button49";
-            this.button49.Size = new System.Drawing.Size(26, 25);
-            this.button49.TabIndex = 55;
-            this.toolTip1.SetToolTip(this.button49, "Select walls");
-            this.button49.UseVisualStyleBackColor = true;
-            this.button49.Visible = false;
-            this.button49.Click += new System.EventHandler(this.Button49Click);
+            button49.BackgroundImage = (System.Drawing.Image)resources.GetObject("button49.BackgroundImage");
+            button49.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button49.Location = new System.Drawing.Point(101, 42);
+            button49.Name = "button49";
+            button49.Size = new System.Drawing.Size(26, 25);
+            button49.TabIndex = 55;
+            toolTip1.SetToolTip(button49, "Select walls");
+            button49.UseVisualStyleBackColor = true;
+            button49.Visible = false;
+            button49.Click += Button49Click;
             // 
             // button52
             // 
-            this.button52.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button52.BackgroundImage")));
-            this.button52.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button52.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button52.Location = new System.Drawing.Point(6, 14);
-            this.button52.Name = "button52";
-            this.button52.Size = new System.Drawing.Size(26, 25);
-            this.button52.TabIndex = 72;
-            this.toolTip1.SetToolTip(this.button52, "Vertical concentration profile at a point");
-            this.button52.UseVisualStyleBackColor = true;
-            this.button52.Click += new System.EventHandler(this.Button52_Click);
+            button52.BackgroundImage = (System.Drawing.Image)resources.GetObject("button52.BackgroundImage");
+            button52.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button52.Location = new System.Drawing.Point(6, 14);
+            button52.Name = "button52";
+            button52.Size = new System.Drawing.Size(26, 25);
+            button52.TabIndex = 72;
+            toolTip1.SetToolTip(button52, "Vertical concentration profile at a point");
+            button52.UseVisualStyleBackColor = true;
+            button52.Click += Button52_Click;
             // 
             // button50
             // 
-            this.button50.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button50.BackgroundImage")));
-            this.button50.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button50.Location = new System.Drawing.Point(6, 69);
-            this.button50.Name = "button50";
-            this.button50.Size = new System.Drawing.Size(26, 25);
-            this.button50.TabIndex = 56;
-            this.toolTip1.SetToolTip(this.button50, "Select a Vegetation Area");
-            this.button50.UseVisualStyleBackColor = true;
-            this.button50.Visible = false;
-            this.button50.Click += new System.EventHandler(this.Button50Click);
+            button50.BackgroundImage = (System.Drawing.Image)resources.GetObject("button50.BackgroundImage");
+            button50.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button50.Location = new System.Drawing.Point(6, 69);
+            button50.Name = "button50";
+            button50.Size = new System.Drawing.Size(26, 25);
+            button50.TabIndex = 56;
+            toolTip1.SetToolTip(button50, "Select a Vegetation Area");
+            button50.UseVisualStyleBackColor = true;
+            button50.Visible = false;
+            button50.Click += Button50Click;
             // 
             // button51
             // 
-            this.button51.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button51.BackgroundImage")));
-            this.button51.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button51.Location = new System.Drawing.Point(7, 71);
-            this.button51.Name = "button51";
-            this.button51.Size = new System.Drawing.Size(26, 25);
-            this.button51.TabIndex = 65;
-            this.toolTip1.SetToolTip(this.button51, "Import vegetation data");
-            this.button51.UseVisualStyleBackColor = true;
-            this.button51.Click += new System.EventHandler(this.Button51Click);
+            button51.BackgroundImage = (System.Drawing.Image)resources.GetObject("button51.BackgroundImage");
+            button51.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button51.Location = new System.Drawing.Point(7, 71);
+            button51.Name = "button51";
+            button51.Size = new System.Drawing.Size(26, 25);
+            button51.TabIndex = 65;
+            toolTip1.SetToolTip(button51, "Import vegetation data");
+            button51.UseVisualStyleBackColor = true;
+            button51.Click += Button51Click;
             // 
             // button_section_concentration
             // 
-            this.button_section_concentration.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button_section_concentration.BackgroundImage")));
-            this.button_section_concentration.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button_section_concentration.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button_section_concentration.Location = new System.Drawing.Point(38, 14);
-            this.button_section_concentration.Name = "button_section_concentration";
-            this.button_section_concentration.Size = new System.Drawing.Size(26, 25);
-            this.button_section_concentration.TabIndex = 73;
-            this.toolTip1.SetToolTip(this.button_section_concentration, "Vertical concentration profile at a given section line");
-            this.button_section_concentration.UseVisualStyleBackColor = true;
-            this.button_section_concentration.Click += new System.EventHandler(this.Button_section_concentrationClick);
+            button_section_concentration.BackgroundImage = (System.Drawing.Image)resources.GetObject("button_section_concentration.BackgroundImage");
+            button_section_concentration.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button_section_concentration.Location = new System.Drawing.Point(38, 14);
+            button_section_concentration.Name = "button_section_concentration";
+            button_section_concentration.Size = new System.Drawing.Size(26, 25);
+            button_section_concentration.TabIndex = 73;
+            toolTip1.SetToolTip(button_section_concentration, "Vertical concentration profile at a given section line");
+            button_section_concentration.UseVisualStyleBackColor = true;
+            button_section_concentration.Click += Button_section_concentrationClick;
             // 
             // button53
             // 
-            this.button53.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button53.BackgroundImage")));
-            this.button53.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.button53.Location = new System.Drawing.Point(101, 14);
-            this.button53.Name = "button53";
-            this.button53.Size = new System.Drawing.Size(26, 25);
-            this.button53.TabIndex = 60;
-            this.button53.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
-            this.toolTip1.SetToolTip(this.button53, "Import a wind rose");
-            this.button53.UseVisualStyleBackColor = true;
-            this.button53.Click += new System.EventHandler(this.Button53Click);
+            button53.BackgroundImage = (System.Drawing.Image)resources.GetObject("button53.BackgroundImage");
+            button53.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            button53.Location = new System.Drawing.Point(101, 14);
+            button53.Name = "button53";
+            button53.Size = new System.Drawing.Size(26, 25);
+            button53.TabIndex = 60;
+            button53.TextAlign = System.Drawing.ContentAlignment.BottomLeft;
+            toolTip1.SetToolTip(button53, "Import a wind rose");
+            button53.UseVisualStyleBackColor = true;
+            button53.Click += Button53Click;
             // 
             // button54
             // 
-            this.button54.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button54.BackgroundImage")));
-            this.button54.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button54.Cursor = System.Windows.Forms.Cursors.Default;
-            this.button54.Location = new System.Drawing.Point(101, 42);
-            this.button54.Name = "button54";
-            this.button54.Size = new System.Drawing.Size(26, 25);
-            this.button54.TabIndex = 64;
-            this.toolTip1.SetToolTip(this.button54, "Import Walls");
-            this.button54.UseVisualStyleBackColor = true;
-            this.button54.Click += new System.EventHandler(this.Button54Click);
+            button54.BackgroundImage = (System.Drawing.Image)resources.GetObject("button54.BackgroundImage");
+            button54.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button54.Location = new System.Drawing.Point(101, 42);
+            button54.Name = "button54";
+            button54.Size = new System.Drawing.Size(26, 25);
+            button54.TabIndex = 64;
+            toolTip1.SetToolTip(button54, "Import Walls");
+            button54.UseVisualStyleBackColor = true;
+            button54.Click += Button54Click;
             // 
             // button55
             // 
-            this.button55.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button55.AutoSize = true;
-            this.button55.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button55.BackgroundImage")));
-            this.button55.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button55.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button55.ForeColor = System.Drawing.Color.Blue;
-            this.button55.Location = new System.Drawing.Point(112, 195);
-            this.button55.Name = "button55";
-            this.button55.Size = new System.Drawing.Size(26, 25);
-            this.button55.TabIndex = 21;
-            this.toolTip1.SetToolTip(this.button55, "Create animated GIF from a series of *.con files");
-            this.button55.UseVisualStyleBackColor = true;
-            this.button55.Click += new System.EventHandler(this.CreateAnmiatedGIF);
+            button55.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button55.AutoSize = true;
+            button55.BackgroundImage = (System.Drawing.Image)resources.GetObject("button55.BackgroundImage");
+            button55.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button55.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, 0);
+            button55.ForeColor = System.Drawing.Color.Blue;
+            button55.Location = new System.Drawing.Point(112, 195);
+            button55.Name = "button55";
+            button55.Size = new System.Drawing.Size(26, 25);
+            button55.TabIndex = 21;
+            toolTip1.SetToolTip(button55, "Create animated GIF from a series of *.con files");
+            button55.UseVisualStyleBackColor = true;
+            button55.Click += CreateAnmiatedGIF;
             // 
             // button56
             // 
-            this.button56.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button56.BackgroundImage")));
-            this.button56.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button56.Location = new System.Drawing.Point(38, 41);
-            this.button56.Name = "button56";
-            this.button56.Size = new System.Drawing.Size(26, 25);
-            this.button56.TabIndex = 70;
-            this.toolTip1.SetToolTip(this.button56, "Export contour map");
-            this.button56.UseVisualStyleBackColor = true;
-            this.button56.Visible = false;
-            this.button56.Click += new System.EventHandler(this.Button56_Click);
+            button56.BackgroundImage = (System.Drawing.Image)resources.GetObject("button56.BackgroundImage");
+            button56.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button56.Location = new System.Drawing.Point(38, 41);
+            button56.Name = "button56";
+            button56.Size = new System.Drawing.Size(26, 25);
+            button56.TabIndex = 70;
+            toolTip1.SetToolTip(button56, "Export contour map");
+            button56.UseVisualStyleBackColor = true;
+            button56.Visible = false;
+            button56.Click += Button56_Click;
             // 
             // button57
             // 
-            this.button57.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button57.AutoSize = true;
-            this.button57.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("button57.BackgroundImage")));
-            this.button57.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.button57.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.button57.Location = new System.Drawing.Point(74, 0);
-            this.button57.Name = "button57";
-            this.button57.Size = new System.Drawing.Size(26, 25);
-            this.button57.TabIndex = 2;
-            this.toolTip1.SetToolTip(this.button57, "Save or load a viewframe");
-            this.button57.UseVisualStyleBackColor = true;
-            this.button57.Click += new System.EventHandler(this.button57_Click);
+            button57.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button57.AutoSize = true;
+            button57.BackgroundImage = (System.Drawing.Image)resources.GetObject("button57.BackgroundImage");
+            button57.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button57.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.7F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            button57.Location = new System.Drawing.Point(74, 0);
+            button57.Name = "button57";
+            button57.Size = new System.Drawing.Size(26, 25);
+            button57.TabIndex = 2;
+            toolTip1.SetToolTip(button57, "Save or load a viewframe");
+            button57.UseVisualStyleBackColor = true;
+            button57.Click += button57_Click;
+            // 
+            // button58
+            // 
+            button58.BackgroundImage = (System.Drawing.Image)resources.GetObject("button58.BackgroundImage");
+            button58.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            button58.Location = new System.Drawing.Point(6, 41);
+            button58.Name = "button58";
+            button58.Size = new System.Drawing.Size(26, 25);
+            button58.TabIndex = 72;
+            toolTip1.SetToolTip(button58, "Export buildings to a *.shp file");
+            button58.UseVisualStyleBackColor = true;
+            button58.Click += Button58_Click;
             // 
             // openFileDialog1
             // 
-            this.openFileDialog1.FileName = "openFileDialog1";
+            openFileDialog1.FileName = "openFileDialog1";
             // 
             // label1
             // 
-            this.label1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label1.AutoSize = true;
-            this.label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.label1.Location = new System.Drawing.Point(6, 130);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(31, 13);
-            this.label1.TabIndex = 14;
-            this.label1.Text = "Xpos";
+            label1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            label1.AutoSize = true;
+            label1.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            label1.Location = new System.Drawing.Point(6, 130);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(31, 13);
+            label1.TabIndex = 14;
+            label1.Text = "Xpos";
             // 
             // textBox2
             // 
-            this.textBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox2.BackColor = System.Drawing.SystemColors.MenuBar;
-            this.textBox2.Location = new System.Drawing.Point(54, 148);
-            this.textBox2.Name = "textBox2";
-            this.textBox2.ReadOnly = true;
-            this.textBox2.Size = new System.Drawing.Size(84, 20);
-            this.textBox2.TabIndex = 0;
-            this.textBox2.TabStop = false;
-            this.textBox2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            textBox2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            textBox2.BackColor = System.Drawing.SystemColors.MenuBar;
+            textBox2.Location = new System.Drawing.Point(54, 148);
+            textBox2.Name = "textBox2";
+            textBox2.ReadOnly = true;
+            textBox2.Size = new System.Drawing.Size(84, 23);
+            textBox2.TabIndex = 0;
+            textBox2.TabStop = false;
+            textBox2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // label2
             // 
-            this.label2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label2.AutoSize = true;
-            this.label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.label2.Location = new System.Drawing.Point(6, 150);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(31, 13);
-            this.label2.TabIndex = 15;
-            this.label2.Text = "Ypos";
+            label2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            label2.AutoSize = true;
+            label2.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            label2.Location = new System.Drawing.Point(6, 150);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(31, 13);
+            label2.TabIndex = 15;
+            label2.Text = "Ypos";
             // 
             // textBox1
             // 
-            this.textBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox1.BackColor = System.Drawing.SystemColors.MenuBar;
-            this.textBox1.Location = new System.Drawing.Point(54, 126);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.ReadOnly = true;
-            this.textBox1.Size = new System.Drawing.Size(84, 20);
-            this.textBox1.TabIndex = 13;
-            this.textBox1.TabStop = false;
-            this.textBox1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            textBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            textBox1.BackColor = System.Drawing.SystemColors.MenuBar;
+            textBox1.Location = new System.Drawing.Point(54, 126);
+            textBox1.Name = "textBox1";
+            textBox1.ReadOnly = true;
+            textBox1.Size = new System.Drawing.Size(84, 23);
+            textBox1.TabIndex = 13;
+            textBox1.TabStop = false;
+            textBox1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // groupBox1
             // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox1.Controls.Add(this.toolStrip1);
-            this.groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox1.ForeColor = System.Drawing.Color.Black;
-            this.groupBox1.Location = new System.Drawing.Point(6, 78);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(132, 42);
-            this.groupBox1.TabIndex = 14;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Georeference";
+            groupBox1.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox1.Controls.Add(toolStrip1);
+            groupBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox1.ForeColor = System.Drawing.Color.Black;
+            groupBox1.Location = new System.Drawing.Point(6, 78);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Size = new System.Drawing.Size(132, 42);
+            groupBox1.TabIndex = 14;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Georeference";
             // 
             // toolStrip1
             // 
-            this.toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
-            this.toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.toolStripButton3,
-            this.toolStripButton4,
-            this.toolStripButton1});
-            this.toolStrip1.Location = new System.Drawing.Point(3, 15);
-            this.toolStrip1.Name = "toolStrip1";
-            this.toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.toolStrip1.Size = new System.Drawing.Size(126, 25);
-            this.toolStrip1.TabIndex = 0;
-            this.toolStrip1.Text = "toolStrip1";
+            toolStrip1.GripStyle = System.Windows.Forms.ToolStripGripStyle.Hidden;
+            toolStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { toolStripButton3, toolStripButton4, toolStripButton1 });
+            toolStrip1.Location = new System.Drawing.Point(3, 15);
+            toolStrip1.Name = "toolStrip1";
+            toolStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            toolStrip1.Size = new System.Drawing.Size(126, 25);
+            toolStrip1.TabIndex = 0;
+            toolStrip1.Text = "toolStrip1";
             // 
             // toolStripButton3
             // 
-            this.toolStripButton3.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.toolStripButton3.CheckOnClick = true;
-            this.toolStripButton3.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButton3.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton3.Image")));
-            this.toolStripButton3.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton3.Name = "toolStripButton3";
-            this.toolStripButton3.Size = new System.Drawing.Size(23, 22);
-            this.toolStripButton3.Click += new System.EventHandler(this.ToolStripButton3_Click);
+            toolStripButton3.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            toolStripButton3.CheckOnClick = true;
+            toolStripButton3.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripButton3.Image = (System.Drawing.Image)resources.GetObject("toolStripButton3.Image");
+            toolStripButton3.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripButton3.Name = "toolStripButton3";
+            toolStripButton3.Size = new System.Drawing.Size(23, 22);
+            toolStripButton3.Click += ToolStripButton3_Click;
             // 
             // toolStripButton4
             // 
-            this.toolStripButton4.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
-            this.toolStripButton4.CheckOnClick = true;
-            this.toolStripButton4.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButton4.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton4.Image")));
-            this.toolStripButton4.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton4.Name = "toolStripButton4";
-            this.toolStripButton4.Size = new System.Drawing.Size(23, 22);
-            this.toolStripButton4.Click += new System.EventHandler(this.ToolStripButton4_Click);
+            toolStripButton4.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Stretch;
+            toolStripButton4.CheckOnClick = true;
+            toolStripButton4.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripButton4.Image = (System.Drawing.Image)resources.GetObject("toolStripButton4.Image");
+            toolStripButton4.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripButton4.Name = "toolStripButton4";
+            toolStripButton4.Size = new System.Drawing.Size(23, 22);
+            toolStripButton4.Click += ToolStripButton4_Click;
             // 
             // toolStripButton1
             // 
-            this.toolStripButton1.CheckOnClick = true;
-            this.toolStripButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
-            this.toolStripButton1.Image = ((System.Drawing.Image)(resources.GetObject("toolStripButton1.Image")));
-            this.toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
-            this.toolStripButton1.Name = "toolStripButton1";
-            this.toolStripButton1.Size = new System.Drawing.Size(23, 22);
-            this.toolStripButton1.Text = "toolStripButton1";
-            this.toolStripButton1.ToolTipText = "Move and zoom base map using cursor + and - keys";
-            this.toolStripButton1.Click += new System.EventHandler(this.ToolStripButton1Click);
+            toolStripButton1.CheckOnClick = true;
+            toolStripButton1.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Image;
+            toolStripButton1.Image = (System.Drawing.Image)resources.GetObject("toolStripButton1.Image");
+            toolStripButton1.ImageTransparentColor = System.Drawing.Color.Magenta;
+            toolStripButton1.Name = "toolStripButton1";
+            toolStripButton1.Size = new System.Drawing.Size(23, 22);
+            toolStripButton1.Text = "toolStripButton1";
+            toolStripButton1.ToolTipText = "Move and zoom base map using cursor + and - keys";
+            toolStripButton1.Click += ToolStripButton1Click;
             // 
             // groupBox2
             // 
-            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox2.Controls.Add(this.checkBox26);
-            this.groupBox2.Controls.Add(this.checkBox25);
-            this.groupBox2.Controls.Add(this.checkBox20);
-            this.groupBox2.Controls.Add(this.checkBox15);
-            this.groupBox2.Controls.Add(this.checkBox12);
-            this.groupBox2.Controls.Add(this.checkBox8);
-            this.groupBox2.Controls.Add(this.checkBox5);
-            this.groupBox2.Controls.Add(this.checkBox4);
-            this.groupBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox2.ForeColor = System.Drawing.Color.Black;
-            this.groupBox2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
-            this.groupBox2.Location = new System.Drawing.Point(6, 276);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(132, 145);
-            this.groupBox2.TabIndex = 32;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Edit items";
-            this.groupBox2.Visible = false;
+            groupBox2.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox2.Controls.Add(checkBox26);
+            groupBox2.Controls.Add(checkBox25);
+            groupBox2.Controls.Add(checkBox20);
+            groupBox2.Controls.Add(checkBox15);
+            groupBox2.Controls.Add(checkBox12);
+            groupBox2.Controls.Add(checkBox8);
+            groupBox2.Controls.Add(checkBox5);
+            groupBox2.Controls.Add(checkBox4);
+            groupBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox2.ForeColor = System.Drawing.Color.Black;
+            groupBox2.ImeMode = System.Windows.Forms.ImeMode.NoControl;
+            groupBox2.Location = new System.Drawing.Point(6, 276);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Size = new System.Drawing.Size(132, 145);
+            groupBox2.TabIndex = 32;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Edit items";
+            groupBox2.Visible = false;
             // 
             // checkBox26
             // 
-            this.checkBox26.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox26.AutoSize = true;
-            this.checkBox26.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox26.Location = new System.Drawing.Point(8, 124);
-            this.checkBox26.Name = "checkBox26";
-            this.checkBox26.Size = new System.Drawing.Size(77, 17);
-            this.checkBox26.TabIndex = 39;
-            this.checkBox26.Text = "Vegetation";
-            this.checkBox26.UseVisualStyleBackColor = true;
-            this.checkBox26.CheckedChanged += new System.EventHandler(this.checkBox26_CheckedChanged);
+            checkBox26.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox26.AutoSize = true;
+            checkBox26.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox26.Location = new System.Drawing.Point(8, 124);
+            checkBox26.Name = "checkBox26";
+            checkBox26.Size = new System.Drawing.Size(77, 17);
+            checkBox26.TabIndex = 39;
+            checkBox26.Text = "Vegetation";
+            checkBox26.UseVisualStyleBackColor = true;
+            checkBox26.CheckedChanged += checkBox26_CheckedChanged;
             // 
             // checkBox25
             // 
-            this.checkBox25.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox25.AutoSize = true;
-            this.checkBox25.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox25.Location = new System.Drawing.Point(8, 109);
-            this.checkBox25.Name = "checkBox25";
-            this.checkBox25.Size = new System.Drawing.Size(52, 17);
-            this.checkBox25.TabIndex = 38;
-            this.checkBox25.Text = "Walls";
-            this.checkBox25.UseVisualStyleBackColor = true;
-            this.checkBox25.CheckedChanged += new System.EventHandler(this.checkBox25_CheckedChanged);
+            checkBox25.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox25.AutoSize = true;
+            checkBox25.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox25.Location = new System.Drawing.Point(8, 109);
+            checkBox25.Name = "checkBox25";
+            checkBox25.Size = new System.Drawing.Size(52, 17);
+            checkBox25.TabIndex = 38;
+            checkBox25.Text = "Walls";
+            checkBox25.UseVisualStyleBackColor = true;
+            checkBox25.CheckedChanged += checkBox25_CheckedChanged;
             // 
             // checkBox20
             // 
-            this.checkBox20.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox20.AutoSize = true;
-            this.checkBox20.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox20.Location = new System.Drawing.Point(8, 94);
-            this.checkBox20.Name = "checkBox20";
-            this.checkBox20.Size = new System.Drawing.Size(75, 17);
-            this.checkBox20.TabIndex = 37;
-            this.checkBox20.Text = "Receptors";
-            this.checkBox20.UseVisualStyleBackColor = true;
-            this.checkBox20.CheckedChanged += new System.EventHandler(this.checkBox20_CheckedChanged);
+            checkBox20.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox20.AutoSize = true;
+            checkBox20.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox20.Location = new System.Drawing.Point(8, 94);
+            checkBox20.Name = "checkBox20";
+            checkBox20.Size = new System.Drawing.Size(75, 17);
+            checkBox20.TabIndex = 37;
+            checkBox20.Text = "Receptors";
+            checkBox20.UseVisualStyleBackColor = true;
+            checkBox20.CheckedChanged += checkBox20_CheckedChanged;
             // 
             // checkBox15
             // 
-            this.checkBox15.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox15.AutoSize = true;
-            this.checkBox15.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox15.Location = new System.Drawing.Point(8, 79);
-            this.checkBox15.Name = "checkBox15";
-            this.checkBox15.Size = new System.Drawing.Size(68, 17);
-            this.checkBox15.TabIndex = 36;
-            this.checkBox15.Text = "Buildings";
-            this.checkBox15.UseVisualStyleBackColor = true;
-            this.checkBox15.CheckedChanged += new System.EventHandler(this.checkBox15_CheckedChanged);
+            checkBox15.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox15.AutoSize = true;
+            checkBox15.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox15.Location = new System.Drawing.Point(8, 79);
+            checkBox15.Name = "checkBox15";
+            checkBox15.Size = new System.Drawing.Size(68, 17);
+            checkBox15.TabIndex = 36;
+            checkBox15.Text = "Buildings";
+            checkBox15.UseVisualStyleBackColor = true;
+            checkBox15.CheckedChanged += checkBox15_CheckedChanged;
             // 
             // checkBox12
             // 
-            this.checkBox12.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox12.AutoSize = true;
-            this.checkBox12.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox12.Location = new System.Drawing.Point(8, 64);
-            this.checkBox12.Name = "checkBox12";
-            this.checkBox12.Size = new System.Drawing.Size(93, 17);
-            this.checkBox12.TabIndex = 35;
-            this.checkBox12.Text = "Tunnel portals";
-            this.checkBox12.UseVisualStyleBackColor = true;
-            this.checkBox12.CheckedChanged += new System.EventHandler(this.checkBox12_CheckedChanged);
+            checkBox12.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox12.AutoSize = true;
+            checkBox12.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox12.Location = new System.Drawing.Point(8, 64);
+            checkBox12.Name = "checkBox12";
+            checkBox12.Size = new System.Drawing.Size(93, 17);
+            checkBox12.TabIndex = 35;
+            checkBox12.Text = "Tunnel portals";
+            checkBox12.UseVisualStyleBackColor = true;
+            checkBox12.CheckedChanged += checkBox12_CheckedChanged;
             // 
             // checkBox8
             // 
-            this.checkBox8.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox8.AutoSize = true;
-            this.checkBox8.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox8.Location = new System.Drawing.Point(8, 49);
-            this.checkBox8.Name = "checkBox8";
-            this.checkBox8.Size = new System.Drawing.Size(86, 17);
-            this.checkBox8.TabIndex = 34;
-            this.checkBox8.Text = "Line sources";
-            this.checkBox8.UseVisualStyleBackColor = true;
-            this.checkBox8.CheckedChanged += new System.EventHandler(this.checkBox8_CheckedChanged);
+            checkBox8.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox8.AutoSize = true;
+            checkBox8.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox8.Location = new System.Drawing.Point(8, 49);
+            checkBox8.Name = "checkBox8";
+            checkBox8.Size = new System.Drawing.Size(86, 17);
+            checkBox8.TabIndex = 34;
+            checkBox8.Text = "Line sources";
+            checkBox8.UseVisualStyleBackColor = true;
+            checkBox8.CheckedChanged += checkBox8_CheckedChanged;
             // 
             // checkBox5
             // 
-            this.checkBox5.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox5.AutoSize = true;
-            this.checkBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox5.Location = new System.Drawing.Point(8, 34);
-            this.checkBox5.Name = "checkBox5";
-            this.checkBox5.Size = new System.Drawing.Size(88, 17);
-            this.checkBox5.TabIndex = 33;
-            this.checkBox5.Text = "Area sources";
-            this.checkBox5.UseVisualStyleBackColor = true;
-            this.checkBox5.CheckedChanged += new System.EventHandler(this.checkBox5_CheckedChanged);
+            checkBox5.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox5.AutoSize = true;
+            checkBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox5.Location = new System.Drawing.Point(8, 34);
+            checkBox5.Name = "checkBox5";
+            checkBox5.Size = new System.Drawing.Size(88, 17);
+            checkBox5.TabIndex = 33;
+            checkBox5.Text = "Area sources";
+            checkBox5.UseVisualStyleBackColor = true;
+            checkBox5.CheckedChanged += checkBox5_CheckedChanged;
             // 
             // checkBox4
             // 
-            this.checkBox4.Anchor = System.Windows.Forms.AnchorStyles.Left;
-            this.checkBox4.AutoSize = true;
-            this.checkBox4.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.checkBox4.Location = new System.Drawing.Point(8, 19);
-            this.checkBox4.Name = "checkBox4";
-            this.checkBox4.Size = new System.Drawing.Size(90, 17);
-            this.checkBox4.TabIndex = 32;
-            this.checkBox4.Text = "Point sources";
-            this.checkBox4.UseVisualStyleBackColor = true;
-            this.checkBox4.CheckedChanged += new System.EventHandler(this.checkBox4_CheckedChanged);
+            checkBox4.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            checkBox4.AutoSize = true;
+            checkBox4.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            checkBox4.Location = new System.Drawing.Point(8, 19);
+            checkBox4.Name = "checkBox4";
+            checkBox4.Size = new System.Drawing.Size(90, 17);
+            checkBox4.TabIndex = 32;
+            checkBox4.Text = "Point sources";
+            checkBox4.UseVisualStyleBackColor = true;
+            checkBox4.CheckedChanged += checkBox4_CheckedChanged;
             // 
             // groupBox4
             // 
-            this.groupBox4.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox4.Controls.Add(this.button50);
-            this.groupBox4.Controls.Add(this.button49);
-            this.groupBox4.Controls.Add(this.button47);
-            this.groupBox4.Controls.Add(this.button23);
-            this.groupBox4.Controls.Add(this.button16);
-            this.groupBox4.Controls.Add(this.button14);
-            this.groupBox4.Controls.Add(this.button12);
-            this.groupBox4.Controls.Add(this.button10);
-            this.groupBox4.Controls.Add(this.button8);
-            this.groupBox4.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox4.ForeColor = System.Drawing.Color.Black;
-            this.groupBox4.Location = new System.Drawing.Point(7, 503);
-            this.groupBox4.Name = "groupBox4";
-            this.groupBox4.Size = new System.Drawing.Size(132, 100);
-            this.groupBox4.TabIndex = 48;
-            this.groupBox4.TabStop = false;
-            this.groupBox4.Text = "Select items";
+            groupBox4.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox4.Controls.Add(button50);
+            groupBox4.Controls.Add(button49);
+            groupBox4.Controls.Add(button47);
+            groupBox4.Controls.Add(button23);
+            groupBox4.Controls.Add(button16);
+            groupBox4.Controls.Add(button14);
+            groupBox4.Controls.Add(button12);
+            groupBox4.Controls.Add(button10);
+            groupBox4.Controls.Add(button8);
+            groupBox4.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox4.ForeColor = System.Drawing.Color.Black;
+            groupBox4.Location = new System.Drawing.Point(7, 503);
+            groupBox4.Name = "groupBox4";
+            groupBox4.Size = new System.Drawing.Size(132, 100);
+            groupBox4.TabIndex = 48;
+            groupBox4.TabStop = false;
+            groupBox4.Text = "Select items";
             // 
             // groupBox3
             // 
-            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox3.Controls.Add(this.buttonstabilityclass);
-            this.groupBox3.Controls.Add(this.button_section_wind);
-            this.groupBox3.Controls.Add(this.button43);
-            this.groupBox3.Controls.Add(this.button42);
-            this.groupBox3.Controls.Add(this.button41);
-            this.groupBox3.Controls.Add(this.button32);
-            this.groupBox3.Controls.Add(this.button31);
-            this.groupBox3.Controls.Add(this.button30);
-            this.groupBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox3.ForeColor = System.Drawing.Color.Black;
-            this.groupBox3.Location = new System.Drawing.Point(7, 427);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(132, 75);
-            this.groupBox3.TabIndex = 40;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Windfield analysis";
-            this.groupBox3.Visible = false;
+            groupBox3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox3.Controls.Add(buttonstabilityclass);
+            groupBox3.Controls.Add(button_section_wind);
+            groupBox3.Controls.Add(button43);
+            groupBox3.Controls.Add(button42);
+            groupBox3.Controls.Add(button41);
+            groupBox3.Controls.Add(button32);
+            groupBox3.Controls.Add(button31);
+            groupBox3.Controls.Add(button30);
+            groupBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox3.ForeColor = System.Drawing.Color.Black;
+            groupBox3.Location = new System.Drawing.Point(7, 427);
+            groupBox3.Name = "groupBox3";
+            groupBox3.Size = new System.Drawing.Size(132, 75);
+            groupBox3.TabIndex = 40;
+            groupBox3.TabStop = false;
+            groupBox3.Text = "Windfield analysis";
+            groupBox3.Visible = false;
             // 
             // groupBox5
             // 
-            this.groupBox5.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox5.Controls.Add(this.button51);
-            this.groupBox5.Controls.Add(this.button24);
-            this.groupBox5.Controls.Add(this.button54);
-            this.groupBox5.Controls.Add(this.button17);
-            this.groupBox5.Controls.Add(this.button15);
-            this.groupBox5.Controls.Add(this.button13);
-            this.groupBox5.Controls.Add(this.button11);
-            this.groupBox5.Controls.Add(this.button9);
-            this.groupBox5.Controls.Add(this.button53);
-            this.groupBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox5.ForeColor = System.Drawing.Color.Black;
-            this.groupBox5.Location = new System.Drawing.Point(7, 609);
-            this.groupBox5.Name = "groupBox5";
-            this.groupBox5.Size = new System.Drawing.Size(132, 102);
-            this.groupBox5.TabIndex = 57;
-            this.groupBox5.TabStop = false;
-            this.groupBox5.Text = "Import items";
-            this.groupBox5.Visible = false;
+            groupBox5.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox5.Controls.Add(button51);
+            groupBox5.Controls.Add(button24);
+            groupBox5.Controls.Add(button54);
+            groupBox5.Controls.Add(button17);
+            groupBox5.Controls.Add(button15);
+            groupBox5.Controls.Add(button13);
+            groupBox5.Controls.Add(button11);
+            groupBox5.Controls.Add(button9);
+            groupBox5.Controls.Add(button53);
+            groupBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox5.ForeColor = System.Drawing.Color.Black;
+            groupBox5.Location = new System.Drawing.Point(7, 609);
+            groupBox5.Name = "groupBox5";
+            groupBox5.Size = new System.Drawing.Size(132, 102);
+            groupBox5.TabIndex = 57;
+            groupBox5.TabStop = false;
+            groupBox5.Text = "Import items";
+            groupBox5.Visible = false;
             // 
             // panel1
             // 
-            this.panel1.AutoSize = true;
-            this.panel1.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(192)))), ((int)(((byte)(255)))), ((int)(((byte)(255)))));
-            this.panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.panel1.Controls.Add(this.label3);
-            this.panel1.Controls.Add(this.textBox3);
-            this.panel1.Controls.Add(this.button57);
-            this.panel1.Controls.Add(this.button55);
-            this.panel1.Controls.Add(this.groupBox7);
-            this.panel1.Controls.Add(this.button46);
-            this.panel1.Controls.Add(this.button45);
-            this.panel1.Controls.Add(this.button44);
-            this.panel1.Controls.Add(this.button3D);
-            this.panel1.Controls.Add(this.domain_clipboard);
-            this.panel1.Controls.Add(this.button40);
-            this.panel1.Controls.Add(this.groupBox6);
-            this.panel1.Controls.Add(this.button35);
-            this.panel1.Controls.Add(this.button34);
-            this.panel1.Controls.Add(this.groupBox5);
-            this.panel1.Controls.Add(this.groupBox3);
-            this.panel1.Controls.Add(this.groupBox4);
-            this.panel1.Controls.Add(this.button33);
-            this.panel1.Controls.Add(this.button1);
-            this.panel1.Controls.Add(this.button2);
-            this.panel1.Controls.Add(this.groupBox2);
-            this.panel1.Controls.Add(this.button29);
-            this.panel1.Controls.Add(this.button3);
-            this.panel1.Controls.Add(this.button28);
-            this.panel1.Controls.Add(this.button4);
-            this.panel1.Controls.Add(this.button27);
-            this.panel1.Controls.Add(this.button5);
-            this.panel1.Controls.Add(this.button26);
-            this.panel1.Controls.Add(this.button7);
-            this.panel1.Controls.Add(this.button25);
-            this.panel1.Controls.Add(this.button18);
-            this.panel1.Controls.Add(this.button22);
-            this.panel1.Controls.Add(this.button19);
-            this.panel1.Controls.Add(this.button21);
-            this.panel1.Controls.Add(this.button20);
-            this.panel1.Controls.Add(this.button6);
-            this.panel1.Controls.Add(this.groupBox1);
-            this.panel1.Controls.Add(this.textBox1);
-            this.panel1.Controls.Add(this.label2);
-            this.panel1.Controls.Add(this.textBox2);
-            this.panel1.Controls.Add(this.label1);
-            this.panel1.Dock = System.Windows.Forms.DockStyle.Right;
-            this.panel1.Location = new System.Drawing.Point(883, 25);
-            this.panel1.Margin = new System.Windows.Forms.Padding(2);
-            this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(144, 867);
-            this.panel1.TabIndex = 38;
-            this.panel1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.Panel1_MouseMove);
+            panel1.AutoSize = true;
+            panel1.BackColor = System.Drawing.Color.FromArgb(192, 255, 255);
+            panel1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            panel1.Controls.Add(label3);
+            panel1.Controls.Add(textBox3);
+            panel1.Controls.Add(button57);
+            panel1.Controls.Add(button55);
+            panel1.Controls.Add(groupBox7);
+            panel1.Controls.Add(button46);
+            panel1.Controls.Add(button45);
+            panel1.Controls.Add(button44);
+            panel1.Controls.Add(button3D);
+            panel1.Controls.Add(domain_clipboard);
+            panel1.Controls.Add(button40);
+            panel1.Controls.Add(groupBox6);
+            panel1.Controls.Add(button35);
+            panel1.Controls.Add(button34);
+            panel1.Controls.Add(groupBox5);
+            panel1.Controls.Add(groupBox3);
+            panel1.Controls.Add(groupBox4);
+            panel1.Controls.Add(button33);
+            panel1.Controls.Add(button1);
+            panel1.Controls.Add(button2);
+            panel1.Controls.Add(groupBox2);
+            panel1.Controls.Add(button29);
+            panel1.Controls.Add(button3);
+            panel1.Controls.Add(button28);
+            panel1.Controls.Add(button4);
+            panel1.Controls.Add(button27);
+            panel1.Controls.Add(button5);
+            panel1.Controls.Add(button26);
+            panel1.Controls.Add(button7);
+            panel1.Controls.Add(button25);
+            panel1.Controls.Add(button18);
+            panel1.Controls.Add(button22);
+            panel1.Controls.Add(button19);
+            panel1.Controls.Add(button21);
+            panel1.Controls.Add(button20);
+            panel1.Controls.Add(button6);
+            panel1.Controls.Add(groupBox1);
+            panel1.Controls.Add(textBox1);
+            panel1.Controls.Add(label2);
+            panel1.Controls.Add(textBox2);
+            panel1.Controls.Add(label1);
+            panel1.Dock = System.Windows.Forms.DockStyle.Right;
+            panel1.Location = new System.Drawing.Point(883, 25);
+            panel1.Margin = new System.Windows.Forms.Padding(2);
+            panel1.Name = "panel1";
+            panel1.Size = new System.Drawing.Size(144, 867);
+            panel1.TabIndex = 38;
+            panel1.MouseMove += Panel1_MouseMove;
             // 
             // label3
             // 
-            this.label3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.label3.AutoSize = true;
-            this.label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.label3.Location = new System.Drawing.Point(6, 170);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(31, 13);
-            this.label3.TabIndex = 54;
-            this.label3.Text = "Zpos";
+            label3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            label3.AutoSize = true;
+            label3.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            label3.Location = new System.Drawing.Point(6, 170);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(31, 13);
+            label3.TabIndex = 54;
+            label3.Text = "Zpos";
             // 
             // textBox3
             // 
-            this.textBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBox3.BackColor = System.Drawing.SystemColors.MenuBar;
-            this.textBox3.Location = new System.Drawing.Point(54, 170);
-            this.textBox3.Name = "textBox3";
-            this.textBox3.ReadOnly = true;
-            this.textBox3.Size = new System.Drawing.Size(84, 20);
-            this.textBox3.TabIndex = 53;
-            this.textBox3.TabStop = false;
-            this.textBox3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            textBox3.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            textBox3.BackColor = System.Drawing.SystemColors.MenuBar;
+            textBox3.Location = new System.Drawing.Point(54, 170);
+            textBox3.Name = "textBox3";
+            textBox3.ReadOnly = true;
+            textBox3.Size = new System.Drawing.Size(84, 23);
+            textBox3.TabIndex = 53;
+            textBox3.TabStop = false;
+            textBox3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // groupBox7
             // 
-            this.groupBox7.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox7.Controls.Add(this.button_section_concentration);
-            this.groupBox7.Controls.Add(this.button52);
-            this.groupBox7.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox7.ForeColor = System.Drawing.Color.Black;
-            this.groupBox7.Location = new System.Drawing.Point(7, 795);
-            this.groupBox7.Name = "groupBox7";
-            this.groupBox7.Size = new System.Drawing.Size(132, 44);
-            this.groupBox7.TabIndex = 72;
-            this.groupBox7.TabStop = false;
-            this.groupBox7.Text = "Vert. concentration";
+            groupBox7.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox7.Controls.Add(button_section_concentration);
+            groupBox7.Controls.Add(button52);
+            groupBox7.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox7.ForeColor = System.Drawing.Color.Black;
+            groupBox7.Location = new System.Drawing.Point(7, 795);
+            groupBox7.Name = "groupBox7";
+            groupBox7.Size = new System.Drawing.Size(132, 44);
+            groupBox7.TabIndex = 72;
+            groupBox7.TabStop = false;
+            groupBox7.Text = "Vert. concentration";
             // 
             // button46
             // 
-            this.button46.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button46.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button46.Location = new System.Drawing.Point(6, 2);
-            this.button46.Margin = new System.Windows.Forms.Padding(2);
-            this.button46.Name = "button46";
-            this.button46.Size = new System.Drawing.Size(53, 19);
-            this.button46.TabIndex = 1;
-            this.button46.Text = "<>";
-            this.button46.UseMnemonic = false;
-            this.button46.UseVisualStyleBackColor = true;
-            this.button46.Click += new System.EventHandler(this.Button46Click);
+            button46.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button46.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            button46.Location = new System.Drawing.Point(6, 2);
+            button46.Margin = new System.Windows.Forms.Padding(2);
+            button46.Name = "button46";
+            button46.Size = new System.Drawing.Size(53, 19);
+            button46.TabIndex = 1;
+            button46.Text = "<>";
+            button46.UseMnemonic = false;
+            button46.UseVisualStyleBackColor = true;
+            button46.Click += Button46Click;
             // 
             // button45
             // 
-            this.button45.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.button45.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.button45.Location = new System.Drawing.Point(118, 2);
-            this.button45.Margin = new System.Windows.Forms.Padding(2);
-            this.button45.Name = "button45";
-            this.button45.Size = new System.Drawing.Size(19, 19);
-            this.button45.TabIndex = 3;
-            this.button45.Text = "X";
-            this.button45.UseMnemonic = false;
-            this.button45.UseVisualStyleBackColor = true;
-            this.button45.Click += new System.EventHandler(this.ToolBoxToolStripMenuItemClick);
+            button45.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            button45.Font = new System.Drawing.Font("Microsoft Sans Serif", 7.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            button45.Location = new System.Drawing.Point(118, 2);
+            button45.Margin = new System.Windows.Forms.Padding(2);
+            button45.Name = "button45";
+            button45.Size = new System.Drawing.Size(19, 19);
+            button45.TabIndex = 3;
+            button45.Text = "X";
+            button45.UseMnemonic = false;
+            button45.UseVisualStyleBackColor = true;
+            button45.Click += ToolBoxToolStripMenuItemClick;
             // 
             // groupBox6
             // 
-            this.groupBox6.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.groupBox6.Controls.Add(this.button56);
-            this.groupBox6.Controls.Add(this.button48);
-            this.groupBox6.Controls.Add(this.button39);
-            this.groupBox6.Controls.Add(this.button38);
-            this.groupBox6.Controls.Add(this.button36);
-            this.groupBox6.Controls.Add(this.button37);
-            this.groupBox6.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, ((byte)(0)));
-            this.groupBox6.ForeColor = System.Drawing.Color.Black;
-            this.groupBox6.Location = new System.Drawing.Point(7, 716);
-            this.groupBox6.Name = "groupBox6";
-            this.groupBox6.Size = new System.Drawing.Size(132, 72);
-            this.groupBox6.TabIndex = 66;
-            this.groupBox6.TabStop = false;
-            this.groupBox6.Text = "Export items";
+            groupBox6.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
+            groupBox6.Controls.Add(button58);
+            groupBox6.Controls.Add(button56);
+            groupBox6.Controls.Add(button48);
+            groupBox6.Controls.Add(button39);
+            groupBox6.Controls.Add(button38);
+            groupBox6.Controls.Add(button36);
+            groupBox6.Controls.Add(button37);
+            groupBox6.Font = new System.Drawing.Font("Microsoft Sans Serif", 2.8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter, 0);
+            groupBox6.ForeColor = System.Drawing.Color.Black;
+            groupBox6.Location = new System.Drawing.Point(7, 716);
+            groupBox6.Name = "groupBox6";
+            groupBox6.Size = new System.Drawing.Size(132, 72);
+            groupBox6.TabIndex = 66;
+            groupBox6.TabStop = false;
+            groupBox6.Text = "Export items";
             // 
             // viewtoolStripMenuItem
             // 
-            this.viewtoolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.viewtoolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.objectManagerToolStripMenuItem,
-            this.toolStripSeparator1,
-            this.toolStripMenuItem3,
-            this.toolStripMenuItem7,
-            this.zoomInToolStripMenuItem,
-            this.zoomOutToolStripMenuItem,
-            this.zoomFrameToolStripMenuItem,
-            this.originalSizeToolStripMenuItem,
-            this.moveMapToolStripMenuItem,
-            this.arrowCursorToolStripMenuItem1,
-            this.toolStripMenuItem18,
-            this.shownCellHeightToolStripMenuItem,
-            this.toolStripMenuItem5,
-            this.sectionViewToolStripMenuItem,
-            this.dViewToolStripMenuItem,
-            this.toolStripMenuItem6,
-            this.toolBoxToolStripMenuItem});
-            this.viewtoolStripMenuItem.Name = "viewtoolStripMenuItem";
-            this.viewtoolStripMenuItem.ShortcutKeyDisplayString = "V";
-            this.viewtoolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.V)));
-            this.viewtoolStripMenuItem.Size = new System.Drawing.Size(44, 21);
-            this.viewtoolStripMenuItem.Text = "&View";
+            viewtoolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            viewtoolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { objectManagerToolStripMenuItem, toolStripSeparator1, toolStripMenuItem3, toolStripMenuItem7, zoomInToolStripMenuItem, zoomOutToolStripMenuItem, zoomFrameToolStripMenuItem, originalSizeToolStripMenuItem, moveMapToolStripMenuItem, arrowCursorToolStripMenuItem1, toolStripMenuItem18, shownCellHeightToolStripMenuItem, toolStripMenuItem5, sectionViewToolStripMenuItem, dViewToolStripMenuItem, toolStripMenuItem6, toolBoxToolStripMenuItem });
+            viewtoolStripMenuItem.Name = "viewtoolStripMenuItem";
+            viewtoolStripMenuItem.ShortcutKeyDisplayString = "V";
+            viewtoolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.V;
+            viewtoolStripMenuItem.Size = new System.Drawing.Size(44, 21);
+            viewtoolStripMenuItem.Text = "&View";
             // 
             // objectManagerToolStripMenuItem
             // 
-            this.objectManagerToolStripMenuItem.Name = "objectManagerToolStripMenuItem";
-            this.objectManagerToolStripMenuItem.ShortcutKeyDisplayString = "";
-            this.objectManagerToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D0)));
-            this.objectManagerToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.objectManagerToolStripMenuItem.Text = "&Object manager";
-            this.objectManagerToolStripMenuItem.Click += new System.EventHandler(this.Button25_Click);
+            objectManagerToolStripMenuItem.Name = "objectManagerToolStripMenuItem";
+            objectManagerToolStripMenuItem.ShortcutKeyDisplayString = "";
+            objectManagerToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D0;
+            objectManagerToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            objectManagerToolStripMenuItem.Text = "&Object manager";
+            objectManagerToolStripMenuItem.Click += Button25_Click;
             // 
             // toolStripSeparator1
             // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(202, 6);
+            toolStripSeparator1.Name = "toolStripSeparator1";
+            toolStripSeparator1.Size = new System.Drawing.Size(202, 6);
             // 
             // toolStripMenuItem3
             // 
-            this.toolStripMenuItem3.Name = "toolStripMenuItem3";
-            this.toolStripMenuItem3.Size = new System.Drawing.Size(205, 22);
-            this.toolStripMenuItem3.Text = "Save or load a &viewframe";
-            this.toolStripMenuItem3.Click += new System.EventHandler(this.button57_Click);
+            toolStripMenuItem3.Name = "toolStripMenuItem3";
+            toolStripMenuItem3.Size = new System.Drawing.Size(205, 22);
+            toolStripMenuItem3.Text = "Save or load a &viewframe";
+            toolStripMenuItem3.Click += button57_Click;
             // 
             // toolStripMenuItem7
             // 
-            this.toolStripMenuItem7.Name = "toolStripMenuItem7";
-            this.toolStripMenuItem7.Size = new System.Drawing.Size(202, 6);
+            toolStripMenuItem7.Name = "toolStripMenuItem7";
+            toolStripMenuItem7.Size = new System.Drawing.Size(202, 6);
             // 
             // zoomInToolStripMenuItem
             // 
-            this.zoomInToolStripMenuItem.Name = "zoomInToolStripMenuItem";
-            this.zoomInToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.zoomInToolStripMenuItem.Text = "Zoom in           (+)";
-            this.zoomInToolStripMenuItem.Click += new System.EventHandler(this.Button1_Click);
+            zoomInToolStripMenuItem.Name = "zoomInToolStripMenuItem";
+            zoomInToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            zoomInToolStripMenuItem.Text = "Zoom in           (+)";
+            zoomInToolStripMenuItem.Click += Button1_Click;
             // 
             // zoomOutToolStripMenuItem
             // 
-            this.zoomOutToolStripMenuItem.Name = "zoomOutToolStripMenuItem";
-            this.zoomOutToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.zoomOutToolStripMenuItem.Text = "Zoom out         (-)";
-            this.zoomOutToolStripMenuItem.Click += new System.EventHandler(this.Button2_Click);
+            zoomOutToolStripMenuItem.Name = "zoomOutToolStripMenuItem";
+            zoomOutToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            zoomOutToolStripMenuItem.Text = "Zoom out         (-)";
+            zoomOutToolStripMenuItem.Click += Button2_Click;
             // 
             // zoomFrameToolStripMenuItem
             // 
-            this.zoomFrameToolStripMenuItem.Name = "zoomFrameToolStripMenuItem";
-            this.zoomFrameToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.zoomFrameToolStripMenuItem.Text = "Zoom frame";
-            this.zoomFrameToolStripMenuItem.Click += new System.EventHandler(this.Button7_Click);
+            zoomFrameToolStripMenuItem.Name = "zoomFrameToolStripMenuItem";
+            zoomFrameToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            zoomFrameToolStripMenuItem.Text = "Zoom frame";
+            zoomFrameToolStripMenuItem.Click += Button7_Click;
             // 
             // originalSizeToolStripMenuItem
             // 
-            this.originalSizeToolStripMenuItem.Name = "originalSizeToolStripMenuItem";
-            this.originalSizeToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.originalSizeToolStripMenuItem.Text = "&Original size";
-            this.originalSizeToolStripMenuItem.Click += new System.EventHandler(this.Button3_Click_1);
+            originalSizeToolStripMenuItem.Name = "originalSizeToolStripMenuItem";
+            originalSizeToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            originalSizeToolStripMenuItem.Text = "&Original size";
+            originalSizeToolStripMenuItem.Click += Button3_Click_1;
             // 
             // moveMapToolStripMenuItem
             // 
-            this.moveMapToolStripMenuItem.Name = "moveMapToolStripMenuItem";
-            this.moveMapToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.moveMapToolStripMenuItem.Text = "&Move map";
-            this.moveMapToolStripMenuItem.Click += new System.EventHandler(this.Button4Click);
+            moveMapToolStripMenuItem.Name = "moveMapToolStripMenuItem";
+            moveMapToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            moveMapToolStripMenuItem.Text = "&Move map";
+            moveMapToolStripMenuItem.Click += Button4Click;
             // 
             // arrowCursorToolStripMenuItem1
             // 
-            this.arrowCursorToolStripMenuItem1.Name = "arrowCursorToolStripMenuItem1";
-            this.arrowCursorToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.arrowCursorToolStripMenuItem1.Text = "&Arrow Cursor";
-            this.arrowCursorToolStripMenuItem1.Click += new System.EventHandler(this.Button5_Click);
+            arrowCursorToolStripMenuItem1.Name = "arrowCursorToolStripMenuItem1";
+            arrowCursorToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            arrowCursorToolStripMenuItem1.Text = "&Arrow Cursor";
+            arrowCursorToolStripMenuItem1.Click += Button5_Click;
             // 
             // toolStripMenuItem18
             // 
-            this.toolStripMenuItem18.Checked = true;
-            this.toolStripMenuItem18.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.toolStripMenuItem18.Name = "toolStripMenuItem18";
-            this.toolStripMenuItem18.Size = new System.Drawing.Size(205, 22);
-            this.toolStripMenuItem18.Text = "Show &length label info";
-            this.toolStripMenuItem18.Click += new System.EventHandler(this.ToolStripMenuItem18Click);
+            toolStripMenuItem18.Checked = true;
+            toolStripMenuItem18.CheckState = System.Windows.Forms.CheckState.Checked;
+            toolStripMenuItem18.Name = "toolStripMenuItem18";
+            toolStripMenuItem18.Size = new System.Drawing.Size(205, 22);
+            toolStripMenuItem18.Text = "Show &length label info";
+            toolStripMenuItem18.Click += ToolStripMenuItem18Click;
             // 
             // shownCellHeightToolStripMenuItem
             // 
-            this.shownCellHeightToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.MenuEntryCellHeightsGramm,
-            this.MenuEntryCellHeightsGrammEdge,
-            this.MenuEntryCellHeightsGral});
-            this.shownCellHeightToolStripMenuItem.Name = "shownCellHeightToolStripMenuItem";
-            this.shownCellHeightToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.shownCellHeightToolStripMenuItem.Text = "Show cell heights for";
+            shownCellHeightToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { MenuEntryCellHeightsGramm, MenuEntryCellHeightsGrammEdge, MenuEntryCellHeightsGral });
+            shownCellHeightToolStripMenuItem.Name = "shownCellHeightToolStripMenuItem";
+            shownCellHeightToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            shownCellHeightToolStripMenuItem.Text = "Show cell heights for";
             // 
             // MenuEntryCellHeightsGramm
             // 
-            this.MenuEntryCellHeightsGramm.Name = "MenuEntryCellHeightsGramm";
-            this.MenuEntryCellHeightsGramm.Size = new System.Drawing.Size(213, 22);
-            this.MenuEntryCellHeightsGramm.Text = "GRAMM grid mean height";
-            this.MenuEntryCellHeightsGramm.Click += new System.EventHandler(this.MenuCellHeightsGramm);
+            MenuEntryCellHeightsGramm.Name = "MenuEntryCellHeightsGramm";
+            MenuEntryCellHeightsGramm.Size = new System.Drawing.Size(213, 22);
+            MenuEntryCellHeightsGramm.Text = "GRAMM grid mean height";
+            MenuEntryCellHeightsGramm.Click += MenuCellHeightsGramm;
             // 
             // MenuEntryCellHeightsGrammEdge
             // 
-            this.MenuEntryCellHeightsGrammEdge.Name = "MenuEntryCellHeightsGrammEdge";
-            this.MenuEntryCellHeightsGrammEdge.Size = new System.Drawing.Size(213, 22);
-            this.MenuEntryCellHeightsGrammEdge.Text = "GRAMM grid edge points";
-            this.MenuEntryCellHeightsGrammEdge.Click += new System.EventHandler(this.MenuEntryCellHeightsGrammEdge_Click);
+            MenuEntryCellHeightsGrammEdge.Name = "MenuEntryCellHeightsGrammEdge";
+            MenuEntryCellHeightsGrammEdge.Size = new System.Drawing.Size(213, 22);
+            MenuEntryCellHeightsGrammEdge.Text = "GRAMM grid edge points";
+            MenuEntryCellHeightsGrammEdge.Click += MenuEntryCellHeightsGrammEdge_Click;
             // 
             // MenuEntryCellHeightsGral
             // 
-            this.MenuEntryCellHeightsGral.Name = "MenuEntryCellHeightsGral";
-            this.MenuEntryCellHeightsGral.Size = new System.Drawing.Size(213, 22);
-            this.MenuEntryCellHeightsGral.Text = "GRAL grid";
-            this.MenuEntryCellHeightsGral.Click += new System.EventHandler(this.MenuCellHeightsGral);
+            MenuEntryCellHeightsGral.Name = "MenuEntryCellHeightsGral";
+            MenuEntryCellHeightsGral.Size = new System.Drawing.Size(213, 22);
+            MenuEntryCellHeightsGral.Text = "GRAL grid";
+            MenuEntryCellHeightsGral.Click += MenuCellHeightsGral;
             // 
             // toolStripMenuItem5
             // 
-            this.toolStripMenuItem5.Name = "toolStripMenuItem5";
-            this.toolStripMenuItem5.Size = new System.Drawing.Size(202, 6);
+            toolStripMenuItem5.Name = "toolStripMenuItem5";
+            toolStripMenuItem5.Size = new System.Drawing.Size(202, 6);
             // 
             // sectionViewToolStripMenuItem
             // 
-            this.sectionViewToolStripMenuItem.Name = "sectionViewToolStripMenuItem";
-            this.sectionViewToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.sectionViewToolStripMenuItem.Text = "&Section view";
-            this.sectionViewToolStripMenuItem.Click += new System.EventHandler(this.Button_section_windMouseClick);
+            sectionViewToolStripMenuItem.Name = "sectionViewToolStripMenuItem";
+            sectionViewToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            sectionViewToolStripMenuItem.Text = "&Section view";
+            sectionViewToolStripMenuItem.Click += Button_section_windMouseClick;
             // 
             // dViewToolStripMenuItem
             // 
-            this.dViewToolStripMenuItem.Name = "dViewToolStripMenuItem";
-            this.dViewToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.dViewToolStripMenuItem.Text = "&3D view";
-            this.dViewToolStripMenuItem.Click += new System.EventHandler(this.Button3DClick);
+            dViewToolStripMenuItem.Name = "dViewToolStripMenuItem";
+            dViewToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            dViewToolStripMenuItem.Text = "&3D view";
+            dViewToolStripMenuItem.Click += Button3DClick;
             // 
             // toolStripMenuItem6
             // 
-            this.toolStripMenuItem6.Name = "toolStripMenuItem6";
-            this.toolStripMenuItem6.Size = new System.Drawing.Size(202, 6);
+            toolStripMenuItem6.Name = "toolStripMenuItem6";
+            toolStripMenuItem6.Size = new System.Drawing.Size(202, 6);
             // 
             // toolBoxToolStripMenuItem
             // 
-            this.toolBoxToolStripMenuItem.Checked = true;
-            this.toolBoxToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.toolBoxToolStripMenuItem.Name = "toolBoxToolStripMenuItem";
-            this.toolBoxToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.toolBoxToolStripMenuItem.Text = "Show tool box";
-            this.toolBoxToolStripMenuItem.Click += new System.EventHandler(this.ToolBoxToolStripMenuItemClick);
+            toolBoxToolStripMenuItem.Checked = true;
+            toolBoxToolStripMenuItem.CheckState = System.Windows.Forms.CheckState.Checked;
+            toolBoxToolStripMenuItem.Name = "toolBoxToolStripMenuItem";
+            toolBoxToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            toolBoxToolStripMenuItem.Text = "Show tool box";
+            toolBoxToolStripMenuItem.Click += ToolBoxToolStripMenuItemClick;
             // 
             // menuStrip1
             // 
-            this.menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.importexportToolStripMenuItem,
-            this.editToolStripMenuItem,
-            this.viewtoolStripMenuItem,
-            this.selectToolStripMenuItem,
-            this.toolsToolStripMenuItem,
-            this.windfieldAnalysisToolStripMenuItem,
-            this.analyzeResultsToolStripMenuItem,
-            this.exportToolStripMenuItem,
-            this.toolStripTextBox3,
-            this.toolStripTextBox2,
-            this.toolStripTextBox1,
-            this.toolStripComboBox1});
-            this.menuStrip1.Location = new System.Drawing.Point(0, 0);
-            this.menuStrip1.Name = "menuStrip1";
-            this.menuStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.menuStrip1.Size = new System.Drawing.Size(1027, 25);
-            this.menuStrip1.TabIndex = 1;
-            this.menuStrip1.Text = "menuStrip1";
+            menuStrip1.Items.AddRange(new System.Windows.Forms.ToolStripItem[] { importexportToolStripMenuItem, editToolStripMenuItem, viewtoolStripMenuItem, selectToolStripMenuItem, toolsToolStripMenuItem, windfieldAnalysisToolStripMenuItem, analyzeResultsToolStripMenuItem, exportToolStripMenuItem, toolStripTextBox3, toolStripTextBox2, toolStripTextBox1, toolStripComboBox1 });
+            menuStrip1.Location = new System.Drawing.Point(0, 0);
+            menuStrip1.Name = "menuStrip1";
+            menuStrip1.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+            menuStrip1.Size = new System.Drawing.Size(1027, 25);
+            menuStrip1.TabIndex = 1;
+            menuStrip1.Text = "menuStrip1";
             // 
             // importexportToolStripMenuItem
             // 
-            this.importexportToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.importexportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.basMapsToolStripMenuItem,
-            this.georeferenceToolStripMenuItem,
-            this.toolStripMenuItem9,
-            this.importToolStripMenuItem,
-            this.toolStripMenuItem16,
-            this.exitGISWindowToolStripMenuItem});
-            this.importexportToolStripMenuItem.Name = "importexportToolStripMenuItem";
-            this.importexportToolStripMenuItem.ShortcutKeyDisplayString = "I";
-            this.importexportToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.I)));
-            this.importexportToolStripMenuItem.Size = new System.Drawing.Size(37, 21);
-            this.importexportToolStripMenuItem.Text = "&File";
+            importexportToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            importexportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { basMapsToolStripMenuItem, georeferenceToolStripMenuItem, toolStripMenuItem9, importToolStripMenuItem, toolStripMenuItem16, exitGISWindowToolStripMenuItem });
+            importexportToolStripMenuItem.Name = "importexportToolStripMenuItem";
+            importexportToolStripMenuItem.ShortcutKeyDisplayString = "I";
+            importexportToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.I;
+            importexportToolStripMenuItem.Size = new System.Drawing.Size(37, 21);
+            importexportToolStripMenuItem.Text = "&File";
             // 
             // basMapsToolStripMenuItem
             // 
-            this.basMapsToolStripMenuItem.Name = "basMapsToolStripMenuItem";
-            this.basMapsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.basMapsToolStripMenuItem.Text = "Load Base map";
-            this.basMapsToolStripMenuItem.Click += new System.EventHandler(this.Button26_Click);
+            basMapsToolStripMenuItem.Name = "basMapsToolStripMenuItem";
+            basMapsToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            basMapsToolStripMenuItem.Text = "Load Base map";
+            basMapsToolStripMenuItem.Click += Button26_Click;
             // 
             // georeferenceToolStripMenuItem
             // 
-            this.georeferenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.onePointAndScaleToolStripMenuItem,
-            this.twoPointsToolStripMenuItem,
-            this.moveAndZoomMapToolStripMenuItem});
-            this.georeferenceToolStripMenuItem.Name = "georeferenceToolStripMenuItem";
-            this.georeferenceToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.georeferenceToolStripMenuItem.Text = "Georeference map";
+            georeferenceToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { onePointAndScaleToolStripMenuItem, twoPointsToolStripMenuItem, moveAndZoomMapToolStripMenuItem });
+            georeferenceToolStripMenuItem.Name = "georeferenceToolStripMenuItem";
+            georeferenceToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            georeferenceToolStripMenuItem.Text = "Georeference map";
             // 
             // onePointAndScaleToolStripMenuItem
             // 
-            this.onePointAndScaleToolStripMenuItem.Name = "onePointAndScaleToolStripMenuItem";
-            this.onePointAndScaleToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.onePointAndScaleToolStripMenuItem.Text = "&Scale and one point";
-            this.onePointAndScaleToolStripMenuItem.Click += new System.EventHandler(this.OnePointAndScaleToolStripMenuItemClick);
+            onePointAndScaleToolStripMenuItem.Name = "onePointAndScaleToolStripMenuItem";
+            onePointAndScaleToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            onePointAndScaleToolStripMenuItem.Text = "&Scale and one point";
+            onePointAndScaleToolStripMenuItem.Click += OnePointAndScaleToolStripMenuItemClick;
             // 
             // twoPointsToolStripMenuItem
             // 
-            this.twoPointsToolStripMenuItem.Name = "twoPointsToolStripMenuItem";
-            this.twoPointsToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.twoPointsToolStripMenuItem.Text = "&Two points";
-            this.twoPointsToolStripMenuItem.Click += new System.EventHandler(this.TwoPointsToolStripMenuItemClick);
+            twoPointsToolStripMenuItem.Name = "twoPointsToolStripMenuItem";
+            twoPointsToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            twoPointsToolStripMenuItem.Text = "&Two points";
+            twoPointsToolStripMenuItem.Click += TwoPointsToolStripMenuItemClick;
             // 
             // moveAndZoomMapToolStripMenuItem
             // 
-            this.moveAndZoomMapToolStripMenuItem.Name = "moveAndZoomMapToolStripMenuItem";
-            this.moveAndZoomMapToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
-            this.moveAndZoomMapToolStripMenuItem.Text = "Move and zoom base map";
-            this.moveAndZoomMapToolStripMenuItem.Click += new System.EventHandler(this.MoveAndZoomMapToolStripMenuItemClick);
+            moveAndZoomMapToolStripMenuItem.Name = "moveAndZoomMapToolStripMenuItem";
+            moveAndZoomMapToolStripMenuItem.Size = new System.Drawing.Size(214, 22);
+            moveAndZoomMapToolStripMenuItem.Text = "Move and zoom base map";
+            moveAndZoomMapToolStripMenuItem.Click += MoveAndZoomMapToolStripMenuItemClick;
             // 
             // toolStripMenuItem9
             // 
-            this.toolStripMenuItem9.Name = "toolStripMenuItem9";
-            this.toolStripMenuItem9.Size = new System.Drawing.Size(185, 6);
+            toolStripMenuItem9.Name = "toolStripMenuItem9";
+            toolStripMenuItem9.Size = new System.Drawing.Size(185, 6);
             // 
             // importToolStripMenuItem
             // 
-            this.importToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.buildingsToolStripMenuItem3,
-            this.receptorPointsToolStripMenuItem4,
-            this.pointSourcesToolStripMenuItem4,
-            this.areaSourcesToolStripMenuItem4,
-            this.lineSourcesToolStripMenuItem4,
-            this.tunnelPortalsToolStripMenuItem3,
-            this.wallsToolStripMenuItem2,
-            this.windRosesToolStripMenuItem,
-            this.originalGRALTopographyToolStripMenuItem});
-            this.importToolStripMenuItem.Name = "importToolStripMenuItem";
-            this.importToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.importToolStripMenuItem.Text = "Import";
+            importToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { buildingsToolStripMenuItem3, receptorPointsToolStripMenuItem4, pointSourcesToolStripMenuItem4, areaSourcesToolStripMenuItem4, lineSourcesToolStripMenuItem4, tunnelPortalsToolStripMenuItem3, wallsToolStripMenuItem2, windRosesToolStripMenuItem, originalGRALTopographyToolStripMenuItem });
+            importToolStripMenuItem.Name = "importToolStripMenuItem";
+            importToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            importToolStripMenuItem.Text = "Import";
             // 
             // buildingsToolStripMenuItem3
             // 
-            this.buildingsToolStripMenuItem3.Name = "buildingsToolStripMenuItem3";
-            this.buildingsToolStripMenuItem3.Size = new System.Drawing.Size(213, 22);
-            this.buildingsToolStripMenuItem3.Text = "Buildings";
-            this.buildingsToolStripMenuItem3.Click += new System.EventHandler(this.Button17_Click);
+            buildingsToolStripMenuItem3.Name = "buildingsToolStripMenuItem3";
+            buildingsToolStripMenuItem3.Size = new System.Drawing.Size(213, 22);
+            buildingsToolStripMenuItem3.Text = "Buildings";
+            buildingsToolStripMenuItem3.Click += Button17_Click;
             // 
             // receptorPointsToolStripMenuItem4
             // 
-            this.receptorPointsToolStripMenuItem4.Name = "receptorPointsToolStripMenuItem4";
-            this.receptorPointsToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
-            this.receptorPointsToolStripMenuItem4.Text = "Receptor points";
-            this.receptorPointsToolStripMenuItem4.Click += new System.EventHandler(this.Button24_Click);
+            receptorPointsToolStripMenuItem4.Name = "receptorPointsToolStripMenuItem4";
+            receptorPointsToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
+            receptorPointsToolStripMenuItem4.Text = "Receptor points";
+            receptorPointsToolStripMenuItem4.Click += Button24_Click;
             // 
             // pointSourcesToolStripMenuItem4
             // 
-            this.pointSourcesToolStripMenuItem4.Name = "pointSourcesToolStripMenuItem4";
-            this.pointSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
-            this.pointSourcesToolStripMenuItem4.Text = "Point sources";
-            this.pointSourcesToolStripMenuItem4.Click += new System.EventHandler(this.Button9_Click);
+            pointSourcesToolStripMenuItem4.Name = "pointSourcesToolStripMenuItem4";
+            pointSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
+            pointSourcesToolStripMenuItem4.Text = "Point sources";
+            pointSourcesToolStripMenuItem4.Click += Button9_Click;
             // 
             // areaSourcesToolStripMenuItem4
             // 
-            this.areaSourcesToolStripMenuItem4.Name = "areaSourcesToolStripMenuItem4";
-            this.areaSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
-            this.areaSourcesToolStripMenuItem4.Text = "Area sources";
-            this.areaSourcesToolStripMenuItem4.Click += new System.EventHandler(this.Button11_Click);
+            areaSourcesToolStripMenuItem4.Name = "areaSourcesToolStripMenuItem4";
+            areaSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
+            areaSourcesToolStripMenuItem4.Text = "Area sources";
+            areaSourcesToolStripMenuItem4.Click += Button11_Click;
             // 
             // lineSourcesToolStripMenuItem4
             // 
-            this.lineSourcesToolStripMenuItem4.Name = "lineSourcesToolStripMenuItem4";
-            this.lineSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
-            this.lineSourcesToolStripMenuItem4.Text = "Line sources";
-            this.lineSourcesToolStripMenuItem4.Click += new System.EventHandler(this.Button13_Click);
+            lineSourcesToolStripMenuItem4.Name = "lineSourcesToolStripMenuItem4";
+            lineSourcesToolStripMenuItem4.Size = new System.Drawing.Size(213, 22);
+            lineSourcesToolStripMenuItem4.Text = "Line sources";
+            lineSourcesToolStripMenuItem4.Click += Button13_Click;
             // 
             // tunnelPortalsToolStripMenuItem3
             // 
-            this.tunnelPortalsToolStripMenuItem3.Name = "tunnelPortalsToolStripMenuItem3";
-            this.tunnelPortalsToolStripMenuItem3.Size = new System.Drawing.Size(213, 22);
-            this.tunnelPortalsToolStripMenuItem3.Text = "Tunnel portals";
-            this.tunnelPortalsToolStripMenuItem3.Click += new System.EventHandler(this.Button15_Click);
+            tunnelPortalsToolStripMenuItem3.Name = "tunnelPortalsToolStripMenuItem3";
+            tunnelPortalsToolStripMenuItem3.Size = new System.Drawing.Size(213, 22);
+            tunnelPortalsToolStripMenuItem3.Text = "Tunnel portals";
+            tunnelPortalsToolStripMenuItem3.Click += Button15_Click;
             // 
             // wallsToolStripMenuItem2
             // 
-            this.wallsToolStripMenuItem2.Name = "wallsToolStripMenuItem2";
-            this.wallsToolStripMenuItem2.Size = new System.Drawing.Size(213, 22);
-            this.wallsToolStripMenuItem2.Text = "Walls";
-            this.wallsToolStripMenuItem2.Click += new System.EventHandler(this.Button54Click);
+            wallsToolStripMenuItem2.Name = "wallsToolStripMenuItem2";
+            wallsToolStripMenuItem2.Size = new System.Drawing.Size(213, 22);
+            wallsToolStripMenuItem2.Text = "Walls";
+            wallsToolStripMenuItem2.Click += Button54Click;
             // 
             // windRosesToolStripMenuItem
             // 
-            this.windRosesToolStripMenuItem.Name = "windRosesToolStripMenuItem";
-            this.windRosesToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.windRosesToolStripMenuItem.Text = "Wind roses";
-            this.windRosesToolStripMenuItem.Click += new System.EventHandler(this.Button53Click);
+            windRosesToolStripMenuItem.Name = "windRosesToolStripMenuItem";
+            windRosesToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            windRosesToolStripMenuItem.Text = "Wind roses";
+            windRosesToolStripMenuItem.Click += Button53Click;
             // 
             // originalGRALTopographyToolStripMenuItem
             // 
-            this.originalGRALTopographyToolStripMenuItem.Name = "originalGRALTopographyToolStripMenuItem";
-            this.originalGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
-            this.originalGRALTopographyToolStripMenuItem.Text = "Original GRAL topography";
-            this.originalGRALTopographyToolStripMenuItem.Click += new System.EventHandler(this.OriginalGRALTopographyToolStripMenuItemClick);
+            originalGRALTopographyToolStripMenuItem.Name = "originalGRALTopographyToolStripMenuItem";
+            originalGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(213, 22);
+            originalGRALTopographyToolStripMenuItem.Text = "Original GRAL topography";
+            originalGRALTopographyToolStripMenuItem.Click += OriginalGRALTopographyToolStripMenuItemClick;
             // 
             // toolStripMenuItem16
             // 
-            this.toolStripMenuItem16.Name = "toolStripMenuItem16";
-            this.toolStripMenuItem16.Size = new System.Drawing.Size(185, 6);
+            toolStripMenuItem16.Name = "toolStripMenuItem16";
+            toolStripMenuItem16.Size = new System.Drawing.Size(185, 6);
             // 
             // exitGISWindowToolStripMenuItem
             // 
-            this.exitGISWindowToolStripMenuItem.Name = "exitGISWindowToolStripMenuItem";
-            this.exitGISWindowToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
-            this.exitGISWindowToolStripMenuItem.Text = "Close the GIS window";
-            this.exitGISWindowToolStripMenuItem.Click += new System.EventHandler(this.ExitGISWindowToolStripMenuItemClick);
+            exitGISWindowToolStripMenuItem.Name = "exitGISWindowToolStripMenuItem";
+            exitGISWindowToolStripMenuItem.Size = new System.Drawing.Size(188, 22);
+            exitGISWindowToolStripMenuItem.Text = "Close the GIS window";
+            exitGISWindowToolStripMenuItem.Click += ExitGISWindowToolStripMenuItemClick;
             // 
             // editToolStripMenuItem
             // 
-            this.editToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.gRAMMModelDomainToolStripMenuItem,
-            this.gRALToolStripMenuItem,
-            this.toolStripMenuItem8,
-            this.pointSourcesToolStripMenuItem,
-            this.areaSourcesToolStripMenuItem,
-            this.lineSourcesToolStripMenuItem,
-            this.tunnelPortalsToolStripMenuItem,
-            this.buildingsToolStripMenuItem,
-            this.receptorPointsToolStripMenuItem,
-            this.wallsToolStripMenuItem,
-            this.VegetationToolStripMenuItem,
-            this.toolStripMenuItem25,
-            this.deleteSelectedItemsToolStripMenuItem,
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem,
-            this.toolStripMenuItem35,
-            this.northToolStripMenuItem,
-            this.mapScaleToolStripMenuItem});
-            this.editToolStripMenuItem.Name = "editToolStripMenuItem";
-            this.editToolStripMenuItem.ShortcutKeyDisplayString = "E";
-            this.editToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.E)));
-            this.editToolStripMenuItem.Size = new System.Drawing.Size(39, 21);
-            this.editToolStripMenuItem.Text = "Edit";
+            editToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            editToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { gRAMMModelDomainToolStripMenuItem, gRALToolStripMenuItem, toolStripMenuItem8, pointSourcesToolStripMenuItem, areaSourcesToolStripMenuItem, lineSourcesToolStripMenuItem, tunnelPortalsToolStripMenuItem, buildingsToolStripMenuItem, receptorPointsToolStripMenuItem, wallsToolStripMenuItem, VegetationToolStripMenuItem, toolStripMenuItem25, deleteSelectedItemsToolStripMenuItem, deleteBuildingsAtTheGRALBorderToolStripMenuItem, toolStripMenuItem35, northToolStripMenuItem, mapScaleToolStripMenuItem });
+            editToolStripMenuItem.Name = "editToolStripMenuItem";
+            editToolStripMenuItem.ShortcutKeyDisplayString = "E";
+            editToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.E;
+            editToolStripMenuItem.Size = new System.Drawing.Size(39, 21);
+            editToolStripMenuItem.Text = "Edit";
             // 
             // gRAMMModelDomainToolStripMenuItem
             // 
-            this.gRAMMModelDomainToolStripMenuItem.Name = "gRAMMModelDomainToolStripMenuItem";
-            this.gRAMMModelDomainToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.gRAMMModelDomainToolStripMenuItem.Text = "GRAMM model domain";
-            this.gRAMMModelDomainToolStripMenuItem.Click += new System.EventHandler(this.Button29_Click);
+            gRAMMModelDomainToolStripMenuItem.Name = "gRAMMModelDomainToolStripMenuItem";
+            gRAMMModelDomainToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            gRAMMModelDomainToolStripMenuItem.Text = "GRAMM model domain";
+            gRAMMModelDomainToolStripMenuItem.Click += Button29_Click;
             // 
             // gRALToolStripMenuItem
             // 
-            this.gRALToolStripMenuItem.Name = "gRALToolStripMenuItem";
-            this.gRALToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.gRALToolStripMenuItem.Text = "GRAL model domain";
-            this.gRALToolStripMenuItem.Click += new System.EventHandler(this.Button6_Click_1);
+            gRALToolStripMenuItem.Name = "gRALToolStripMenuItem";
+            gRALToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            gRALToolStripMenuItem.Text = "GRAL model domain";
+            gRALToolStripMenuItem.Click += Button6_Click_1;
             // 
             // toolStripMenuItem8
             // 
-            this.toolStripMenuItem8.Name = "toolStripMenuItem8";
-            this.toolStripMenuItem8.Size = new System.Drawing.Size(294, 6);
+            toolStripMenuItem8.Name = "toolStripMenuItem8";
+            toolStripMenuItem8.Size = new System.Drawing.Size(294, 6);
             // 
             // pointSourcesToolStripMenuItem
             // 
-            this.pointSourcesToolStripMenuItem.Name = "pointSourcesToolStripMenuItem";
-            this.pointSourcesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D1)));
-            this.pointSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.pointSourcesToolStripMenuItem.Text = "Point sources";
-            this.pointSourcesToolStripMenuItem.Click += new System.EventHandler(this.PointSourcesToolStripMenuItemClick);
+            pointSourcesToolStripMenuItem.Name = "pointSourcesToolStripMenuItem";
+            pointSourcesToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D1;
+            pointSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            pointSourcesToolStripMenuItem.Text = "Point sources";
+            pointSourcesToolStripMenuItem.Click += PointSourcesToolStripMenuItemClick;
             // 
             // areaSourcesToolStripMenuItem
             // 
-            this.areaSourcesToolStripMenuItem.Name = "areaSourcesToolStripMenuItem";
-            this.areaSourcesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D2)));
-            this.areaSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.areaSourcesToolStripMenuItem.Text = "Area sources";
-            this.areaSourcesToolStripMenuItem.Click += new System.EventHandler(this.AreaSourcesToolStripMenuItemClick);
+            areaSourcesToolStripMenuItem.Name = "areaSourcesToolStripMenuItem";
+            areaSourcesToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D2;
+            areaSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            areaSourcesToolStripMenuItem.Text = "Area sources";
+            areaSourcesToolStripMenuItem.Click += AreaSourcesToolStripMenuItemClick;
             // 
             // lineSourcesToolStripMenuItem
             // 
-            this.lineSourcesToolStripMenuItem.Name = "lineSourcesToolStripMenuItem";
-            this.lineSourcesToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D3)));
-            this.lineSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.lineSourcesToolStripMenuItem.Text = "Line sources";
-            this.lineSourcesToolStripMenuItem.Click += new System.EventHandler(this.LineSourcesToolStripMenuItemClick);
+            lineSourcesToolStripMenuItem.Name = "lineSourcesToolStripMenuItem";
+            lineSourcesToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D3;
+            lineSourcesToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            lineSourcesToolStripMenuItem.Text = "Line sources";
+            lineSourcesToolStripMenuItem.Click += LineSourcesToolStripMenuItemClick;
             // 
             // tunnelPortalsToolStripMenuItem
             // 
-            this.tunnelPortalsToolStripMenuItem.Name = "tunnelPortalsToolStripMenuItem";
-            this.tunnelPortalsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D4)));
-            this.tunnelPortalsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.tunnelPortalsToolStripMenuItem.Text = "Tunnel portals";
-            this.tunnelPortalsToolStripMenuItem.Click += new System.EventHandler(this.TunnelPortalsToolStripMenuItemClick);
+            tunnelPortalsToolStripMenuItem.Name = "tunnelPortalsToolStripMenuItem";
+            tunnelPortalsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D4;
+            tunnelPortalsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            tunnelPortalsToolStripMenuItem.Text = "Tunnel portals";
+            tunnelPortalsToolStripMenuItem.Click += TunnelPortalsToolStripMenuItemClick;
             // 
             // buildingsToolStripMenuItem
             // 
-            this.buildingsToolStripMenuItem.Name = "buildingsToolStripMenuItem";
-            this.buildingsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D5)));
-            this.buildingsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.buildingsToolStripMenuItem.Text = "Buildings";
-            this.buildingsToolStripMenuItem.Click += new System.EventHandler(this.BuildingsToolStripMenuItemClick);
+            buildingsToolStripMenuItem.Name = "buildingsToolStripMenuItem";
+            buildingsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D5;
+            buildingsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            buildingsToolStripMenuItem.Text = "Buildings";
+            buildingsToolStripMenuItem.Click += BuildingsToolStripMenuItemClick;
             // 
             // receptorPointsToolStripMenuItem
             // 
-            this.receptorPointsToolStripMenuItem.Name = "receptorPointsToolStripMenuItem";
-            this.receptorPointsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D6)));
-            this.receptorPointsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.receptorPointsToolStripMenuItem.Text = "Receptor points";
-            this.receptorPointsToolStripMenuItem.Click += new System.EventHandler(this.ReceptorPointsToolStripMenuItemClick);
+            receptorPointsToolStripMenuItem.Name = "receptorPointsToolStripMenuItem";
+            receptorPointsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D6;
+            receptorPointsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            receptorPointsToolStripMenuItem.Text = "Receptor points";
+            receptorPointsToolStripMenuItem.Click += ReceptorPointsToolStripMenuItemClick;
             // 
             // wallsToolStripMenuItem
             // 
-            this.wallsToolStripMenuItem.Name = "wallsToolStripMenuItem";
-            this.wallsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D7)));
-            this.wallsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.wallsToolStripMenuItem.Text = "Walls";
-            this.wallsToolStripMenuItem.Click += new System.EventHandler(this.WallsToolStripMenuItemClick);
+            wallsToolStripMenuItem.Name = "wallsToolStripMenuItem";
+            wallsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D7;
+            wallsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            wallsToolStripMenuItem.Text = "Walls";
+            wallsToolStripMenuItem.Click += WallsToolStripMenuItemClick;
             // 
             // VegetationToolStripMenuItem
             // 
-            this.VegetationToolStripMenuItem.Name = "VegetationToolStripMenuItem";
-            this.VegetationToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D8)));
-            this.VegetationToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.VegetationToolStripMenuItem.Text = "Vegetation";
-            this.VegetationToolStripMenuItem.Click += new System.EventHandler(this.VegetationToolStripMenuItemClick);
+            VegetationToolStripMenuItem.Name = "VegetationToolStripMenuItem";
+            VegetationToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.D8;
+            VegetationToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            VegetationToolStripMenuItem.Text = "Vegetation";
+            VegetationToolStripMenuItem.Click += VegetationToolStripMenuItemClick;
             // 
             // toolStripMenuItem25
             // 
-            this.toolStripMenuItem25.Name = "toolStripMenuItem25";
-            this.toolStripMenuItem25.Size = new System.Drawing.Size(294, 6);
+            toolStripMenuItem25.Name = "toolStripMenuItem25";
+            toolStripMenuItem25.Size = new System.Drawing.Size(294, 6);
             // 
             // deleteSelectedItemsToolStripMenuItem
             // 
-            this.deleteSelectedItemsToolStripMenuItem.Name = "deleteSelectedItemsToolStripMenuItem";
-            this.deleteSelectedItemsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.deleteSelectedItemsToolStripMenuItem.Text = "Delete selected items";
-            this.deleteSelectedItemsToolStripMenuItem.Click += new System.EventHandler(this.DeleteSelectedItemsToolStripMenuItemClick);
+            deleteSelectedItemsToolStripMenuItem.Name = "deleteSelectedItemsToolStripMenuItem";
+            deleteSelectedItemsToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            deleteSelectedItemsToolStripMenuItem.Text = "Delete selected items";
+            deleteSelectedItemsToolStripMenuItem.Click += DeleteSelectedItemsToolStripMenuItemClick;
             // 
             // deleteBuildingsAtTheGRALBorderToolStripMenuItem
             // 
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem.Name = "deleteBuildingsAtTheGRALBorderToolStripMenuItem";
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem.Text = "Delete buildings outside the GRAL domain";
-            this.deleteBuildingsAtTheGRALBorderToolStripMenuItem.Click += new System.EventHandler(this.Button44Click);
+            deleteBuildingsAtTheGRALBorderToolStripMenuItem.Name = "deleteBuildingsAtTheGRALBorderToolStripMenuItem";
+            deleteBuildingsAtTheGRALBorderToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            deleteBuildingsAtTheGRALBorderToolStripMenuItem.Text = "Delete buildings outside the GRAL domain";
+            deleteBuildingsAtTheGRALBorderToolStripMenuItem.Click += Button44Click;
             // 
             // toolStripMenuItem35
             // 
-            this.toolStripMenuItem35.Name = "toolStripMenuItem35";
-            this.toolStripMenuItem35.Size = new System.Drawing.Size(294, 6);
+            toolStripMenuItem35.Name = "toolStripMenuItem35";
+            toolStripMenuItem35.Size = new System.Drawing.Size(294, 6);
             // 
             // northToolStripMenuItem
             // 
-            this.northToolStripMenuItem.Name = "northToolStripMenuItem";
-            this.northToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.northToolStripMenuItem.Text = "North arrow";
-            this.northToolStripMenuItem.Click += new System.EventHandler(this.Button18_Click);
+            northToolStripMenuItem.Name = "northToolStripMenuItem";
+            northToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            northToolStripMenuItem.Text = "North arrow";
+            northToolStripMenuItem.Click += Button18_Click;
             // 
             // mapScaleToolStripMenuItem
             // 
-            this.mapScaleToolStripMenuItem.Name = "mapScaleToolStripMenuItem";
-            this.mapScaleToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
-            this.mapScaleToolStripMenuItem.Text = "Scale bar";
-            this.mapScaleToolStripMenuItem.Click += new System.EventHandler(this.Button19_Click);
+            mapScaleToolStripMenuItem.Name = "mapScaleToolStripMenuItem";
+            mapScaleToolStripMenuItem.Size = new System.Drawing.Size(297, 22);
+            mapScaleToolStripMenuItem.Text = "Scale bar";
+            mapScaleToolStripMenuItem.Click += Button19_Click;
             // 
             // selectToolStripMenuItem
             // 
-            this.selectToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.selectToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.pointSourcesToolStripMenuItem1,
-            this.areaSourcesToolStripMenuItem1,
-            this.lineSourcesToolStripMenuItem1,
-            this.tunnelPortalsToolStripMenuItem1,
-            this.buildingsToolStripMenuItem1,
-            this.receptorPointsToolStripMenuItem1,
-            this.wallsToolStripMenuItem1,
-            this.VegetationtToolStripMenuItem1,
-            this.toolStripMenuItem17,
-            this.searchItemToolStripMenuItem});
-            this.selectToolStripMenuItem.Name = "selectToolStripMenuItem";
-            this.selectToolStripMenuItem.ShortcutKeyDisplayString = "S";
-            this.selectToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S)));
-            this.selectToolStripMenuItem.Size = new System.Drawing.Size(50, 21);
-            this.selectToolStripMenuItem.Text = "&Select";
+            selectToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            selectToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { pointSourcesToolStripMenuItem1, areaSourcesToolStripMenuItem1, lineSourcesToolStripMenuItem1, tunnelPortalsToolStripMenuItem1, buildingsToolStripMenuItem1, receptorPointsToolStripMenuItem1, wallsToolStripMenuItem1, VegetationtToolStripMenuItem1, toolStripMenuItem17, searchItemToolStripMenuItem });
+            selectToolStripMenuItem.Name = "selectToolStripMenuItem";
+            selectToolStripMenuItem.ShortcutKeyDisplayString = "S";
+            selectToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.S;
+            selectToolStripMenuItem.Size = new System.Drawing.Size(50, 21);
+            selectToolStripMenuItem.Text = "&Select";
             // 
             // pointSourcesToolStripMenuItem1
             // 
-            this.pointSourcesToolStripMenuItem1.Name = "pointSourcesToolStripMenuItem1";
-            this.pointSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F1)));
-            this.pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.pointSourcesToolStripMenuItem1.Text = "Point sources";
-            this.pointSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button8_Click);
+            pointSourcesToolStripMenuItem1.Name = "pointSourcesToolStripMenuItem1";
+            pointSourcesToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F1;
+            pointSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            pointSourcesToolStripMenuItem1.Text = "Point sources";
+            pointSourcesToolStripMenuItem1.Click += Button8_Click;
             // 
             // areaSourcesToolStripMenuItem1
             // 
-            this.areaSourcesToolStripMenuItem1.Name = "areaSourcesToolStripMenuItem1";
-            this.areaSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F2)));
-            this.areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.areaSourcesToolStripMenuItem1.Text = "Area sources";
-            this.areaSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button10_Click);
+            areaSourcesToolStripMenuItem1.Name = "areaSourcesToolStripMenuItem1";
+            areaSourcesToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F2;
+            areaSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            areaSourcesToolStripMenuItem1.Text = "Area sources";
+            areaSourcesToolStripMenuItem1.Click += Button10_Click;
             // 
             // lineSourcesToolStripMenuItem1
             // 
-            this.lineSourcesToolStripMenuItem1.Name = "lineSourcesToolStripMenuItem1";
-            this.lineSourcesToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F3)));
-            this.lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.lineSourcesToolStripMenuItem1.Text = "Line sources";
-            this.lineSourcesToolStripMenuItem1.Click += new System.EventHandler(this.Button12_Click);
+            lineSourcesToolStripMenuItem1.Name = "lineSourcesToolStripMenuItem1";
+            lineSourcesToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F3;
+            lineSourcesToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            lineSourcesToolStripMenuItem1.Text = "Line sources";
+            lineSourcesToolStripMenuItem1.Click += Button12_Click;
             // 
             // tunnelPortalsToolStripMenuItem1
             // 
-            this.tunnelPortalsToolStripMenuItem1.Name = "tunnelPortalsToolStripMenuItem1";
-            this.tunnelPortalsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F4)));
-            this.tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.tunnelPortalsToolStripMenuItem1.Text = "Tunnel portals";
-            this.tunnelPortalsToolStripMenuItem1.Click += new System.EventHandler(this.Button14_Click);
+            tunnelPortalsToolStripMenuItem1.Name = "tunnelPortalsToolStripMenuItem1";
+            tunnelPortalsToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F4;
+            tunnelPortalsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            tunnelPortalsToolStripMenuItem1.Text = "Tunnel portals";
+            tunnelPortalsToolStripMenuItem1.Click += Button14_Click;
             // 
             // buildingsToolStripMenuItem1
             // 
-            this.buildingsToolStripMenuItem1.Name = "buildingsToolStripMenuItem1";
-            this.buildingsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F5)));
-            this.buildingsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.buildingsToolStripMenuItem1.Text = "Buildings";
-            this.buildingsToolStripMenuItem1.Click += new System.EventHandler(this.Button16_Click);
+            buildingsToolStripMenuItem1.Name = "buildingsToolStripMenuItem1";
+            buildingsToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F5;
+            buildingsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            buildingsToolStripMenuItem1.Text = "Buildings";
+            buildingsToolStripMenuItem1.Click += Button16_Click;
             // 
             // receptorPointsToolStripMenuItem1
             // 
-            this.receptorPointsToolStripMenuItem1.Name = "receptorPointsToolStripMenuItem1";
-            this.receptorPointsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F6)));
-            this.receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.receptorPointsToolStripMenuItem1.Text = "Receptor points";
-            this.receptorPointsToolStripMenuItem1.Click += new System.EventHandler(this.Button23_Click);
+            receptorPointsToolStripMenuItem1.Name = "receptorPointsToolStripMenuItem1";
+            receptorPointsToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F6;
+            receptorPointsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            receptorPointsToolStripMenuItem1.Text = "Receptor points";
+            receptorPointsToolStripMenuItem1.Click += Button23_Click;
             // 
             // wallsToolStripMenuItem1
             // 
-            this.wallsToolStripMenuItem1.Name = "wallsToolStripMenuItem1";
-            this.wallsToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7)));
-            this.wallsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.wallsToolStripMenuItem1.Text = "Walls";
-            this.wallsToolStripMenuItem1.Click += new System.EventHandler(this.Button49Click);
+            wallsToolStripMenuItem1.Name = "wallsToolStripMenuItem1";
+            wallsToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F7;
+            wallsToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            wallsToolStripMenuItem1.Text = "Walls";
+            wallsToolStripMenuItem1.Click += Button49Click;
             // 
             // VegetationtToolStripMenuItem1
             // 
-            this.VegetationtToolStripMenuItem1.Name = "VegetationtToolStripMenuItem1";
-            this.VegetationtToolStripMenuItem1.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F10)));
-            this.VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
-            this.VegetationtToolStripMenuItem1.Text = "Vegetation";
-            this.VegetationtToolStripMenuItem1.Click += new System.EventHandler(this.Button50Click);
+            VegetationtToolStripMenuItem1.Name = "VegetationtToolStripMenuItem1";
+            VegetationtToolStripMenuItem1.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F10;
+            VegetationtToolStripMenuItem1.Size = new System.Drawing.Size(205, 22);
+            VegetationtToolStripMenuItem1.Text = "Vegetation";
+            VegetationtToolStripMenuItem1.Click += Button50Click;
             // 
             // toolStripMenuItem17
             // 
-            this.toolStripMenuItem17.Name = "toolStripMenuItem17";
-            this.toolStripMenuItem17.Size = new System.Drawing.Size(202, 6);
+            toolStripMenuItem17.Name = "toolStripMenuItem17";
+            toolStripMenuItem17.Size = new System.Drawing.Size(202, 6);
             // 
             // searchItemToolStripMenuItem
             // 
-            this.searchItemToolStripMenuItem.Name = "searchItemToolStripMenuItem";
-            this.searchItemToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S)));
-            this.searchItemToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
-            this.searchItemToolStripMenuItem.Text = "Search items";
-            this.searchItemToolStripMenuItem.Click += new System.EventHandler(this.SearchItemToolStripMenuItemClick);
+            searchItemToolStripMenuItem.Name = "searchItemToolStripMenuItem";
+            searchItemToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.S;
+            searchItemToolStripMenuItem.Size = new System.Drawing.Size(205, 22);
+            searchItemToolStripMenuItem.Text = "Search items";
+            searchItemToolStripMenuItem.Click += SearchItemToolStripMenuItemClick;
             // 
             // toolsToolStripMenuItem
             // 
-            this.toolsToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.measureLenghtToolStripMenuItem,
-            this.measureAreaToolStripMenuItem,
-            this.toolStripMenuItem4,
-            this.modifyTopographyToolStripMenuItem,
-            this.lowPassGRALTopographyToolStripMenuItem,
-            this.saveTopographyToolStripMenuItem,
-            this.restoreGRALTopographyToolStripMenuItem,
-            this.toolStripMenuItem1,
-            this.arrowCursorToolStripMenuItem,
-            this.crossCursorToolStripMenuItem});
-            this.toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
-            this.toolsToolStripMenuItem.ShortcutKeyDisplayString = "T";
-            this.toolsToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.T)));
-            this.toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 21);
-            this.toolsToolStripMenuItem.Text = "&Tools";
+            toolsToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            toolsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { measureLenghtToolStripMenuItem, measureAreaToolStripMenuItem, toolStripMenuItem4, modifyTopographyToolStripMenuItem, lowPassGRALTopographyToolStripMenuItem, saveTopographyToolStripMenuItem, restoreGRALTopographyToolStripMenuItem, toolStripMenuItem1, arrowCursorToolStripMenuItem, crossCursorToolStripMenuItem });
+            toolsToolStripMenuItem.Name = "toolsToolStripMenuItem";
+            toolsToolStripMenuItem.ShortcutKeyDisplayString = "T";
+            toolsToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.T;
+            toolsToolStripMenuItem.Size = new System.Drawing.Size(46, 21);
+            toolsToolStripMenuItem.Text = "&Tools";
             // 
             // measureLenghtToolStripMenuItem
             // 
-            this.measureLenghtToolStripMenuItem.Name = "measureLenghtToolStripMenuItem";
-            this.measureLenghtToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.measureLenghtToolStripMenuItem.Text = "Length measurement";
-            this.measureLenghtToolStripMenuItem.Click += new System.EventHandler(this.Button20_Click);
+            measureLenghtToolStripMenuItem.Name = "measureLenghtToolStripMenuItem";
+            measureLenghtToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            measureLenghtToolStripMenuItem.Text = "Length measurement";
+            measureLenghtToolStripMenuItem.Click += Button20_Click;
             // 
             // measureAreaToolStripMenuItem
             // 
-            this.measureAreaToolStripMenuItem.Name = "measureAreaToolStripMenuItem";
-            this.measureAreaToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.measureAreaToolStripMenuItem.Text = "Area measurement";
-            this.measureAreaToolStripMenuItem.Click += new System.EventHandler(this.Button21_Click);
+            measureAreaToolStripMenuItem.Name = "measureAreaToolStripMenuItem";
+            measureAreaToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            measureAreaToolStripMenuItem.Text = "Area measurement";
+            measureAreaToolStripMenuItem.Click += Button21_Click;
             // 
             // toolStripMenuItem4
             // 
-            this.toolStripMenuItem4.Name = "toolStripMenuItem4";
-            this.toolStripMenuItem4.Size = new System.Drawing.Size(243, 6);
+            toolStripMenuItem4.Name = "toolStripMenuItem4";
+            toolStripMenuItem4.Size = new System.Drawing.Size(243, 6);
             // 
             // modifyTopographyToolStripMenuItem
             // 
-            this.modifyTopographyToolStripMenuItem.Enabled = false;
-            this.modifyTopographyToolStripMenuItem.Name = "modifyTopographyToolStripMenuItem";
-            this.modifyTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.modifyTopographyToolStripMenuItem.Text = "Modify GRAL topography";
-            this.modifyTopographyToolStripMenuItem.Click += new System.EventHandler(this.ModifyTopographyToolStripMenuItemClick);
+            modifyTopographyToolStripMenuItem.Enabled = false;
+            modifyTopographyToolStripMenuItem.Name = "modifyTopographyToolStripMenuItem";
+            modifyTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            modifyTopographyToolStripMenuItem.Text = "Modify GRAL topography";
+            modifyTopographyToolStripMenuItem.Click += ModifyTopographyToolStripMenuItemClick;
             // 
             // lowPassGRALTopographyToolStripMenuItem
             // 
-            this.lowPassGRALTopographyToolStripMenuItem.Enabled = false;
-            this.lowPassGRALTopographyToolStripMenuItem.Name = "lowPassGRALTopographyToolStripMenuItem";
-            this.lowPassGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.lowPassGRALTopographyToolStripMenuItem.Text = "Low pass filter GRAL topography";
-            this.lowPassGRALTopographyToolStripMenuItem.Click += new System.EventHandler(this.LowPassGRALTopographyToolStripMenuItemClick);
+            lowPassGRALTopographyToolStripMenuItem.Enabled = false;
+            lowPassGRALTopographyToolStripMenuItem.Name = "lowPassGRALTopographyToolStripMenuItem";
+            lowPassGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            lowPassGRALTopographyToolStripMenuItem.Text = "Low pass filter GRAL topography";
+            lowPassGRALTopographyToolStripMenuItem.Click += LowPassGRALTopographyToolStripMenuItemClick;
             // 
             // saveTopographyToolStripMenuItem
             // 
-            this.saveTopographyToolStripMenuItem.Enabled = false;
-            this.saveTopographyToolStripMenuItem.Name = "saveTopographyToolStripMenuItem";
-            this.saveTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.saveTopographyToolStripMenuItem.Text = "Save GRAL topography";
-            this.saveTopographyToolStripMenuItem.Click += new System.EventHandler(this.SaveTopographyToolStripMenuItemClick);
+            saveTopographyToolStripMenuItem.Enabled = false;
+            saveTopographyToolStripMenuItem.Name = "saveTopographyToolStripMenuItem";
+            saveTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            saveTopographyToolStripMenuItem.Text = "Save GRAL topography";
+            saveTopographyToolStripMenuItem.Click += SaveTopographyToolStripMenuItemClick;
             // 
             // restoreGRALTopographyToolStripMenuItem
             // 
-            this.restoreGRALTopographyToolStripMenuItem.Enabled = false;
-            this.restoreGRALTopographyToolStripMenuItem.Name = "restoreGRALTopographyToolStripMenuItem";
-            this.restoreGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.restoreGRALTopographyToolStripMenuItem.Text = "Restore GRAL topography";
-            this.restoreGRALTopographyToolStripMenuItem.Click += new System.EventHandler(this.RestoreGRALTopographyToolStripMenuItemClick);
+            restoreGRALTopographyToolStripMenuItem.Enabled = false;
+            restoreGRALTopographyToolStripMenuItem.Name = "restoreGRALTopographyToolStripMenuItem";
+            restoreGRALTopographyToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            restoreGRALTopographyToolStripMenuItem.Text = "Restore GRAL topography";
+            restoreGRALTopographyToolStripMenuItem.Click += RestoreGRALTopographyToolStripMenuItemClick;
             // 
             // toolStripMenuItem1
             // 
-            this.toolStripMenuItem1.Name = "toolStripMenuItem1";
-            this.toolStripMenuItem1.Size = new System.Drawing.Size(243, 6);
+            toolStripMenuItem1.Name = "toolStripMenuItem1";
+            toolStripMenuItem1.Size = new System.Drawing.Size(243, 6);
             // 
             // arrowCursorToolStripMenuItem
             // 
-            this.arrowCursorToolStripMenuItem.Name = "arrowCursorToolStripMenuItem";
-            this.arrowCursorToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.arrowCursorToolStripMenuItem.Text = "Arrow cursor";
-            this.arrowCursorToolStripMenuItem.Click += new System.EventHandler(this.Button5_Click);
+            arrowCursorToolStripMenuItem.Name = "arrowCursorToolStripMenuItem";
+            arrowCursorToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            arrowCursorToolStripMenuItem.Text = "Arrow cursor";
+            arrowCursorToolStripMenuItem.Click += Button5_Click;
             // 
             // crossCursorToolStripMenuItem
             // 
-            this.crossCursorToolStripMenuItem.Name = "crossCursorToolStripMenuItem";
-            this.crossCursorToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
-            this.crossCursorToolStripMenuItem.Text = "Cross cursor";
-            this.crossCursorToolStripMenuItem.Click += new System.EventHandler(this.CrossCursorToolStripMenuItemClick);
+            crossCursorToolStripMenuItem.Name = "crossCursorToolStripMenuItem";
+            crossCursorToolStripMenuItem.Size = new System.Drawing.Size(246, 22);
+            crossCursorToolStripMenuItem.Text = "Cross cursor";
+            crossCursorToolStripMenuItem.Click += CrossCursorToolStripMenuItemClick;
             // 
             // windfieldAnalysisToolStripMenuItem
             // 
-            this.windfieldAnalysisToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.windStatisticAtAPointToolStripMenuItem,
-            this.verticalProfileAtAPointToolStripMenuItem,
-            this.toolStripMenuItem10,
-            this.meanWindSpeedAtAHeightToolStripMenuItem,
-            this.windFieldAtAHeightToolStripMenuItem,
-            this.analyzeStabilityClassesToolStripMenuItem,
-            this.toolStripMenuItem13,
-            this.sectionWindfieldDrawingToolStripMenuItem,
-            this.toolStripMenuItem11,
-            this.reorderWindFieldsToolStripMenuItem,
-            this.matchToObservationToolStripMenuItem});
-            this.windfieldAnalysisToolStripMenuItem.Enabled = false;
-            this.windfieldAnalysisToolStripMenuItem.Name = "windfieldAnalysisToolStripMenuItem";
-            this.windfieldAnalysisToolStripMenuItem.ShortcutKeyDisplayString = "W";
-            this.windfieldAnalysisToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.W)));
-            this.windfieldAnalysisToolStripMenuItem.Size = new System.Drawing.Size(114, 21);
-            this.windfieldAnalysisToolStripMenuItem.Text = "&Windfield analysis";
+            windfieldAnalysisToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { windStatisticAtAPointToolStripMenuItem, verticalProfileAtAPointToolStripMenuItem, toolStripMenuItem10, meanWindSpeedAtAHeightToolStripMenuItem, windFieldAtAHeightToolStripMenuItem, analyzeStabilityClassesToolStripMenuItem, toolStripMenuItem13, sectionWindfieldDrawingToolStripMenuItem, toolStripMenuItem11, reorderWindFieldsToolStripMenuItem, matchToObservationToolStripMenuItem });
+            windfieldAnalysisToolStripMenuItem.Enabled = false;
+            windfieldAnalysisToolStripMenuItem.Name = "windfieldAnalysisToolStripMenuItem";
+            windfieldAnalysisToolStripMenuItem.ShortcutKeyDisplayString = "W";
+            windfieldAnalysisToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.W;
+            windfieldAnalysisToolStripMenuItem.Size = new System.Drawing.Size(114, 21);
+            windfieldAnalysisToolStripMenuItem.Text = "&Windfield analysis";
             // 
             // windStatisticAtAPointToolStripMenuItem
             // 
-            this.windStatisticAtAPointToolStripMenuItem.Name = "windStatisticAtAPointToolStripMenuItem";
-            this.windStatisticAtAPointToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.windStatisticAtAPointToolStripMenuItem.Text = "Wind statistic at a point";
-            this.windStatisticAtAPointToolStripMenuItem.Click += new System.EventHandler(this.Button30_Click);
+            windStatisticAtAPointToolStripMenuItem.Name = "windStatisticAtAPointToolStripMenuItem";
+            windStatisticAtAPointToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            windStatisticAtAPointToolStripMenuItem.Text = "Wind statistic at a point";
+            windStatisticAtAPointToolStripMenuItem.Click += Button30_Click;
             // 
             // verticalProfileAtAPointToolStripMenuItem
             // 
-            this.verticalProfileAtAPointToolStripMenuItem.Name = "verticalProfileAtAPointToolStripMenuItem";
-            this.verticalProfileAtAPointToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.verticalProfileAtAPointToolStripMenuItem.Text = "Vertical profile at a point";
-            this.verticalProfileAtAPointToolStripMenuItem.Click += new System.EventHandler(this.Button41_Click);
+            verticalProfileAtAPointToolStripMenuItem.Name = "verticalProfileAtAPointToolStripMenuItem";
+            verticalProfileAtAPointToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            verticalProfileAtAPointToolStripMenuItem.Text = "Vertical profile at a point";
+            verticalProfileAtAPointToolStripMenuItem.Click += Button41_Click;
             // 
             // toolStripMenuItem10
             // 
-            this.toolStripMenuItem10.Name = "toolStripMenuItem10";
-            this.toolStripMenuItem10.Size = new System.Drawing.Size(223, 6);
+            toolStripMenuItem10.Name = "toolStripMenuItem10";
+            toolStripMenuItem10.Size = new System.Drawing.Size(223, 6);
             // 
             // meanWindSpeedAtAHeightToolStripMenuItem
             // 
-            this.meanWindSpeedAtAHeightToolStripMenuItem.Name = "meanWindSpeedAtAHeightToolStripMenuItem";
-            this.meanWindSpeedAtAHeightToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.meanWindSpeedAtAHeightToolStripMenuItem.Text = "Mean wind speed at a height";
-            this.meanWindSpeedAtAHeightToolStripMenuItem.Click += new System.EventHandler(this.Button31_Click);
+            meanWindSpeedAtAHeightToolStripMenuItem.Name = "meanWindSpeedAtAHeightToolStripMenuItem";
+            meanWindSpeedAtAHeightToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            meanWindSpeedAtAHeightToolStripMenuItem.Text = "Mean wind speed at a height";
+            meanWindSpeedAtAHeightToolStripMenuItem.Click += Button31_Click;
             // 
             // windFieldAtAHeightToolStripMenuItem
             // 
-            this.windFieldAtAHeightToolStripMenuItem.Name = "windFieldAtAHeightToolStripMenuItem";
-            this.windFieldAtAHeightToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.windFieldAtAHeightToolStripMenuItem.Text = "Wind field at a height";
-            this.windFieldAtAHeightToolStripMenuItem.Click += new System.EventHandler(this.Button32_Click);
+            windFieldAtAHeightToolStripMenuItem.Name = "windFieldAtAHeightToolStripMenuItem";
+            windFieldAtAHeightToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            windFieldAtAHeightToolStripMenuItem.Text = "Wind field at a height";
+            windFieldAtAHeightToolStripMenuItem.Click += Button32_Click;
             // 
             // analyzeStabilityClassesToolStripMenuItem
             // 
-            this.analyzeStabilityClassesToolStripMenuItem.Name = "analyzeStabilityClassesToolStripMenuItem";
-            this.analyzeStabilityClassesToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.analyzeStabilityClassesToolStripMenuItem.Text = "Analyze stability classes";
-            this.analyzeStabilityClassesToolStripMenuItem.ToolTipText = " 10m above ground";
-            this.analyzeStabilityClassesToolStripMenuItem.Click += new System.EventHandler(this.ButtonstabilityclassClick);
+            analyzeStabilityClassesToolStripMenuItem.Name = "analyzeStabilityClassesToolStripMenuItem";
+            analyzeStabilityClassesToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            analyzeStabilityClassesToolStripMenuItem.Text = "Analyze stability classes";
+            analyzeStabilityClassesToolStripMenuItem.ToolTipText = " 10m above ground";
+            analyzeStabilityClassesToolStripMenuItem.Click += ButtonstabilityclassClick;
             // 
             // toolStripMenuItem13
             // 
-            this.toolStripMenuItem13.Name = "toolStripMenuItem13";
-            this.toolStripMenuItem13.Size = new System.Drawing.Size(223, 6);
+            toolStripMenuItem13.Name = "toolStripMenuItem13";
+            toolStripMenuItem13.Size = new System.Drawing.Size(223, 6);
             // 
             // sectionWindfieldDrawingToolStripMenuItem
             // 
-            this.sectionWindfieldDrawingToolStripMenuItem.Name = "sectionWindfieldDrawingToolStripMenuItem";
-            this.sectionWindfieldDrawingToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.sectionWindfieldDrawingToolStripMenuItem.Text = "Section windfield drawing";
-            this.sectionWindfieldDrawingToolStripMenuItem.Click += new System.EventHandler(this.Button_section_windMouseClick);
+            sectionWindfieldDrawingToolStripMenuItem.Name = "sectionWindfieldDrawingToolStripMenuItem";
+            sectionWindfieldDrawingToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            sectionWindfieldDrawingToolStripMenuItem.Text = "Section windfield drawing";
+            sectionWindfieldDrawingToolStripMenuItem.Click += Button_section_windMouseClick;
             // 
             // toolStripMenuItem11
             // 
-            this.toolStripMenuItem11.Name = "toolStripMenuItem11";
-            this.toolStripMenuItem11.Size = new System.Drawing.Size(223, 6);
+            toolStripMenuItem11.Name = "toolStripMenuItem11";
+            toolStripMenuItem11.Size = new System.Drawing.Size(223, 6);
             // 
             // reorderWindFieldsToolStripMenuItem
             // 
-            this.reorderWindFieldsToolStripMenuItem.Name = "reorderWindFieldsToolStripMenuItem";
-            this.reorderWindFieldsToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.reorderWindFieldsToolStripMenuItem.Text = "Re-order wind fields";
-            this.reorderWindFieldsToolStripMenuItem.Click += new System.EventHandler(this.Button42_Click);
+            reorderWindFieldsToolStripMenuItem.Name = "reorderWindFieldsToolStripMenuItem";
+            reorderWindFieldsToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            reorderWindFieldsToolStripMenuItem.Text = "Re-order wind fields";
+            reorderWindFieldsToolStripMenuItem.Click += Button42_Click;
             // 
             // matchToObservationToolStripMenuItem
             // 
-            this.matchToObservationToolStripMenuItem.Name = "matchToObservationToolStripMenuItem";
-            this.matchToObservationToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
-            this.matchToObservationToolStripMenuItem.Text = "Match to observation";
-            this.matchToObservationToolStripMenuItem.Click += new System.EventHandler(this.Button43_Click);
+            matchToObservationToolStripMenuItem.Name = "matchToObservationToolStripMenuItem";
+            matchToObservationToolStripMenuItem.Size = new System.Drawing.Size(226, 22);
+            matchToObservationToolStripMenuItem.Text = "Match to observation";
+            matchToObservationToolStripMenuItem.Click += Button43_Click;
             // 
             // analyzeResultsToolStripMenuItem
             // 
-            this.analyzeResultsToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.analyzeResultsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.loadContourMapToolStripMenuItem,
-            this.mathToolStripMenuItem,
-            this.extractConcentrationAtOnePointToolStripMenuItem,
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem,
-            this.convertgrzFileToASCIIFileToolStripMenuItem,
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem,
-            this.toolStripMenuItem14,
-            this.verticalConcentrationProfileToolStripMenuItem,
-            this.verticalConcentrationProfileSectionToolStripMenuItem,
-            this.toolStripMenuItem2,
-            this.sourceToolStripMenuItem});
-            this.analyzeResultsToolStripMenuItem.Name = "analyzeResultsToolStripMenuItem";
-            this.analyzeResultsToolStripMenuItem.ShortcutKeyDisplayString = "A";
-            this.analyzeResultsToolStripMenuItem.Size = new System.Drawing.Size(97, 21);
-            this.analyzeResultsToolStripMenuItem.Text = "&Analyze results";
+            analyzeResultsToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            analyzeResultsToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { loadContourMapToolStripMenuItem, mathToolStripMenuItem, extractConcentrationAtOnePointToolStripMenuItem, generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem, convertgrzFileToASCIIFileToolStripMenuItem, createAnAnimatedGIFFromgrzFilesToolStripMenuItem, toolStripMenuItem14, verticalConcentrationProfileToolStripMenuItem, verticalConcentrationProfileSectionToolStripMenuItem, toolStripMenuItem2, sourceToolStripMenuItem });
+            analyzeResultsToolStripMenuItem.Name = "analyzeResultsToolStripMenuItem";
+            analyzeResultsToolStripMenuItem.ShortcutKeyDisplayString = "A";
+            analyzeResultsToolStripMenuItem.Size = new System.Drawing.Size(97, 21);
+            analyzeResultsToolStripMenuItem.Text = "&Analyze results";
             // 
             // loadContourMapToolStripMenuItem
             // 
-            this.loadContourMapToolStripMenuItem.Name = "loadContourMapToolStripMenuItem";
-            this.loadContourMapToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.L)));
-            this.loadContourMapToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.loadContourMapToolStripMenuItem.Text = "Load contour map";
-            this.loadContourMapToolStripMenuItem.Click += new System.EventHandler(this.Button27_Click);
+            loadContourMapToolStripMenuItem.Name = "loadContourMapToolStripMenuItem";
+            loadContourMapToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.L;
+            loadContourMapToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            loadContourMapToolStripMenuItem.Text = "Load contour map";
+            loadContourMapToolStripMenuItem.Click += Button27_Click;
             // 
             // mathToolStripMenuItem
             // 
-            this.mathToolStripMenuItem.Name = "mathToolStripMenuItem";
-            this.mathToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.mathToolStripMenuItem.Text = "Contour map math operations";
-            this.mathToolStripMenuItem.Click += new System.EventHandler(this.Button28_Click);
+            mathToolStripMenuItem.Name = "mathToolStripMenuItem";
+            mathToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            mathToolStripMenuItem.Text = "Contour map math operations";
+            mathToolStripMenuItem.Click += Button28_Click;
             // 
             // extractConcentrationAtOnePointToolStripMenuItem
             // 
-            this.extractConcentrationAtOnePointToolStripMenuItem.Name = "extractConcentrationAtOnePointToolStripMenuItem";
-            this.extractConcentrationAtOnePointToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.extractConcentrationAtOnePointToolStripMenuItem.Text = "Extract concentration at a point";
-            this.extractConcentrationAtOnePointToolStripMenuItem.Click += new System.EventHandler(this.Button35_Click);
+            extractConcentrationAtOnePointToolStripMenuItem.Name = "extractConcentrationAtOnePointToolStripMenuItem";
+            extractConcentrationAtOnePointToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            extractConcentrationAtOnePointToolStripMenuItem.Text = "Extract concentration at a point";
+            extractConcentrationAtOnePointToolStripMenuItem.Click += Button35_Click;
             // 
             // generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem
             // 
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Name = "generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem";
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Text = "Generate time series for several evaluation points";
-            this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Click += new System.EventHandler(this.generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem_Click);
+            generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Name = "generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem";
+            generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Text = "Generate time series for several evaluation points";
+            generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem.Click += generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem_Click;
             // 
             // convertgrzFileToASCIIFileToolStripMenuItem
             // 
-            this.convertgrzFileToASCIIFileToolStripMenuItem.Name = "convertgrzFileToASCIIFileToolStripMenuItem";
-            this.convertgrzFileToASCIIFileToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.convertgrzFileToASCIIFileToolStripMenuItem.Text = "Convert *.grz file to ASCII file";
-            this.convertgrzFileToASCIIFileToolStripMenuItem.Click += new System.EventHandler(this.Button40_Click);
+            convertgrzFileToASCIIFileToolStripMenuItem.Name = "convertgrzFileToASCIIFileToolStripMenuItem";
+            convertgrzFileToASCIIFileToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            convertgrzFileToASCIIFileToolStripMenuItem.Text = "Convert *.grz file to ASCII file";
+            convertgrzFileToASCIIFileToolStripMenuItem.Click += Button40_Click;
             // 
             // createAnAnimatedGIFFromgrzFilesToolStripMenuItem
             // 
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Name = "createAnAnimatedGIFFromgrzFilesToolStripMenuItem";
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Text = "Create an animated GIF from *.grz files";
-            this.createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Click += new System.EventHandler(this.CreateAnmiatedGIF);
+            createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Name = "createAnAnimatedGIFFromgrzFilesToolStripMenuItem";
+            createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Text = "Create an animated GIF from *.grz files";
+            createAnAnimatedGIFFromgrzFilesToolStripMenuItem.Click += CreateAnmiatedGIF;
             // 
             // toolStripMenuItem14
             // 
-            this.toolStripMenuItem14.Name = "toolStripMenuItem14";
-            this.toolStripMenuItem14.Size = new System.Drawing.Size(328, 6);
+            toolStripMenuItem14.Name = "toolStripMenuItem14";
+            toolStripMenuItem14.Size = new System.Drawing.Size(328, 6);
             // 
             // verticalConcentrationProfileToolStripMenuItem
             // 
-            this.verticalConcentrationProfileToolStripMenuItem.Name = "verticalConcentrationProfileToolStripMenuItem";
-            this.verticalConcentrationProfileToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.verticalConcentrationProfileToolStripMenuItem.Text = "Vertical concentration profile at a point";
-            this.verticalConcentrationProfileToolStripMenuItem.Click += new System.EventHandler(this.Button52_Click);
+            verticalConcentrationProfileToolStripMenuItem.Name = "verticalConcentrationProfileToolStripMenuItem";
+            verticalConcentrationProfileToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            verticalConcentrationProfileToolStripMenuItem.Text = "Vertical concentration profile at a point";
+            verticalConcentrationProfileToolStripMenuItem.Click += Button52_Click;
             // 
             // verticalConcentrationProfileSectionToolStripMenuItem
             // 
-            this.verticalConcentrationProfileSectionToolStripMenuItem.Name = "verticalConcentrationProfileSectionToolStripMenuItem";
-            this.verticalConcentrationProfileSectionToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.verticalConcentrationProfileSectionToolStripMenuItem.Text = "Vertical concentration profile along a section";
-            this.verticalConcentrationProfileSectionToolStripMenuItem.Click += new System.EventHandler(this.Button_section_concentrationClick);
+            verticalConcentrationProfileSectionToolStripMenuItem.Name = "verticalConcentrationProfileSectionToolStripMenuItem";
+            verticalConcentrationProfileSectionToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            verticalConcentrationProfileSectionToolStripMenuItem.Text = "Vertical concentration profile along a section";
+            verticalConcentrationProfileSectionToolStripMenuItem.Click += Button_section_concentrationClick;
             // 
             // toolStripMenuItem2
             // 
-            this.toolStripMenuItem2.Name = "toolStripMenuItem2";
-            this.toolStripMenuItem2.Size = new System.Drawing.Size(328, 6);
+            toolStripMenuItem2.Name = "toolStripMenuItem2";
+            toolStripMenuItem2.Size = new System.Drawing.Size(328, 6);
             // 
             // sourceToolStripMenuItem
             // 
-            this.sourceToolStripMenuItem.Name = "sourceToolStripMenuItem";
-            this.sourceToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
-            this.sourceToolStripMenuItem.Text = "Source apportionment";
-            this.sourceToolStripMenuItem.Click += new System.EventHandler(this.Button33_Click);
+            sourceToolStripMenuItem.Name = "sourceToolStripMenuItem";
+            sourceToolStripMenuItem.Size = new System.Drawing.Size(331, 22);
+            sourceToolStripMenuItem.Text = "Source apportionment";
+            sourceToolStripMenuItem.Click += Button33_Click;
             // 
             // exportToolStripMenuItem
             // 
-            this.exportToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
-            this.exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
-            this.saveMapToDiscToolStripMenuItem,
-            this.exportMapToTheClipboardToolStripMenuItem,
-            this.toolStripMenuItem15,
-            this.convertconFileToAsciiFormatToolStripMenuItem,
-            this.toolStripMenuItem12,
-            this.pointSourcesToolStripMenuItem3,
-            this.areaSourcesToolStripMenuItem3,
-            this.lineSourcesToolStripMenuItem3,
-            this.receptorPointsToolStripMenuItem3,
-            this.contourLinesToolStripMenuItem,
-            this.GRAMMWindFieldsToolStripMenuItem});
-            this.exportToolStripMenuItem.Name = "exportToolStripMenuItem";
-            this.exportToolStripMenuItem.ShortcutKeyDisplayString = "E";
-            this.exportToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.X)));
-            this.exportToolStripMenuItem.Size = new System.Drawing.Size(53, 21);
-            this.exportToolStripMenuItem.Text = "E&xport";
+            exportToolStripMenuItem.DisplayStyle = System.Windows.Forms.ToolStripItemDisplayStyle.Text;
+            exportToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] { saveMapToDiscToolStripMenuItem, exportMapToTheClipboardToolStripMenuItem, toolStripMenuItem15, convertconFileToAsciiFormatToolStripMenuItem, toolStripMenuItem12, pointSourcesToolStripMenuItem3, areaSourcesToolStripMenuItem3, lineSourcesToolStripMenuItem3, receptorPointsToolStripMenuItem3, contourLinesToolStripMenuItem, GRAMMWindFieldsToolStripMenuItem, buildingsToolStripMenuItem2, domainAreaToolStripMenuItem });
+            exportToolStripMenuItem.Name = "exportToolStripMenuItem";
+            exportToolStripMenuItem.ShortcutKeyDisplayString = "E";
+            exportToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Alt | System.Windows.Forms.Keys.X;
+            exportToolStripMenuItem.Size = new System.Drawing.Size(53, 21);
+            exportToolStripMenuItem.Text = "E&xport";
             // 
             // saveMapToDiscToolStripMenuItem
             // 
-            this.saveMapToDiscToolStripMenuItem.Name = "saveMapToDiscToolStripMenuItem";
-            this.saveMapToDiscToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.saveMapToDiscToolStripMenuItem.Text = "Save map to disk";
-            this.saveMapToDiscToolStripMenuItem.Click += new System.EventHandler(this.Button22_Click);
+            saveMapToDiscToolStripMenuItem.Name = "saveMapToDiscToolStripMenuItem";
+            saveMapToDiscToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            saveMapToDiscToolStripMenuItem.Text = "Save map to disk";
+            saveMapToDiscToolStripMenuItem.Click += Button22_Click;
             // 
             // exportMapToTheClipboardToolStripMenuItem
             // 
-            this.exportMapToTheClipboardToolStripMenuItem.Name = "exportMapToTheClipboardToolStripMenuItem";
-            this.exportMapToTheClipboardToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-            this.exportMapToTheClipboardToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.exportMapToTheClipboardToolStripMenuItem.Text = "Copy map to the clipboard";
-            this.exportMapToTheClipboardToolStripMenuItem.Click += new System.EventHandler(this.Domain_clipboardClick);
+            exportMapToTheClipboardToolStripMenuItem.Name = "exportMapToTheClipboardToolStripMenuItem";
+            exportMapToTheClipboardToolStripMenuItem.ShortcutKeys = System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C;
+            exportMapToTheClipboardToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            exportMapToTheClipboardToolStripMenuItem.Text = "Copy map to the clipboard";
+            exportMapToTheClipboardToolStripMenuItem.Click += Domain_clipboardClick;
             // 
             // toolStripMenuItem15
             // 
-            this.toolStripMenuItem15.Name = "toolStripMenuItem15";
-            this.toolStripMenuItem15.Size = new System.Drawing.Size(279, 6);
+            toolStripMenuItem15.Name = "toolStripMenuItem15";
+            toolStripMenuItem15.Size = new System.Drawing.Size(279, 6);
             // 
             // convertconFileToAsciiFormatToolStripMenuItem
             // 
-            this.convertconFileToAsciiFormatToolStripMenuItem.Name = "convertconFileToAsciiFormatToolStripMenuItem";
-            this.convertconFileToAsciiFormatToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.convertconFileToAsciiFormatToolStripMenuItem.Text = "Convert *.con file to ASCII raster format";
-            this.convertconFileToAsciiFormatToolStripMenuItem.Click += new System.EventHandler(this.Button40_Click);
+            convertconFileToAsciiFormatToolStripMenuItem.Name = "convertconFileToAsciiFormatToolStripMenuItem";
+            convertconFileToAsciiFormatToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            convertconFileToAsciiFormatToolStripMenuItem.Text = "Convert *.con file to ASCII raster format";
+            convertconFileToAsciiFormatToolStripMenuItem.Click += Button40_Click;
             // 
             // toolStripMenuItem12
             // 
-            this.toolStripMenuItem12.Name = "toolStripMenuItem12";
-            this.toolStripMenuItem12.Size = new System.Drawing.Size(279, 6);
+            toolStripMenuItem12.Name = "toolStripMenuItem12";
+            toolStripMenuItem12.Size = new System.Drawing.Size(279, 6);
             // 
             // pointSourcesToolStripMenuItem3
             // 
-            this.pointSourcesToolStripMenuItem3.Name = "pointSourcesToolStripMenuItem3";
-            this.pointSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
-            this.pointSourcesToolStripMenuItem3.Text = "Point sources";
-            this.pointSourcesToolStripMenuItem3.Click += new System.EventHandler(this.Button38_Click);
+            pointSourcesToolStripMenuItem3.Name = "pointSourcesToolStripMenuItem3";
+            pointSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
+            pointSourcesToolStripMenuItem3.Text = "Point sources";
+            pointSourcesToolStripMenuItem3.Click += Button38_Click;
             // 
             // areaSourcesToolStripMenuItem3
             // 
-            this.areaSourcesToolStripMenuItem3.Name = "areaSourcesToolStripMenuItem3";
-            this.areaSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
-            this.areaSourcesToolStripMenuItem3.Text = "Area sources";
-            this.areaSourcesToolStripMenuItem3.Click += new System.EventHandler(this.Button37_Click);
+            areaSourcesToolStripMenuItem3.Name = "areaSourcesToolStripMenuItem3";
+            areaSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
+            areaSourcesToolStripMenuItem3.Text = "Area sources";
+            areaSourcesToolStripMenuItem3.Click += Button37_Click;
             // 
             // lineSourcesToolStripMenuItem3
             // 
-            this.lineSourcesToolStripMenuItem3.Name = "lineSourcesToolStripMenuItem3";
-            this.lineSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
-            this.lineSourcesToolStripMenuItem3.Text = "Line sources";
-            this.lineSourcesToolStripMenuItem3.Click += new System.EventHandler(this.Button36_Click);
+            lineSourcesToolStripMenuItem3.Name = "lineSourcesToolStripMenuItem3";
+            lineSourcesToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
+            lineSourcesToolStripMenuItem3.Text = "Line sources";
+            lineSourcesToolStripMenuItem3.Click += Button36_Click;
             // 
             // receptorPointsToolStripMenuItem3
             // 
-            this.receptorPointsToolStripMenuItem3.Name = "receptorPointsToolStripMenuItem3";
-            this.receptorPointsToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
-            this.receptorPointsToolStripMenuItem3.Text = "Receptor points";
-            this.receptorPointsToolStripMenuItem3.Click += new System.EventHandler(this.Button39_Click);
+            receptorPointsToolStripMenuItem3.Name = "receptorPointsToolStripMenuItem3";
+            receptorPointsToolStripMenuItem3.Size = new System.Drawing.Size(282, 22);
+            receptorPointsToolStripMenuItem3.Text = "Receptor points";
+            receptorPointsToolStripMenuItem3.Click += Button39_Click;
             // 
             // contourLinesToolStripMenuItem
             // 
-            this.contourLinesToolStripMenuItem.Name = "contourLinesToolStripMenuItem";
-            this.contourLinesToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.contourLinesToolStripMenuItem.Text = "Contour lines";
-            this.contourLinesToolStripMenuItem.Click += new System.EventHandler(this.Button56_Click);
+            contourLinesToolStripMenuItem.Name = "contourLinesToolStripMenuItem";
+            contourLinesToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            contourLinesToolStripMenuItem.Text = "Contour lines";
+            contourLinesToolStripMenuItem.Click += Button56_Click;
             // 
             // GRAMMWindFieldsToolStripMenuItem
             // 
-            this.GRAMMWindFieldsToolStripMenuItem.Name = "GRAMMWindFieldsToolStripMenuItem";
-            this.GRAMMWindFieldsToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
-            this.GRAMMWindFieldsToolStripMenuItem.Text = "GRAMM windfields";
-            this.GRAMMWindFieldsToolStripMenuItem.Click += new System.EventHandler(this.Button48_Click);
+            GRAMMWindFieldsToolStripMenuItem.Name = "GRAMMWindFieldsToolStripMenuItem";
+            GRAMMWindFieldsToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            GRAMMWindFieldsToolStripMenuItem.Text = "GRAMM windfields";
+            GRAMMWindFieldsToolStripMenuItem.Click += Button48_Click;
+            // 
+            // buildingsToolStripMenuItem2
+            // 
+            buildingsToolStripMenuItem2.Name = "buildingsToolStripMenuItem2";
+            buildingsToolStripMenuItem2.Size = new System.Drawing.Size(282, 22);
+            buildingsToolStripMenuItem2.Text = "Buildings";
+            buildingsToolStripMenuItem2.Click += Button58_Click;
+            // 
+            // domainAreaToolStripMenuItem
+            // 
+            domainAreaToolStripMenuItem.Name = "domainAreaToolStripMenuItem";
+            domainAreaToolStripMenuItem.Size = new System.Drawing.Size(282, 22);
+            domainAreaToolStripMenuItem.Text = "Domain Area";
+            domainAreaToolStripMenuItem.Click += domainAreaToolStripMenuItem_Click;
             // 
             // toolStripTextBox3
             // 
-            this.toolStripTextBox3.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripTextBox3.BackColor = System.Drawing.SystemColors.MenuBar;
-            this.toolStripTextBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.toolStripTextBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripTextBox3.Name = "toolStripTextBox3";
-            this.toolStripTextBox3.ReadOnly = true;
-            this.toolStripTextBox3.ShortcutsEnabled = false;
-            this.toolStripTextBox3.Size = new System.Drawing.Size(60, 21);
-            this.toolStripTextBox3.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            toolStripTextBox3.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripTextBox3.BackColor = System.Drawing.SystemColors.MenuBar;
+            toolStripTextBox3.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            toolStripTextBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            toolStripTextBox3.Name = "toolStripTextBox3";
+            toolStripTextBox3.ReadOnly = true;
+            toolStripTextBox3.ShortcutsEnabled = false;
+            toolStripTextBox3.Size = new System.Drawing.Size(60, 21);
+            toolStripTextBox3.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // toolStripTextBox2
             // 
-            this.toolStripTextBox2.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripTextBox2.BackColor = System.Drawing.SystemColors.MenuBar;
-            this.toolStripTextBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.toolStripTextBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripTextBox2.Name = "toolStripTextBox2";
-            this.toolStripTextBox2.ReadOnly = true;
-            this.toolStripTextBox2.ShortcutsEnabled = false;
-            this.toolStripTextBox2.Size = new System.Drawing.Size(90, 21);
-            this.toolStripTextBox2.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            toolStripTextBox2.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripTextBox2.BackColor = System.Drawing.SystemColors.MenuBar;
+            toolStripTextBox2.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            toolStripTextBox2.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            toolStripTextBox2.Name = "toolStripTextBox2";
+            toolStripTextBox2.ReadOnly = true;
+            toolStripTextBox2.ShortcutsEnabled = false;
+            toolStripTextBox2.Size = new System.Drawing.Size(90, 21);
+            toolStripTextBox2.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // toolStripTextBox1
             // 
-            this.toolStripTextBox1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
-            this.toolStripTextBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripTextBox1.Name = "toolStripTextBox1";
-            this.toolStripTextBox1.ReadOnly = true;
-            this.toolStripTextBox1.Size = new System.Drawing.Size(90, 21);
-            this.toolStripTextBox1.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            toolStripTextBox1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
+            toolStripTextBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            toolStripTextBox1.Name = "toolStripTextBox1";
+            toolStripTextBox1.ReadOnly = true;
+            toolStripTextBox1.Size = new System.Drawing.Size(90, 21);
+            toolStripTextBox1.TextBoxTextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             // 
             // toolStripComboBox1
             // 
-            this.toolStripComboBox1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
-            this.toolStripComboBox1.AutoToolTip = true;
-            this.toolStripComboBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.toolStripComboBox1.Name = "toolStripComboBox1";
-            this.toolStripComboBox1.Size = new System.Drawing.Size(121, 21);
-            this.toolStripComboBox1.ToolTipText = "Set the current viewframe";
-            this.toolStripComboBox1.SelectedIndexChanged += new System.EventHandler(this.ViewframeSelectedIndexChanged);
+            toolStripComboBox1.Alignment = System.Windows.Forms.ToolStripItemAlignment.Right;
+            toolStripComboBox1.AutoToolTip = true;
+            toolStripComboBox1.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, 0);
+            toolStripComboBox1.Name = "toolStripComboBox1";
+            toolStripComboBox1.Size = new System.Drawing.Size(121, 21);
+            toolStripComboBox1.ToolTipText = "Set the current viewframe";
+            toolStripComboBox1.SelectedIndexChanged += ViewframeSelectedIndexChanged;
             // 
             // BottomToolStripPanel
             // 
-            this.BottomToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.BottomToolStripPanel.Name = "BottomToolStripPanel";
-            this.BottomToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.BottomToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.BottomToolStripPanel.Size = new System.Drawing.Size(0, 0);
+            BottomToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            BottomToolStripPanel.Name = "BottomToolStripPanel";
+            BottomToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            BottomToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            BottomToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
             // TopToolStripPanel
             // 
-            this.TopToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.TopToolStripPanel.Name = "TopToolStripPanel";
-            this.TopToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.TopToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.TopToolStripPanel.Size = new System.Drawing.Size(0, 0);
+            TopToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            TopToolStripPanel.Name = "TopToolStripPanel";
+            TopToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            TopToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            TopToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
             // RightToolStripPanel
             // 
-            this.RightToolStripPanel.Location = new System.Drawing.Point(0, 0);
-            this.RightToolStripPanel.Name = "RightToolStripPanel";
-            this.RightToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
-            this.RightToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
-            this.RightToolStripPanel.Size = new System.Drawing.Size(0, 0);
+            RightToolStripPanel.Location = new System.Drawing.Point(0, 0);
+            RightToolStripPanel.Name = "RightToolStripPanel";
+            RightToolStripPanel.Orientation = System.Windows.Forms.Orientation.Horizontal;
+            RightToolStripPanel.RowMargin = new System.Windows.Forms.Padding(3, 0, 0, 0);
+            RightToolStripPanel.Size = new System.Drawing.Size(0, 0);
             // 
             // picturebox1
             // 
-            this.picturebox1.BackColor = System.Drawing.Color.White;
-            this.picturebox1.Dock = System.Windows.Forms.DockStyle.Fill;
-            this.picturebox1.InitialImage = null;
-            this.picturebox1.Location = new System.Drawing.Point(0, 0);
-            this.picturebox1.Name = "picturebox1";
-            this.picturebox1.Size = new System.Drawing.Size(1027, 892);
-            this.picturebox1.TabIndex = 0;
-            this.picturebox1.TabStop = false;
-            this.picturebox1.MouseDown += new System.Windows.Forms.MouseEventHandler(this.Picturebox1_MouseDown);
-            this.picturebox1.MouseMove += new System.Windows.Forms.MouseEventHandler(this.Picturebox1_MouseMove);
-            this.picturebox1.MouseUp += new System.Windows.Forms.MouseEventHandler(this.Picturebox1_MouseUp);
+            picturebox1.BackColor = System.Drawing.Color.White;
+            picturebox1.Dock = System.Windows.Forms.DockStyle.Fill;
+            picturebox1.InitialImage = null;
+            picturebox1.Location = new System.Drawing.Point(0, 0);
+            picturebox1.Name = "picturebox1";
+            picturebox1.Size = new System.Drawing.Size(1027, 892);
+            picturebox1.TabIndex = 0;
+            picturebox1.TabStop = false;
+            picturebox1.MouseDown += Picturebox1_MouseDown;
+            picturebox1.MouseMove += Picturebox1_MouseMove;
+            picturebox1.MouseUp += Picturebox1_MouseUp;
             // 
             // Domain
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
-            this.ClientSize = new System.Drawing.Size(1027, 892);
-            this.Controls.Add(this.panel1);
-            this.Controls.Add(this.menuStrip1);
-            this.Controls.Add(this.picturebox1);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MainMenuStrip = this.menuStrip1;
-            this.Name = "Domain";
-            this.Text = "Domain";
-            this.WindowState = System.Windows.Forms.FormWindowState.Maximized;
-            this.Activated += new System.EventHandler(this.DomainActivated);
-            this.FormClosing += new System.Windows.Forms.FormClosingEventHandler(this.DomainFormClosing);
-            this.FormClosed += new System.Windows.Forms.FormClosedEventHandler(this.DomainFormClosed);
-            this.Load += new System.EventHandler(this.Domain_Load);
-            this.SizeChanged += new System.EventHandler(this.Domain_SizeChanged);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.toolStrip1.ResumeLayout(false);
-            this.toolStrip1.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            this.groupBox4.ResumeLayout(false);
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox5.ResumeLayout(false);
-            this.panel1.ResumeLayout(false);
-            this.panel1.PerformLayout();
-            this.groupBox7.ResumeLayout(false);
-            this.groupBox6.ResumeLayout(false);
-            this.menuStrip1.ResumeLayout(false);
-            this.menuStrip1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.picturebox1)).EndInit();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(96F, 96F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Dpi;
+            ClientSize = new System.Drawing.Size(1027, 892);
+            Controls.Add(panel1);
+            Controls.Add(menuStrip1);
+            Controls.Add(picturebox1);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            MainMenuStrip = menuStrip1;
+            Name = "Domain";
+            Text = "Domain";
+            WindowState = System.Windows.Forms.FormWindowState.Maximized;
+            Activated += DomainActivated;
+            FormClosing += DomainFormClosing;
+            FormClosed += DomainFormClosed;
+            Load += Domain_Load;
+            SizeChanged += Domain_SizeChanged;
+            groupBox1.ResumeLayout(false);
+            groupBox1.PerformLayout();
+            toolStrip1.ResumeLayout(false);
+            toolStrip1.PerformLayout();
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            groupBox4.ResumeLayout(false);
+            groupBox3.ResumeLayout(false);
+            groupBox5.ResumeLayout(false);
+            panel1.ResumeLayout(false);
+            panel1.PerformLayout();
+            groupBox7.ResumeLayout(false);
+            groupBox6.ResumeLayout(false);
+            menuStrip1.ResumeLayout(false);
+            menuStrip1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)picturebox1).EndInit();
+            ResumeLayout(false);
+            PerformLayout();
         }
+
         private System.Windows.Forms.ToolStripMenuItem windRosesToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem wallsToolStripMenuItem2;
         private System.Windows.Forms.Button button54;
@@ -2839,5 +2723,8 @@
         private System.Windows.Forms.ToolStripMenuItem MenuEntryCellHeightsGral;
         private System.Windows.Forms.ToolStripMenuItem generateTimeSeriesForSeveralEvaluationPointsToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem MenuEntryCellHeightsGrammEdge;
+        private System.Windows.Forms.Button button58;
+        private System.Windows.Forms.ToolStripMenuItem buildingsToolStripMenuItem2;
+        private System.Windows.Forms.ToolStripMenuItem domainAreaToolStripMenuItem;
     }
 }

--- a/src/GRALDomain/Domain.cs
+++ b/src/GRALDomain/Domain.cs
@@ -38,7 +38,7 @@ namespace GralDomain
     public partial class Domain : Form
     {
         private readonly string decsep;                                                // global decimal separator of the system
-        private readonly Gral.Main MainForm = null;
+        public readonly Gral.Main MainForm = null;
         private string MapFileName;
         private string ImageFileNameFromWorldFile;
         /// <summary>
@@ -56,19 +56,19 @@ namespace GralDomain
         /// <summary>
         /// Position whren moving a map with middle mouse button
         /// </summary>
-        private int OldYPosition;                                             
+        private int OldYPosition;
         /// <summary>
         /// Selected DrawingObject in the object manager
         /// </summary>
-        public DrawingObjects ActualEditedDrawingObject;                     
+        public DrawingObjects ActualEditedDrawingObject;
         /// <summary>
         /// Drawing options for each item in the drawing list
         /// </summary>
-        public List<DrawingObjects> ItemOptions = new List<DrawingObjects>();       
+        public List<DrawingObjects> ItemOptions = new List<DrawingObjects>();
         /// <summary>
         /// Copied object container 
         /// </summary>
-        private readonly CopyObjects CopiedItem = new CopyObjects();        
+        private readonly CopyObjects CopiedItem = new CopyObjects();
         /// <summary>
         /// form for georeferencing bitmap file using one reference point and a map scale
         /// </summary>
@@ -84,11 +84,11 @@ namespace GralDomain
         /// <summary>
         /// Form for editing area sources
         /// </summary>
-        public EditAreaSources EditAS = new EditAreaSources();    
+        public EditAreaSources EditAS = new EditAreaSources();
         /// <summary>
         /// Form for editing line sources
         /// </summary>
-        public EditLinesources EditLS = new EditLinesources();   
+        public EditLinesources EditLS = new EditLinesources();
         /// <summary>
         /// Form for editing buildings
         /// </summary>
@@ -112,8 +112,8 @@ namespace GralDomain
         /// <summary>
         /// Dialog for meteo stations
         /// </summary>
-        private DialogCreateMeteoStation MeteoDialog = new DialogCreateMeteoStation(); 
-        
+        private DialogCreateMeteoStation MeteoDialog = new DialogCreateMeteoStation();
+
         /// <summary>
         /// input of new shape allowed?
         /// </summary>
@@ -133,8 +133,8 @@ namespace GralDomain
         /// <summary>
         /// Y position of starting point of model domain
         /// </summary> 
-        private int YDomain;    
-        
+        private int YDomain;
+
         private Rectangle GRALDomain = new Rectangle();   //rectangle to draw GRAL model domain
         private Rectangle GRAMMDomain = new Rectangle();  //rectangle to draw GRAMM model domain
         private Rectangle PanelZoom = new Rectangle();    //rectangle to draw panelzoom area
@@ -142,7 +142,7 @@ namespace GralDomain
         /// Block rubberlines at redraw of online GRAMM/GRAL vectors
         /// </summary> 
         private int RubberRedrawAllowed = 0;
-        
+
         private PointF FirstPointLenght;				  // Lenght measurement
         private readonly ToolTip ToolTipMousePosition;	  // Tooltip for picturebox1
         /// <summary>
@@ -152,8 +152,8 @@ namespace GralDomain
         /// <summary>
         /// [0] = 1st point for lenght label [1] = Point for Rubberline
         /// </summary> 
-        private readonly Point[] RubberLineCoors = new Point[2]; 	       
-        
+        private readonly Point[] RubberLineCoors = new Point[2];
+
         private Bitmap NorthArrowBitmap;                       // Icon for north arrow
         private Bitmap PictureBoxBitmap;					   // Bitmap for the picture box
         private readonly NorthArrowData NorthArrow = new NorthArrowData(); // Data for the north arrow
@@ -166,12 +166,12 @@ namespace GralDomain
         /// <summary>
         /// Map transformation Y when zooming and shifting
         /// </summary> 
-        private int TransformY = 0;                            
-        
+        private int TransformY = 0;
+
         /// <summary>
         /// transformation in x direction of color scale, north arrow, map scale during saving process
         /// </summary>    
-        public int TransformXSave=0;                           
+        public int TransformXSave = 0;
         /// <summary>
         /// transformation in x direction of color scale, north arrow, map scale during saving process
         /// </summary>    
@@ -179,10 +179,10 @@ namespace GralDomain
         /// <summary>
         /// scaling of color scale, north arrow, map scale during saving process
         /// </summary>            
-        public double BmppbXSave = 1;                          
-        
+        public double BmppbXSave = 1;
+
         private string GRAMMmeteofile;                         //Meteo-File generated from GRAMM windfield
-        
+
         /// <summary>
         /// true = contour map should be reloaded and redrawn 
         /// </summary>            
@@ -190,10 +190,10 @@ namespace GralDomain
         /// <summary>
         /// true = vector map should be reloaded and redrawn 
         /// </summary>
-        public bool ReDrawVectors = true;   
-           
+        public bool ReDrawVectors = true;
+
         private readonly FileWatcherCollection FileWatch = new FileWatcherCollection(); // Contains all FileSystemWatchers
-        
+
         public List<Point> sectionpoints = new List<Point>(); // List of section points for the redraw
         /// <summary>
         /// Online Counter for GRAMM and GRAL online and recording of animated GIF files 
@@ -219,12 +219,12 @@ namespace GralDomain
         /// <summary>
         /// List of all selectet Items of one type to delete all selected items
         /// </summary>
-        private readonly List<int> SelectedItems = new List<int>();        
+        private readonly List<int> SelectedItems = new List<int>();
         private string ConcFilename = "";						  // filename for concentration files
         /// <summary>
         /// Array to display GRAMM or GRAL cell heights
         /// </summary>
-        private float [,] CellHeights = new float[1,1];           // Cell heights
+        private float[,] CellHeights = new float[1, 1];           // Cell heights
         /// <summary>
         /// Height - Type: 0 = no, 1= GRAMM, 2 = GRAL, -1 GRAMM edge points
         /// </summary>
@@ -232,15 +232,15 @@ namespace GralDomain
         /// <summary>
         /// variables needed for the routine to import newly observed meteo data
         /// </summary>
-        private readonly MatchMeteoData MMOData =  new MatchMeteoData();
+        private readonly MatchMeteoData MMOData = new MatchMeteoData();
         /// <summary>
         /// form for matching GRAMM wind fields with multiple observations
         /// </summary>
-        public MatchMultipleObservations MMO = new MatchMultipleObservations();    
-        
+        public MatchMultipleObservations MMO = new MatchMultipleObservations();
+
         public VerticalProfileConcentration VerticalProfileForm;
         public DomainformClosed DomainClosed;
-        
+
         private readonly ShowFirstItem ShowFirst = new ShowFirstItem();	          // contains info about the first visible item form
         /// <summary>
         /// Visible Columns in the search datagridview
@@ -258,21 +258,21 @@ namespace GralDomain
         /// Save the BaseMapData when shifting or zooming a map for reset (ESC key)
         /// </summary>
         private readonly GralData.BaseMapData BaseMapOldValues = new GralData.BaseMapData();
-        
+
         private GralData.TopoModifyClass TopoModify = new GralData.TopoModifyClass();
-        private bool[,] TopoModifyBlocked = new bool[1,1];
+        private bool[,] TopoModifyBlocked = new bool[1, 1];
         /// <summary>
         /// Size & Position of Geo-Referenced Map
         /// </summary>
-        private readonly MapSizes MapSize = new MapSizes();                         
-                
+        private readonly MapSizes MapSize = new MapSizes();
+
         private bool GRAL_Locked = false;
         private bool GRAMM_Locked = false;
-        
+
         private MessageWindow MessageInfoForm;
-        
+
         private readonly VerticalWindProfile ProfileConcentration = new VerticalWindProfile();
-       
+
         /// <summary>
         /// Delegate to force a redraw from child forms
         /// </summary>
@@ -292,7 +292,7 @@ namespace GralDomain
         /// Send a event with clicked coordinates to all registered forms
         /// </summary>
         private event SendCoordinates SendCoors;
-        
+
         /// <summary>
         /// Start the Domain (GIS) Form of this application
         /// </summary>
@@ -303,7 +303,7 @@ namespace GralDomain
             GRAMMOnline = online; // Online or Domain Mode?
             InitializeComponent();
             DomainRedrawDelegate = new ForceDomainRedraw(Picturebox_Redraw);
-            
+
             //User defineddecimal seperator
             decsep = NumberFormatInfo.CurrentInfo.NumberDecimalSeparator;
             // reduce flickering
@@ -313,17 +313,17 @@ namespace GralDomain
             //SetStyle(ControlStyles.AllPaintingInWmPaint, true);
             //SetStyle(ControlStyles.UserPaint, true);
             //SetStyle(ControlStyles.OptimizedDoubleBuffer, true);
-            
+
             MainForm = f;
-            
+
             MouseWheel += new MouseEventHandler(form1_MouseWheel); // Kuntner
-            
+
             //event when matching process should start
             MMO.StartMatchProcess += new StartMatchingDelegate(StartMatchingProcess);
             MMO.CancelMatchProcess += new CancelMatchingDelegate(MatchCancel);
             MMO.FinishMatchProcess += new FinishMatchingDelegate(MatchFinish);
             MMO.LoadWindData += new LoadWindFileData(LoadWindFileForMatching);
-            
+
             //GRAMM Online options
             if (GRAMMOnline == true)
             {
@@ -335,7 +335,7 @@ namespace GralDomain
                 {
                     GRAL_Locked = Gral.Main.Project_Locked;
                     GRAMM_Locked = MainForm.GRAMM_Locked;
-                    
+
                     if (MainForm.GRAMM_Locked)
                     {
                         Text = "Domain / " + Path.GetFileName(Gral.Main.ProjectName) + "   (GRAL locked / GRAMM locked)";
@@ -357,22 +357,22 @@ namespace GralDomain
                     }
                 }
             }
-            
+
             panel1.Top = SystemInformation.MenuHeight;
             panel1.Height = Math.Max(600, ClientSize.Height - SystemInformation.MenuHeight);
 
-            #if __MonoCS__
+#if __MonoCS__
             panel1.Dock = DockStyle.None;
             panel1.Left = 0; panel1.Top =  40;
             groupBox1.Visible = true;
             groupBox2.Visible = true;
-            #endif
+#endif
 
             using (Stream s1 = GetType().Assembly.GetManifestResourceStream("Gral.Resources.North.gif"))
             {
                 NorthArrowBitmap = new Bitmap(s1);
             }
-            
+
             EditPS.PointSourceRedraw += DomainRedrawDelegate; // Redraw from Edit Point Sources
             EditAS.AreaSourceRedraw += DomainRedrawDelegate; // Redraw from areaedit
             EditB.BuildingRedraw += DomainRedrawDelegate; // Redraw from editbuilding
@@ -428,10 +428,10 @@ namespace GralDomain
 
             GeoReferenceOne.Form_Georef1_Closed += new Georeference1_Closed(CloseGeoRef1); // Message, that georef1 is closed
             GeoReferenceTwo.Form_Georef2_Closed += new Georeference2_Closed(CloseGeoRef2); // Message, that georef2 is closed
-            
+
             EditR.MinReceptorHeight = MainForm.GRALSettings.Deltaz * 0.5; // minimum Height from Main()
-            
-            
+
+
             //load user defined settings
             LoadSettingsAndMaps();
 
@@ -446,12 +446,12 @@ namespace GralDomain
                 string newPath1 = Path.Combine(Gral.Main.ProjectName, "Computation" + Path.DirectorySeparatorChar);
                 DirectoryInfo di = new DirectoryInfo(newPath1);
                 FileInfo[] files_wind = di.GetFiles("*.wnd");
-                if(files_wind.Length>0)
+                if (files_wind.Length > 0)
                 {
                     button43.Visible = false;
                     matchToObservationToolStripMenuItem.Enabled = false;
                 }
-                
+
                 // GRAL topography allowed?
                 if (Gral.Main.Project_Locked == false &&
                     MainForm.GralDomRect.East != MainForm.GralDomRect.West && MainForm.GralDomRect.North != MainForm.GralDomRect.South)
@@ -484,10 +484,10 @@ namespace GralDomain
             {
                 groupBox3.Visible = true;
                 button_section_wind.Visible = true;
-                
+
                 windfieldAnalysisToolStripMenuItem.Enabled = true;
             }
-            
+
             //show windfield analysis tools for GRAL when a windfield is existent
             //check if wind fields are existent
             bool windfieldfiles = WindfieldsAvailable();
@@ -499,26 +499,26 @@ namespace GralDomain
                 button_section_wind.Visible = true;
                 windfieldAnalysisToolStripMenuItem.Enabled = true;
             }
-            
+
             // Reset Rubber-Line Drawing
-            RubberLineCoors[0].X = -1;RubberLineCoors[0].Y = -1;
-            
+            RubberLineCoors[0].X = -1; RubberLineCoors[0].Y = -1;
+
             ToolTipMousePosition = new ToolTip(); // Tooltip for picturebox1
-            ToolTipMousePosition.SetToolTip(picturebox1,"[m]");
+            ToolTipMousePosition.SetToolTip(picturebox1, "[m]");
             ToolTipMousePosition.UseFading = false;
             ToolTipMousePosition.Active = false;
 
-            #if __MonoCS__
+#if __MonoCS__
             
-            #else
+#else
             ToolTipMousePosition.BackColor = Color.Transparent;
-            #endif
+#endif
             ToolTipMousePosition.UseAnimation = false;
 
             // Try to load cell height information
             TryToLoadCellHeights();
         }
-        
+
         /// <summary>
         /// Load all settings for the domain window and the background maps
         /// </summary>
@@ -527,7 +527,7 @@ namespace GralDomain
             try
             {
                 LoadDomainSettings();
-                
+
                 //load contour, vector, and shape maps
                 try
                 {
@@ -563,7 +563,8 @@ namespace GralDomain
                                             FileName = Convert.ToString(Path.GetFileName(_drobj.ContourFilename))
                                             //ShowHelp = true
 #if NET6_0_OR_GREATER
-                                            ,ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
+                                            ,
+                                            ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
 #endif
                                         })
                                         {
@@ -585,7 +586,7 @@ namespace GralDomain
                             catch
                             {
                                 RemoveMap(k);
-                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename,"GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename, "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             }
                         }
                         if (_drobj.Name.Substring(0, 3) == "VM:")
@@ -638,7 +639,7 @@ namespace GralDomain
                             catch
                             {
                                 RemoveMap(k);
-                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename,"GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename, "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                             }
                         }
                         if (_drobj.Name.Substring(0, 3) == "SM:")
@@ -674,7 +675,8 @@ namespace GralDomain
                                             Title = "Shape file " + Convert.ToString(Path.GetFileName(_drobj.ContourFilename)) + " not found - please enter new path",
                                             FileName = Path.GetFileName(_drobj.ContourFilename)
 #if NET6_0_OR_GREATER
-                                            , ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
+                                            ,
+                                            ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
 #endif
                                         })
                                         {
@@ -724,11 +726,11 @@ namespace GralDomain
                                         }
                                     }
                                 }
-                                
+
                             }
                             catch
                             {
-                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename,"GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                                MessageBox.Show(this, "Unable to open\n\t" + _drobj.ContourFilename, "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                                 RemoveMap(k);
                             }
                             shape = null;
@@ -847,8 +849,8 @@ namespace GralDomain
             //check if wind fields are existent
             string newPath4 = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation") + Path.DirectorySeparatorChar);
             DirectoryInfo di2 = new DirectoryInfo(newPath4);
-            FileInfo[]  files_windgral = di2.GetFiles("*.gff");
-            
+            FileInfo[] files_windgral = di2.GetFiles("*.gff");
+
             if (files_windgral.Length > 0)
             {
                 return true;
@@ -916,8 +918,8 @@ namespace GralDomain
             double ymax = -10000000;
             double fac1 = 1;
             double fac2 = 1;
-            
-            foreach(DrawingObjects _dr in ItemOptions)
+
+            foreach (DrawingObjects _dr in ItemOptions)
             {
                 if ((_dr.Name.Substring(0, 3) == "BM:") || (_dr.Name.Substring(0, 3) == "SM:"))
                 {
@@ -927,17 +929,17 @@ namespace GralDomain
                     ymin = Math.Min(ymin, _dr.North - _dr.PixelMx * _dr.Picture.Height);
                 }
             }
-            
-            fac1 = Convert.ToDouble(picturebox1.Width) / (xmax-xmin)*MapSize.SizeX;
+
+            fac1 = Convert.ToDouble(picturebox1.Width) / (xmax - xmin) * MapSize.SizeX;
             fac2 = Convert.ToDouble(picturebox1.Height) / (ymax - ymin) * MapSize.SizeX;
             XFac = Math.Min(fac1, fac2);
             BmpScale = 1 / XFac;
 
-            TransformX = Convert.ToInt32(-(xmin-MapSize.West)/BmpScale/MapSize.SizeX);
-            TransformY = Convert.ToInt32(-(ymax- MapSize.North) / BmpScale / MapSize.SizeY);
+            TransformX = Convert.ToInt32(-(xmin - MapSize.West) / BmpScale / MapSize.SizeX);
+            TransformY = Convert.ToInt32(-(ymax - MapSize.North) / BmpScale / MapSize.SizeY);
 
             //set source - and destination rectangle
-            foreach(DrawingObjects _dr in ItemOptions)
+            foreach (DrawingObjects _dr in ItemOptions)
             {
                 try
                 {
@@ -947,9 +949,9 @@ namespace GralDomain
                                                 Convert.ToInt32(_dr.Picture.Height * _dr.PixelMx / MapSize.SizeX * XFac));
                     _dr.SourceRec = new Rectangle(0, 0, _dr.Picture.Width, _dr.Picture.Height);
                 }
-                catch{}
+                catch { }
             }
-            
+
             //compute GRAL model domain
             try
             {
@@ -995,29 +997,29 @@ namespace GralDomain
             //prevent parallel editing
             HideWindows(0);
         }
-        
+
         /// <summary>
         /// Delete Buildings ouside the GRAL domain area
         /// </summary>
         void Button44Click(object sender, EventArgs e)
         {
-            if (MainForm.GralDomRect.East >  MainForm.GralDomRect.West && MainForm.GralDomRect.South < MainForm.GralDomRect.North) // GRAL domain visible
+            if (MainForm.GralDomRect.East > MainForm.GralDomRect.West && MainForm.GralDomRect.South < MainForm.GralDomRect.North) // GRAL domain visible
             {
                 SelectedItems.Clear(); // clear the selection list
-                
+
                 int i = 0;
-                double x1=0;
-                double y1=0;
-                
+                double x1 = 0;
+                double y1 = 0;
+
                 foreach (BuildingData _bd in EditB.ItemData)
                 {
-                    List <PointD> _pt = _bd.Pt;
+                    List<PointD> _pt = _bd.Pt;
                     for (int j = 0; j < _pt.Count; j++)
                     {
                         x1 = _pt[j].X;
                         y1 = _pt[j].Y;
-                        
-                        if (x1 <= (MainForm.GralDomRect.West + 5 * MainForm.HorGridSize)||
+
+                        if (x1 <= (MainForm.GralDomRect.West + 5 * MainForm.HorGridSize) ||
                             y1 <= (MainForm.GralDomRect.South + 5 * MainForm.HorGridSize) ||
                             y1 >= (MainForm.GralDomRect.North - 5 * MainForm.HorGridSize) ||
                             x1 >= (MainForm.GralDomRect.East - 5 * MainForm.HorGridSize))
@@ -1047,10 +1049,10 @@ namespace GralDomain
             }
             else
             {
-                MessageBox.Show(this, "Please define GRAL domain","Delete buildings outside GRAL domain area", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(this, "Please define GRAL domain", "Delete buildings outside GRAL domain area", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
         }
-        
+
         /// <summary>
         /// Delete all selected items 
         /// </summary>
@@ -1060,7 +1062,7 @@ namespace GralDomain
             {
                 if (SelectedItems.Count == 1)
                 {
-                    a = Convert.ToString(SelectedItems.Count) + " " + a +"?";
+                    a = Convert.ToString(SelectedItems.Count) + " " + a + "?";
                 }
                 else
                 {
@@ -1071,12 +1073,12 @@ namespace GralDomain
                 {
                     int i_alt = -1;
                     SelectedItems.Sort(new SortIntDescending()); // sort descending
-                    foreach(int i in SelectedItems) // delete all buildings							{
+                    foreach (int i in SelectedItems) // delete all buildings							{
                     {
                         Application.DoEvents();
                         if (i != i_alt) // if one element was selected twice
                         {
-                            
+
                             i_alt = i;
                             if (MouseControl == MouseMode.BuildingSel)
                             {
@@ -1109,7 +1111,7 @@ namespace GralDomain
                     Picturebox1_Paint(); // Kuntner
                 }
             }
-            
+
         }
 
         /// <summary>
@@ -1142,20 +1144,20 @@ namespace GralDomain
         private void ToolStripButton3_Click(object sender, EventArgs e)
         {
             GeoReferencingOne();
-            
+
             //enable/disable GRAL simulations
             MainForm.Enable_GRAL();
             //enable/disable GRAMM simulations
             MainForm.Enable_GRAMM();
         }
-        
+
         /// <summary>
         /// Start a georeferencing with two points
         /// </summary>
         private void ToolStripButton4_Click(object sender, EventArgs e)
         {
             GeoReferencingTwo();
-            
+
             //enable/disable GRAL simulations
             MainForm.Enable_GRAL();
             //enable/disable GRAMM simulations
@@ -1172,14 +1174,14 @@ namespace GralDomain
                 // search top base map at object manager
                 DrawingObjects _drobj = null;
                 foreach (DrawingObjects _dr in ItemOptions)
-                {        
+                {
                     if ((_dr.Name.Substring(0, 3) == "SM:"))
                     {
                         _drobj = _dr;
                         break;
                     }
                 }
-                
+
                 if (_drobj != null) // Shape Map -> coordinate transformation
                 {
                     double west = _drobj.Item;
@@ -1190,7 +1192,7 @@ namespace GralDomain
                     }
                     string x0 = west.ToString();
                     string y0 = north.ToString();
-                    
+
                     try
                     {
                         using (InputCoordinates inp = new InputCoordinates(x0, y0))
@@ -1205,15 +1207,15 @@ namespace GralDomain
 
                         SaveDomainSettings(1);
                     }
-                    catch{}
+                    catch { }
                     toolStripButton1.PerformClick();
                     Picturebox1_Paint();
                 }
                 else // Bitmap -> Shift
                 {
-                    
-                    BaseMapOldValues.Destrec = new Rectangle(0,0,0,0);
-                    
+
+                    BaseMapOldValues.Destrec = new Rectangle(0, 0, 0, 0);
+
                     MouseControl = MouseMode.BaseMapMoveScale;
                     CursorConverter cv = new CursorConverter();
                     Cursor cursor = (Cursor)cv.ConvertFrom(Gral.Properties.Resources.lmove);
@@ -1260,7 +1262,7 @@ namespace GralDomain
         //       Draw map
         //
         //////////////////////////////////////////////////////////////////
-        
+
         /// <summary>
         /// Redraw the picturebox
         /// </summary>
@@ -1285,7 +1287,7 @@ namespace GralDomain
                 System.Threading.Interlocked.Exchange(ref LockOnlineRedraw, 0);
             }
         }
-        
+
         /// <summary>
         /// Catch the event to redraw the picturebox
         /// </summary>
@@ -1293,7 +1295,7 @@ namespace GralDomain
         {
             Picturebox1_Paint();
         }
-        
+
         /// <summary>
         /// Close the (all) item form(s) 
         /// </summary>
@@ -1429,16 +1431,16 @@ namespace GralDomain
             //save data to "in.dat"
             MainForm.GRALSettings.InDatPath = Path.Combine(Gral.Main.ProjectName, @"Computation", "in.dat");
             MainForm.GRALSettings.Pollutant = "NOx";
-            
+
             InDatFileIO write_in_dat = new InDatFileIO
             {
                 Data = MainForm.GRALSettings
             };
             write_in_dat.WriteInDat();
-            
-            write_in_dat = null;          
+
+            write_in_dat = null;
         }
-        
+
         /// <summary>
         /// Load an additional base map
         /// </summary>
@@ -1457,7 +1459,8 @@ namespace GralDomain
                 Title = "Select georeferenced image map",
                 InitialDirectory = Path.Combine(Gral.Main.ProjectName, "Maps" + Path.DirectorySeparatorChar)
 #if NET6_0_OR_GREATER
-                ,ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
+                ,
+                ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
 #endif
             };
             if (dialog.ShowDialog(this) == DialogResult.OK)
@@ -1474,7 +1477,7 @@ namespace GralDomain
                         };
 
                         DrawingObjects _drobj = new DrawingObjects("BM: " + Path.GetFileNameWithoutExtension(MapFileName));
-                        
+
                         if (header.ReadHeader() == false)
                         {
                             throw new FileLoadException();
@@ -1488,7 +1491,7 @@ namespace GralDomain
                             ImageFileNameFromWorldFile = header.Imagefile;
                         }
                         header = null;
-                        
+
                         //File name available but does not exist on the folder -> try to load from local folder
                         if (!string.IsNullOrEmpty(ImageFileNameFromWorldFile) && !File.Exists(ImageFileNameFromWorldFile))
                         {
@@ -1499,9 +1502,9 @@ namespace GralDomain
                                 ImageFileNameFromWorldFile = testfile;
                             }
                         }
-                        
+
                         // ImageFile from world file is not available or does not exist -> try with changed filename from world file in local folder
-                        if ((string.IsNullOrEmpty(ImageFileNameFromWorldFile)) || (File.Exists(ImageFileNameFromWorldFile) == false)) 
+                        if ((string.IsNullOrEmpty(ImageFileNameFromWorldFile)) || (File.Exists(ImageFileNameFromWorldFile) == false))
                         {
                             //check tiff extension
                             if (Path.GetExtension(MapFileName).ToLower() == ".tfw")
@@ -1509,7 +1512,7 @@ namespace GralDomain
                                 ImageFileNameFromWorldFile = Path.Combine(Path.GetDirectoryName(MapFileName), Path.GetFileNameWithoutExtension(MapFileName) + ".tif");
                                 if (File.Exists(ImageFileNameFromWorldFile) == false)
                                 {
-                                    ImageFileNameFromWorldFile = Path.Combine(Path.GetDirectoryName(MapFileName), Path.GetFileNameWithoutExtension(ImageFileNameFromWorldFile) + ".tiff") ; // try tiff
+                                    ImageFileNameFromWorldFile = Path.Combine(Path.GetDirectoryName(MapFileName), Path.GetFileNameWithoutExtension(ImageFileNameFromWorldFile) + ".tiff"); // try tiff
                                 }
                             }
 
@@ -1546,29 +1549,29 @@ namespace GralDomain
                                 ImageFileNameFromWorldFile = testfile;
                             }
                         }
-                        
+
                         // read the picture
                         MapFileName = ImageFileNameFromWorldFile;
 
                         using (FileStream fs = new FileStream(MapFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
                         {
                             _drobj.Picture.Dispose();
-                            _drobj.Picture =  new Bitmap(fs);
+                            _drobj.Picture = new Bitmap(fs);
                         }
-                        
+
                         //add base map to object list
                         _drobj.Label = 0;
                         _drobj.ContourFilename = MapFileName;
                         _drobj.DestRec = new Rectangle(TransformX + Convert.ToInt32((_drobj.West - MapSize.West) / BmpScale / MapSize.SizeX), TransformY - Convert.ToInt32((_drobj.North - MapSize.North) / BmpScale / MapSize.SizeX), Convert.ToInt32(_drobj.Picture.Width * _drobj.PixelMx / MapSize.SizeX * XFac), Convert.ToInt32(_drobj.Picture.Height * _drobj.PixelMx / MapSize.SizeX * XFac));
-                        _drobj.SourceRec =  new Rectangle(0, 0, _drobj.Picture.Width, _drobj.Picture.Height);
+                        _drobj.SourceRec = new Rectangle(0, 0, _drobj.Picture.Width, _drobj.Picture.Height);
 
                         ItemOptions.Insert(0, _drobj);
                         SaveDomainSettings(1);
                         SwitchMenuGeoreference(); // Kuntner
                     }
-                    catch(Exception ex)
+                    catch (Exception ex)
                     {
-                        MessageBox.Show(this, "Error when reading world file" + Environment.NewLine + ex.Message.ToString(),"GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, "Error when reading world file" + Environment.NewLine + ex.Message.ToString(), "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                 }
                 else if (dialog.FileName.EndsWith(".shp"))
@@ -1588,11 +1591,11 @@ namespace GralDomain
                         {
                             if (shp is GralShape.SHPLine)
                             {
-                                _drobj.ShpLines.Add((GralShape.SHPLine) shp);
+                                _drobj.ShpLines.Add((GralShape.SHPLine)shp);
                             }
                             else if (shp is GralShape.SHPPolygon)
                             {
-                                _drobj.ShpPolygons.Add((GralShape.SHPPolygon) shp);
+                                _drobj.ShpPolygons.Add((GralShape.SHPPolygon)shp);
                             }
                             else if (shp is PointF _ptF)
                             {
@@ -1619,9 +1622,9 @@ namespace GralDomain
                         _drobj.ContourFilename = dialog.FileName;
                         //shape.readShapeFile(dialog.FileName,0);
                         shape = null;
-                        
+
                         _drobj.Label = 0;
-                        
+
                         ItemOptions.Insert(0, _drobj);
                         SaveDomainSettings(1);
                     }
@@ -1635,24 +1638,24 @@ namespace GralDomain
                     MapFileName = dialog.FileName;
 
                     DrawingObjects _drobj = new DrawingObjects("BM: " + Path.GetFileNameWithoutExtension(MapFileName));
-                    
+
                     using (FileStream fs = new FileStream(MapFileName, FileMode.Open, FileAccess.Read, FileShare.Read))
                     {
                         _drobj.Picture.Dispose();
                         _drobj.Picture = new Bitmap(fs);
                     }
-                    
+
                     //compute artificial coordinates, such that image appears with full extent at screen
-                    
-                    
-                    _drobj.West = Convert.ToInt32((-TransformX) * MapSize.SizeX* BmpScale + MapSize.West);
+
+
+                    _drobj.West = Convert.ToInt32((-TransformX) * MapSize.SizeX * BmpScale + MapSize.West);
                     _drobj.North = Convert.ToInt32((TransformY) * MapSize.SizeX * BmpScale + MapSize.North);
                     double dummy1 = Convert.ToDouble(picturebox1.Width) / Convert.ToDouble(_drobj.Picture.Width) * MapSize.SizeX / XFac;
                     double dummy2 = Convert.ToDouble(picturebox1.Height) / Convert.ToDouble(_drobj.Picture.Height) * MapSize.SizeX / XFac;
                     _drobj.PixelMx = Math.Min(dummy1, dummy2);
                     _drobj.Label = 0;
                     _drobj.ContourFilename = MapFileName;
-                    
+
                     ItemOptions.Insert(0, _drobj);
                     SaveDomainSettings(1);
                 }
@@ -1665,8 +1668,8 @@ namespace GralDomain
             ymax = -10000000;
             fact1 = 1;
             fact2 = 1;
-            
-            foreach(DrawingObjects _dr in ItemOptions)
+
+            foreach (DrawingObjects _dr in ItemOptions)
             {
                 if ((_dr.Name.Substring(0, 3) == "BM:") || (_dr.Name.Substring(0, 3) == "SM:"))
                 {
@@ -1676,7 +1679,7 @@ namespace GralDomain
                     ymin = Math.Min(ymin, _dr.North - _dr.PixelMx * _dr.Picture.Height);
                 }
             }
-            
+
             fact1 = Convert.ToDouble(picturebox1.Width) / (xmax - xmin) * MapSize.SizeX;
             fact2 = Convert.ToDouble(picturebox1.Height) / (ymax - ymin) * MapSize.SizeX;
             XFac = Math.Min(fact1, fact2);
@@ -1686,7 +1689,7 @@ namespace GralDomain
             TransformY = Convert.ToInt32(-(ymax - MapSize.North) / BmpScale / MapSize.SizeY);
 
             //set source - and destination rectangle
-            foreach(DrawingObjects _dr in ItemOptions)
+            foreach (DrawingObjects _dr in ItemOptions)
             {
                 try
                 {
@@ -1696,7 +1699,7 @@ namespace GralDomain
                                                 Convert.ToInt32(_dr.Picture.Height * _dr.PixelMx / MapSize.SizeX * XFac));
                     _dr.SourceRec = new Rectangle(0, 0, _dr.Picture.Width, _dr.Picture.Height);
                 }
-                catch{}
+                catch { }
             }
             Picturebox1_Paint();
         }
@@ -1735,7 +1738,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             pointSourcesToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1744,7 +1747,7 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.PointSourceSel;
             Cursor = Cursors.Arrow;
@@ -1757,7 +1760,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             areaSourcesToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1766,7 +1769,7 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.AreaSourceSel;
             Cursor = Cursors.Arrow;
@@ -1779,7 +1782,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             buildingsToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1788,7 +1791,7 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.BuildingSel;
             Cursor = Cursors.Arrow;
@@ -1801,7 +1804,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             receptorPointsToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1810,7 +1813,7 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.ReceptorSel;
             Cursor = Cursors.Arrow;
@@ -1823,7 +1826,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             lineSourcesToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1832,12 +1835,12 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.LineSourceSel;
             Cursor = Cursors.Arrow;
         }
-        
+
         /// <summary>
         /// Start selecting a wall by mouse
         /// </summary>
@@ -1845,7 +1848,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             wallsToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1854,12 +1857,12 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.WallSel;
             Cursor = Cursors.Arrow;
         }
-        
+
         /// <summary>
         /// Start selecting a vegetation area by mouse
         /// </summary>
@@ -1867,7 +1870,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             VegetationtToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1876,12 +1879,12 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.VegetationSel;
             Cursor = Cursors.Arrow;
         }
-        
+
         /// <summary>
         /// Start selecting a tunnel portal source by mouse
         /// </summary>
@@ -1889,7 +1892,7 @@ namespace GralDomain
         {
             ResetSelectionChecked();
             tunnelPortalsToolStripMenuItem1.Checked = true;
-            
+
             checkBox4.Checked = false;
             checkBox5.Checked = false;
             checkBox8.Checked = false;
@@ -1898,12 +1901,12 @@ namespace GralDomain
             checkBox20.Checked = false;
             checkBox25.Checked = false;
             checkBox26.Checked = false;
-            
+
             InfoBoxCloseAllForms(); // close all infoboxes
             MouseControl = MouseMode.PortalSourceSel;
             Cursor = Cursors.Arrow;
         }
-        
+
         /// <summary>
         /// Cancel selecting an item by mouse
         /// </summary>
@@ -1931,7 +1934,7 @@ namespace GralDomain
         private void Button9_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportPointSources(sender,e);
+            ImportPointSources(sender, e);
             Cursor = Cursors.Default;
             Picturebox1_Paint();
         }
@@ -1942,18 +1945,18 @@ namespace GralDomain
         private void Button24_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportReceptorPoints(sender,e);
+            ImportReceptorPoints(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
-        
+
         /// <summary>
         /// Import vegetation data from shape file
         /// </summary>
         void Button51Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportVegetationAreas(sender,e);
+            ImportVegetationAreas(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
@@ -1964,7 +1967,7 @@ namespace GralDomain
         private void Button11_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportAreaSources(sender,e);
+            ImportAreaSources(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
@@ -1975,7 +1978,7 @@ namespace GralDomain
         private void Button17_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportBuildings(sender,e);
+            ImportBuildings(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
@@ -1986,7 +1989,7 @@ namespace GralDomain
         private void Button13_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportGralLineSource(sender,e);
+            ImportGralLineSource(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
@@ -1997,22 +2000,22 @@ namespace GralDomain
         private void Button15_Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportTunnelPortals(sender,e);
+            ImportTunnelPortals(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
-        
+
         /// <summary>
         /// Import wall data
         /// </summary>
         void Button54Click(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
-            ImportWalls(sender,e);
+            ImportWalls(sender, e);
             Picturebox1_Paint();
             Cursor = Cursors.Default;
         }
-        
+
         //////////////////////////////////////////////////////////////////
         //
         //       Export to ESRI-.shp files
@@ -2054,7 +2057,22 @@ namespace GralDomain
             HideWindows(0); // Kuntner - close all edit forms
             ExportShapeReceptor(sender, e);
         }
-
+        /// <summary>
+        /// Write buildings to an ESRI-shape file
+        /// </summary>
+        private void Button58_Click(object sender, EventArgs e)
+        {
+            HideWindows(0); // Kuntner - close all edit forms
+            ExportShapeBuildings(sender, e);
+        }
+        /// <summary>
+        /// Write the domain area to an ESRI-shape file
+        /// </summary>
+        private void domainAreaToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+            HideWindows(0); // Kuntner - close all edit forms
+            ExportShapeDomainArea(sender, e);
+        }
         /// <summary>
         /// Write contour lines to ESRI-shape file
         /// </summary>
@@ -2132,7 +2150,7 @@ namespace GralDomain
             }
             return dialogResult;
         }
-        
+
         /// <summary>
         /// Edit and define the size of the north arrow
         /// </summary>
@@ -2140,7 +2158,7 @@ namespace GralDomain
         {
             HideWindows(0); // Kuntner - close all edit forms
             MouseControl = MouseMode.ViewNorthArrowPos;
-            
+
             int trans = Convert.ToInt32(NorthArrow.Scale * 100);
             foreach (DrawingObjects _drobj in ItemOptions)
             {
@@ -2150,7 +2168,7 @@ namespace GralDomain
                     break;
                 }
             }
-            
+
             if (InputBox1("Define the size of the north arrow", "Scaling factor (1000=10 times larger):", 0, 1000, ref trans) == DialogResult.OK)
             {
                 NorthArrow.Scale = Convert.ToDecimal(trans) / 100;
@@ -2217,21 +2235,21 @@ namespace GralDomain
             MouseControl = MouseMode.ViewAreaMeasurement;
             Cursor = Cursors.Cross;
         }
-        
+
         void Button_section_windMouseClick(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
             MouseControl = MouseMode.SectionWindSel;
             Cursor = Cursors.Cross;
         }
-        
+
         void Button_section_concentrationClick(object sender, EventArgs e)
         {
             HideWindows(0); // Kuntner - close all edit forms
             MouseControl = MouseMode.SectionConcSel;
             Cursor = Cursors.Cross;
         }
-        
+
         /// <summary>
         /// Save the current map to a bitmap file
         /// </summary>
@@ -2258,7 +2276,7 @@ namespace GralDomain
                 {
                     g.Dispose();
                 }
-                
+
                 string dotsperinch = Convert.ToString(dx);
                 if (St_F.InputBoxValue("Adjust bitmap resolution", "Dots per inch [dpi]", ref dotsperinch, this) == DialogResult.OK)
                 {
@@ -2269,7 +2287,7 @@ namespace GralDomain
                     }
                     catch
                     {
-                        MessageBox.Show(this, "Invalid resolution. Image saved with " + dotsperinch + " dpi resolution","GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                        MessageBox.Show(this, "Invalid resolution. Image saved with " + dotsperinch + " dpi resolution", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                     }
                     //set resolution
                     XFac *= dpifactor;
@@ -2277,7 +2295,7 @@ namespace GralDomain
                     BmppbXSave = 1 / dpifactor;
                     TransformX = Convert.ToInt32(TransformX * dpifactor);
                     TransformY = Convert.ToInt32(TransformY * dpifactor);
-                    foreach(DrawingObjects _dr in ItemOptions)
+                    foreach (DrawingObjects _dr in ItemOptions)
                     {
                         try
                         {
@@ -2287,7 +2305,7 @@ namespace GralDomain
                                                         Convert.ToInt32(_dr.Picture.Height * _dr.PixelMx / MapSize.SizeX * XFac));
                             _dr.SourceRec = new Rectangle(0, 0, _dr.Picture.Width, _dr.Picture.Height);
                         }
-                        catch{}
+                        catch { }
                     }
 
                     int height = picturebox1.Height; // get actual height and width with dock-style fill
@@ -2295,12 +2313,12 @@ namespace GralDomain
                     picturebox1.Dock = DockStyle.None;
                     picturebox1.Anchor = AnchorStyles.None;
                     Application.DoEvents();
-                    
+
                     picturebox1.Height = Convert.ToInt32(height * dpifactor);
                     picturebox1.Width = Convert.ToInt32(width * dpifactor);
-                    
+
                     Picturebox1_Paint();
-                    
+
                     Bitmap bitMap = new Bitmap(picturebox1.Width, picturebox1.Height);
                     //Graphics gra = Graphics.FromImage(bitMap);
                     picturebox1.DrawToBitmap(bitMap, new Rectangle(0, 0, picturebox1.Width, picturebox1.Height));
@@ -2316,7 +2334,7 @@ namespace GralDomain
                     BmppbXSave = 1;
                     TransformX = Convert.ToInt32(TransformX / dpifactor);
                     TransformY = Convert.ToInt32(TransformY / dpifactor);
-                    foreach(DrawingObjects _dr in ItemOptions)
+                    foreach (DrawingObjects _dr in ItemOptions)
                     {
                         try
                         {
@@ -2326,7 +2344,7 @@ namespace GralDomain
                                                         Convert.ToInt32(_dr.Picture.Height * _dr.PixelMx / MapSize.SizeX * XFac));
                             _dr.SourceRec = new Rectangle(0, 0, _dr.Picture.Width, _dr.Picture.Height);
                         }
-                        catch{}
+                        catch { }
                     }
 
                     string extension = Path.GetExtension(dialog.FileName).ToLower();
@@ -2415,7 +2433,7 @@ namespace GralDomain
             catch
             { }
         }
-        
+
         /// <summary>
         /// Create a contour map
         /// </summary>
@@ -2424,7 +2442,7 @@ namespace GralDomain
             CreateContourMap("");
             Picturebox1_Paint();
         }
-        
+
         /// <summary>
         /// mathematical operations for multiple raster sets
         /// </summary>
@@ -2439,7 +2457,7 @@ namespace GralDomain
         //  GRAMM windfield analysis tools
         //
         /////////////////////////////////////////////////////////////////////////////////
-        
+
         /// <summary>
         /// Compute meteorological time series at a specific point
         /// </summary>
@@ -2649,7 +2667,7 @@ namespace GralDomain
             }
             Picturebox1_Paint();
         }
-        
+
         /// <summary>
         /// Re-order already computed wind fields in order to match them with
         /// new observations at any site in the model domain
@@ -2684,7 +2702,7 @@ namespace GralDomain
             MouseControl = MouseMode.SetPointReOrder;
             Cursor = Cursors.Cross;
         }
-        
+
         /// <summary>
         /// Start the Re-order wind fields function
         /// </summary>
@@ -2694,8 +2712,8 @@ namespace GralDomain
             int trans = Convert.ToInt32(10);
             if (InputBox1("Height above ground", "Height above ground [m]:", 0, 10000, ref trans) == DialogResult.OK)
             {
-                
-                WriteGrammLog(2,Convert.ToString(TestPt.X), Convert.ToString(TestPt.Y), Convert.ToString(trans));
+
+                WriteGrammLog(2, Convert.ToString(TestPt.X), Convert.ToString(TestPt.Y), Convert.ToString(trans));
 
                 GralBackgroundworkers.BackgroundworkerData DataCollection = new GralBackgroundworkers.BackgroundworkerData
                 {
@@ -2716,11 +2734,11 @@ namespace GralDomain
 
                 GralBackgroundworkers.ProgressFormBackgroundworker BackgroundStart =
                     new GralBackgroundworkers.ProgressFormBackgroundworker(DataCollection)
-                {
-                    Text = DataCollection.Caption
-                };
+                    {
+                        Text = DataCollection.Caption
+                    };
                 BackgroundStart.Show();
-                
+
                 // now the backgroundworker works
             }
         }
@@ -2736,7 +2754,7 @@ namespace GralDomain
                 using (SelectDispersionSituation disp = new SelectDispersionSituation(this, MainForm))
                 {
                     bool windfieldfiles = WindfieldsAvailable();
-                    
+
                     if (Gral.Main.ProjectName != null && File.Exists(Path.Combine(Gral.Main.ProjectName, @"Computation", "windfeld.txt")))
                     {
                         if (windfieldfiles == false)
@@ -2762,7 +2780,7 @@ namespace GralDomain
                             disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
                         }
                     }
-                    else if(Gral.Main.ProjectName != null)
+                    else if (Gral.Main.ProjectName != null)
                     {
                         disp.selectGRAMM_GRAL = 2; // select GRAL
                         disp.GFFPath = St_F.GetGffFilePath(Path.Combine(Gral.Main.ProjectName, "Computation"));
@@ -2791,7 +2809,7 @@ namespace GralDomain
             MouseControl = MouseMode.SetPointSourceApport;
             Cursor = Cursors.Cross;
         }
-        
+
         /// <summary>
         /// Computes source apportionment for GRAL results
         /// </summary>
@@ -2814,12 +2832,13 @@ namespace GralDomain
                 Title = "Select concentration file",
                 InitialDirectory = files
 #if NET6_0_OR_GREATER
-                ,ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
+                ,
+                ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
 #endif
             };
             if (dialog.ShowDialog(this) == DialogResult.OK)
             {
-                string fname = dialog.FileName.Replace("total","*");
+                string fname = dialog.FileName.Replace("total", "*");
                 double[] conc = new double[101];               //concentrations for source apportionment
                 FileInfo[] files_conc = new FileInfo[100];     //list of GRAL concentration files MEAN*.txt used for source apportionment
 
@@ -2855,7 +2874,7 @@ namespace GralDomain
                     catch { }
 
                     string file = Path.Combine(files_conc[i].DirectoryName, files_conc[i].Name);
-                    
+
                     try
                     {
                         using (StreamReader myreader = new StreamReader(file))
@@ -2873,8 +2892,8 @@ namespace GralDomain
                             dummy = myreader.ReadLine().Split(new char[] { ' ', ',', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
 
                             //compute raw and column to extract data (no interpolation is applied)
-                            int col = (int) ((TestPt.X - x11) / cellsize) + 1;
-                            int raw = (int) ((TestPt.Y - y11) / cellsize) + 1;
+                            int col = (int)((TestPt.X - x11) / cellsize) + 1;
+                            int raw = (int)((TestPt.Y - y11) / cellsize) + 1;
 
                             if ((TestPt.X > x11 + cellsize * numbcol) || (TestPt.X < x11) || (TestPt.Y > y11 + cellsize * numbraw) || (TestPt.Y < y11))
                             {
@@ -2935,7 +2954,8 @@ namespace GralDomain
                 Title = "Select a concentration file",
                 InitialDirectory = files
 #if NET6_0_OR_GREATER
-                ,ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
+                ,
+                ClientGuid = GralStaticFunctions.St_F.FileDialogMaps
 #endif
             };
 
@@ -2990,8 +3010,8 @@ namespace GralDomain
                         _drobj.ContourPolygons.TrimExcess();
                         _drobj.ContourFilename = Path.GetFileName(FileName);
                     }
-                    
-                    using(StreamReader myreader = new StreamReader(FileName))
+
+                    using (StreamReader myreader = new StreamReader(FileName))
                     {
                         dummy = myreader.ReadLine().Split(new char[] { ' ', ',', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
                         int numbcol = Convert.ToInt32(dummy[1].Replace(".", decsep));
@@ -3003,7 +3023,7 @@ namespace GralDomain
                         double y11 = Convert.ToDouble(dummy[1].Replace(".", decsep));
                         dummy = myreader.ReadLine().Split(new char[] { ' ', ',', '\t', ';' }, StringSplitOptions.RemoveEmptyEntries);
                         double cellsize = Convert.ToDouble(dummy[1].Replace(".", decsep));
-                        dummy = myreader.ReadLine().Split(new char[] { ' ', '\t'}, StringSplitOptions.RemoveEmptyEntries);
+                        dummy = myreader.ReadLine().Split(new char[] { ' ', '\t' }, StringSplitOptions.RemoveEmptyEntries);
                         string unit = "";
                         if (dummy.Length > 3) // read unit, if available
                         {
@@ -3011,12 +3031,12 @@ namespace GralDomain
                         }
 
                         //compute row and column to extract data (no interpolation is applied)
-                        int col = (int) ((TestPt.X - x11) / cellsize) + 1;
-                        int row = (int) ((TestPt.Y - y11) / cellsize) + 1;
+                        int col = (int)((TestPt.X - x11) / cellsize) + 1;
+                        int row = (int)((TestPt.Y - y11) / cellsize) + 1;
 
                         if ((TestPt.X > x11 + cellsize * numbcol) || (TestPt.X < x11) || (TestPt.Y > y11 + cellsize * numbraw) || (TestPt.Y < y11))
                         {
-                            
+
                         }
                         else
                         {
@@ -3025,7 +3045,7 @@ namespace GralDomain
                             {
                                 if (j < finish - 1)
                                 {
-                                   myreader.ReadLine();
+                                    myreader.ReadLine();
                                 }
                                 else
                                 {
@@ -3033,18 +3053,18 @@ namespace GralDomain
                                 }
                             }
                             double concentration = Convert.ToDouble(dummy[col - 1].Replace(".", decsep));
-                            
+
                             if (unit.Length == 0) // unit not available from file -> loot to filename
                             {
-                                string temp =  Path.GetFileName(FileName).ToUpper();
-                                
+                                string temp = Path.GetFileName(FileName).ToUpper();
+
                                 GralData.ContourPolygon _d = new GralData.ContourPolygon();
                                 _d.EdgePoints = new PointD[2];
                                 _d.EdgePoints[0] = new PointD(TestPt.X, TestPt.Y);
                                 _d.EdgePoints[1] = new PointD(concentration * 1E12, 0);
-                                
+
                                 _drobj.ContourPolygons.Add(_d); // position and concentration
-                                
+
                                 if (temp.Contains("ODOUR"))
                                 {
                                     _drobj.LegendTitle = "Odour hours";
@@ -3063,7 +3083,7 @@ namespace GralDomain
                                 else if (temp.Contains("GGEOM.TXT"))
                                 {
                                     _drobj.LegendTitle = "Height";
-                                    _drobj.LegendUnit =  " m";
+                                    _drobj.LegendUnit = " m";
                                 }
                                 else if (temp.Contains("TOPOGRAPHY"))
                                 {
@@ -3089,14 +3109,14 @@ namespace GralDomain
                             }
                             else
                             {
-                                string temp =  Path.GetFileName(FileName).ToUpper();
-                                
+                                string temp = Path.GetFileName(FileName).ToUpper();
+
                                 GralData.ContourPolygon _d = new GralData.ContourPolygon();
                                 _d.EdgePoints = new PointD[2];
                                 _d.EdgePoints[0] = new PointD(TestPt.X, TestPt.Y);
                                 _d.EdgePoints[1] = new PointD(concentration * 1E12, 0);
                                 _drobj.ContourPolygons.Add(_d); // position and concentration
-                                
+
                                 if (unit.Contains("m" + Gral.Main.SquareString) || unit.Contains("ha") | unit.Contains("km" + Gral.Main.SquareString))
                                 {
                                     _drobj.LegendTitle = "Deposition";
@@ -3130,7 +3150,7 @@ namespace GralDomain
                                 readingOK = true;
                             }
                         }
-                        
+
                     }
                 }
                 catch
@@ -3163,10 +3183,10 @@ namespace GralDomain
             DirectoryInfo di = new DirectoryInfo(files);
             FileInfo[] GRAL_con = di.GetFiles("*.grz");
             int temp = GRAL_con.Length;
-            
+
             bool compressed = false; // compressed files?
             string compressed_file = "";
-            
+
             if (temp != 0) // compressed files?
             {
                 //select dispersion situation
@@ -3176,7 +3196,7 @@ namespace GralDomain
                     ShowConcentrationFiles = true,
                     GRZPath = files
                 };
-                
+
                 disp.StartPosition = FormStartPosition.Manual;
                 disp.Location = GetScreenPositionForNewDialog(2);
                 if (disp.ShowDialog() == DialogResult.OK && disp.selected_situation > 0) // unzip the *.con files from this situation
@@ -3184,7 +3204,7 @@ namespace GralDomain
                     int dissit = disp.selected_situation; // selected situation
                     compressed_file = Convert.ToString(dissit).PadLeft(5, '0') + ".grz";
                     string comp_file = Path.Combine(files, compressed_file);   // filename of a compressed file
-                    
+
                     // unzip compressed file if uncompressed results not available
                     if (File.Exists(comp_file))
                     {
@@ -3193,7 +3213,7 @@ namespace GralDomain
                             await System.Threading.Tasks.Task.Run(() => ZipFile.ExtractToDirectory(comp_file, tempPath));
                             compressed = true;
                         }
-                        catch(Exception ex)
+                        catch (Exception ex)
                         {
                             if (ex.Message.Contains("already exists") == false) // otherwise continue, because results are available!
                             {
@@ -3228,7 +3248,7 @@ namespace GralDomain
                 try
                 {
                     CancellationTokenReset();
-                    if(await System.Threading.Tasks.Task.Run(() => ReadConAndWriteESRI(dialog.FileName, string.Empty, CancellationTokenSource.Token)) == true)
+                    if (await System.Threading.Tasks.Task.Run(() => ReadConAndWriteESRI(dialog.FileName, string.Empty, CancellationTokenSource.Token)) == true)
                     {
                         MessageBoxTemporary Box = new MessageBoxTemporary("File successfully converted", Location);
                         Box.Show();
@@ -3284,7 +3304,7 @@ namespace GralDomain
                 MessageBox.Show(this, "No *.grz files (GRAL result files) available", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 return;
             }
-            
+
             // find the position of the displayed *.txt file within the drawing list
             DrawingObjects _drobj = null;
             string SliceAndSourceGroup = "-101.con";
@@ -3341,7 +3361,7 @@ namespace GralDomain
                     return;
                 }
             }
-            
+
             //MessageBox.Show(this, SliceAndSourceGroup , "GRAL GUI");
             bool compressed = false; // compressed files?
             string compressed_file = "";
@@ -3360,11 +3380,11 @@ namespace GralDomain
                     try
                     {
                         Application.DoEvents();
-                       
+
                         compressed_file = Convert.ToString(dissit).PadLeft(5, '0') + ".grz";
                         string comp_file = Path.Combine(files, compressed_file);   // filename of a compressed file
                                                                                    //MessageBox.Show(compressed_file);
-                        // unzip compressed file if uncompressed results not available
+                                                                                   // unzip compressed file if uncompressed results not available
                         if (File.Exists(comp_file))
                         {
                             try
@@ -3440,7 +3460,7 @@ namespace GralDomain
                             }
                         } // delete unzipped files
                     }
-                    catch {_drobj.LegendTitle = _originalLegendTitle;}
+                    catch { _drobj.LegendTitle = _originalLegendTitle; }
 
                     if (OnlineCounter == 1000) // cancel from user
                     {
@@ -3448,9 +3468,9 @@ namespace GralDomain
                     }
                 }
             }
-            
+
             Cursor = Cursors.Cross;
-            
+
             // reset button behaviour
             button55.Click -= new System.EventHandler(this.CancelAnimatedGIF);
             this.button55.Click += new System.EventHandler(this.CreateAnmiatedGIF);
@@ -3476,7 +3496,7 @@ namespace GralDomain
                 bwd.DomainSouth = MainForm.GralDomRect.South;
                 bwd.CellsGralX = MainForm.CellsGralX;
                 bwd.CellsGralY = MainForm.CellsGralY;
-                float[][][] conc = Landuse.CreateArray<float[][]>(bwd.CellsGralX + 1, () => 
+                float[][][] conc = Landuse.CreateArray<float[][]>(bwd.CellsGralX + 1, () =>
                                    Landuse.CreateArray<float[]>(bwd.CellsGralY + 1, () => new float[1]));
 
                 bool ReadingOK = false;
@@ -3486,7 +3506,7 @@ namespace GralDomain
                 {
                     ReadingOK = Background.ReadConFiles(filename, bwd, 0, ref conc);
                 }
-                
+
                 if (!ReadingOK)
                 {
                     return false;
@@ -3531,23 +3551,23 @@ namespace GralDomain
             // Kuntner: writes a log File with Informations about the GRAMM field computation
             string log_path;
             log_path = Path.Combine(Gral.Main.ProjectName, @"Computation", "Logfile_GRAMM.txt");
-            
+
             using (StreamWriter mywriter = File.AppendText(log_path))
             {
-                
+
                 if (select == 2)
                 {
                     mywriter.WriteLine(" ");
-                    mywriter.WriteLine("Re-Order, started at " + Convert.ToString(DateTime.Now).PadRight(65,'_'));
+                    mywriter.WriteLine("Re-Order, started at " + Convert.ToString(DateTime.Now).PadRight(65, '_'));
                     mywriter.WriteLine(info1.PadLeft(10) + "\t  // X-coordinate of reference point");
                     mywriter.WriteLine(info2.PadLeft(10) + "\t  // Y-coordinate of reference point");
                     mywriter.WriteLine(info3.PadLeft(10) + "\t  // Z-coordinate of reference point");
                 }
-                
+
                 if (select == 3)
                 {
                     mywriter.WriteLine(" ");
-                    mywriter.WriteLine("Match with meteorological observation, started at " + Convert.ToString(DateTime.Now).PadRight(65,'_'));
+                    mywriter.WriteLine("Match with meteorological observation, started at " + Convert.ToString(DateTime.Now).PadRight(65, '_'));
                     if (MMO.radioButton1.Checked == true)
                     {
                         mywriter.WriteLine(" Optimization methode: vectorial");
@@ -3581,7 +3601,7 @@ namespace GralDomain
                         mywriter.WriteLine(" Concatenation for situations less " + Convert.ToString(MMO.concatenate.Value) + " per mil ");
                     }
 
-                    for (int i=0; i < MMO.MetFileNames.Count; i++)
+                    for (int i = 0; i < MMO.MetFileNames.Count; i++)
                     {
                         mywriter.WriteLine(MMO.MetFileNames[i] + "\t  // Used Metfiles");
                         mywriter.WriteLine(Convert.ToString(MMO.dataGridView1.Rows[i].Cells[1].Value).PadLeft(10) + "\t  // X-coordinate of met. station");
@@ -3591,16 +3611,16 @@ namespace GralDomain
                         mywriter.WriteLine("Directional weighting factor " + MMO.dataGridView1.Rows[i].Cells[7].Value.ToString());
                     }
                 }
-                
+
                 if (select == 4) // Error
                 {
                     mywriter.WriteLine(" ");
                     mywriter.WriteLine(info1);
                 }
             }
-            
+
         }
-        
+
         /// <summary>
         /// Set or load a viewframe 
         /// </summary>
@@ -3638,35 +3658,35 @@ namespace GralDomain
         //        // If Return is pressed save view if Text <> Empty and Reload Combobox
         //        e.Handled = true;
         //        string Text = toolStripComboBox1.Text;
-                
+
         //        //if (Text.Length > 0)
         //        {
         //            ViewFrameSave(Text);
         //            //MessageBox.Show(this, "Enter pressed", Text);
         //            if (sender == toolStripComboBox1)
         //                toolStripComboBox1.Items.Clear();
-                    
+
         //            ViewFrameMenuBarLoad();
         //        }
         //        groupBox2.Focus(); // Remove Focus from Combobox
         //    }
-            
+
         //    if (e.KeyCode == Keys.Enter && e.Shift)
         //    {
         //        e.Handled = true;
-                
+
         //        if (toolStripComboBox1.SelectedIndex < 0 || toolStripComboBox1.Items.Count == 0) return;
         //        if (MessageBox.Show(this, "Delete viewframe " + toolStripComboBox1.SelectedText +" ?", "Viewframe delete", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.Cancel) return;
         //        ViewFrameDelete(toolStripComboBox1.Items.Count - toolStripComboBox1.SelectedIndex);
         //        toolStripComboBox1.Items.Clear();
-                
+
         //        Application.DoEvents();
         //        ViewFrameMenuBarLoad();
         //        groupBox2.Focus(); // Remove Focus from Combobox
         //    }
-            
+
         //}
-        
+
         /// <summary>
         /// Load a viewframe 
         /// </summary>
@@ -3677,13 +3697,13 @@ namespace GralDomain
                 string Text = toolStripComboBox1.SelectedItem.ToString();
                 groupBox2.Focus(); // Remove Focus from Combobox
                 ViewFrameSet(Text);
-//				viewframe.SelectedIndexChanged -= new System.EventHandler(ViewframeSelectedIndexChanged);
-//				viewframe.Text = toolStripComboBox1.Text;
-//				viewframe.SelectedIndexChanged += new System.EventHandler(ViewframeSelectedIndexChanged);
+                //				viewframe.SelectedIndexChanged -= new System.EventHandler(ViewframeSelectedIndexChanged);
+                //				viewframe.Text = toolStripComboBox1.Text;
+                //				viewframe.SelectedIndexChanged += new System.EventHandler(ViewframeSelectedIndexChanged);
             }
             //MessageBox.Show(this, "Selektiert", Text);
         }
-        
+
         /// <summary>
         /// Set a viewframe 
         /// </summary>
@@ -3694,52 +3714,52 @@ namespace GralDomain
             {
                 string path;
                 path = Path.Combine(Gral.Main.ProjectName, @"Settings", "sections.txt");
-                
+
                 using (StreamReader myreader = new StreamReader(path)) // Open File
                 {
                     string s;
-                    while(myreader.EndOfStream == false)
+                    while (myreader.EndOfStream == false)
                     {
                         s = myreader.ReadLine();
                         if (s == Text) // found selected Text
                         {
                             s = myreader.ReadLine();
-                            double x0 = St_F.TxtToDbl(s,false);
+                            double x0 = St_F.TxtToDbl(s, false);
                             s = myreader.ReadLine();
-                            double xmax = St_F.TxtToDbl(s,false);
+                            double xmax = St_F.TxtToDbl(s, false);
                             s = myreader.ReadLine();
-                            double y0 = St_F.TxtToDbl(s,false);
+                            double y0 = St_F.TxtToDbl(s, false);
                             ZoomSection(x0, xmax, y0);
                         }
-                    }   
-                }    
+                    }
+                }
             }
             catch
-            {}
+            { }
         }
-        
+
         /// <summary>
         /// Move and zoom the map to given coordinates
         /// </summary>
         private void ZoomSection(double x0, double xmax, double y0)
         {
             double temp = picturebox1.Width * MapSize.SizeX / (xmax - x0);
-            
-            if (temp>0)
+
+            if (temp > 0)
             {
                 double xfac_old = XFac;
                 double transformx_old = TransformX;
                 double transformy_old = TransformY;
                 XFac = temp;
                 BmpScale = 1 / XFac;
-                
-                TransformX = Convert.ToInt32( -(x0 - MapSize.West) * XFac / MapSize.SizeX);
-                TransformY = Convert.ToInt32( -(y0 - MapSize.North) * XFac / MapSize.SizeY);
-                
+
+                TransformX = Convert.ToInt32(-(x0 - MapSize.West) * XFac / MapSize.SizeX);
+                TransformY = Convert.ToInt32(-(y0 - MapSize.North) * XFac / MapSize.SizeY);
+
                 try // Kuntner: catch 1/0 and convert.ToInt32 Overflow
                 {
-                    
-                    foreach(DrawingObjects _dr in ItemOptions)
+
+                    foreach (DrawingObjects _dr in ItemOptions)
                     {
                         try
                         {
@@ -3749,17 +3769,17 @@ namespace GralDomain
                                                         Convert.ToInt32(_dr.Picture.Height * _dr.PixelMx / MapSize.SizeX * XFac));
                             _dr.SourceRec = new Rectangle(0, 0, _dr.Picture.Width, _dr.Picture.Height);
                         }
-                        catch{}
+                        catch { }
                     }
-                    
+
                     MoveCoordinatesOfEditedItems(xfac_old, transformx_old, transformy_old);
                 }
                 catch
-                {}
+                { }
                 Picturebox1_Paint();
             }
         }
-        
+
         /// <summary>
         /// Set the viewframe names to the combo box
         /// </summary>
@@ -3767,17 +3787,17 @@ namespace GralDomain
         {
             // Load all
             toolStripComboBox1.Items.Clear(); // clear all items
-            
+
             // Read View.TXT and put all Elements to the Combobox
             try
             {
                 string path;
                 path = Path.Combine(Gral.Main.ProjectName, @"Settings", "sections.txt");
-                
+
                 using (StreamReader myreader = new StreamReader(path)) // Open File
                 {
                     string s;
-                    while(myreader.EndOfStream == false)
+                    while (myreader.EndOfStream == false)
                     {
                         s = myreader.ReadLine();
                         toolStripComboBox1.Items.Insert(0, s);
@@ -3787,10 +3807,10 @@ namespace GralDomain
                         s = myreader.ReadLine();
                     }
                 }
-                
+
             }
             catch
-            {}
+            { }
         }
 
         /// <summary>
@@ -3802,15 +3822,15 @@ namespace GralDomain
             {
                 string path;
                 path = Path.Combine(Gral.Main.ProjectName, @"Settings", "sections.txt");
-                
+
                 using (StreamWriter mywriter = new StreamWriter(path, true)) // Append File
                 {
                     mywriter.WriteLine(Text);
-                    
-                    double x0 = Math.Round((0-TransformX) * BmpScale * MapSize.SizeX + MapSize.West, 1, MidpointRounding.AwayFromZero);
-                    double xmax = Math.Round((picturebox1.Width-TransformX) * BmpScale * MapSize.SizeX + MapSize.West, 1, MidpointRounding.AwayFromZero);
-                    double y0 = Math.Round((0-TransformY) * BmpScale * MapSize.SizeY + MapSize.North, 1, MidpointRounding.AwayFromZero);
-                    
+
+                    double x0 = Math.Round((0 - TransformX) * BmpScale * MapSize.SizeX + MapSize.West, 1, MidpointRounding.AwayFromZero);
+                    double xmax = Math.Round((picturebox1.Width - TransformX) * BmpScale * MapSize.SizeX + MapSize.West, 1, MidpointRounding.AwayFromZero);
+                    double y0 = Math.Round((0 - TransformY) * BmpScale * MapSize.SizeY + MapSize.North, 1, MidpointRounding.AwayFromZero);
+
                     mywriter.WriteLine(St_F.DblToIvarTxt(x0));
                     mywriter.WriteLine(St_F.DblToIvarTxt(xmax));
                     mywriter.WriteLine(St_F.DblToIvarTxt(y0));
@@ -3818,7 +3838,7 @@ namespace GralDomain
                 }
             }
             catch
-            {}
+            { }
         }
 
         /// <summary>
@@ -3830,27 +3850,27 @@ namespace GralDomain
             {
                 string path = Path.Combine(Gral.Main.ProjectName, @"Settings", "sections.txt");
                 string path2 = Path.Combine(Gral.Main.ProjectName, @"Settings", "view_temp.txt");
-                string [] s = new string[5];
+                string[] s = new string[5];
                 if (File.Exists(path2))
                 {
                     File.Delete(path2); // delete old path
                 }
 
                 File.Move(path, path2);
-                
+
                 using (StreamReader myreader = new StreamReader(path2)) // Open File
                 {
                     using (StreamWriter mywriter = new StreamWriter(path, false)) // Write new File
                     {
-                        int i=1;
-                        while (! myreader.EndOfStream)
+                        int i = 1;
+                        while (!myreader.EndOfStream)
                         {
                             s[0] = myreader.ReadLine();
                             s[1] = myreader.ReadLine();
                             s[2] = myreader.ReadLine();
                             s[3] = myreader.ReadLine();
                             s[4] = myreader.ReadLine();
-                            
+
                             if (i != index) // don't write index which should be deleted
                             {
                                 mywriter.WriteLine(s[0]);
@@ -3864,24 +3884,24 @@ namespace GralDomain
                         mywriter.Flush();
                     }
                 }
-                
+
                 File.Delete(path2); // delete old path
             }
             catch
-            {}
-            
+            { }
+
         }
-        
+
         /// <summary>
         /// Start a 3D view 
         /// </summary>
         void Button3DClick(object sender, EventArgs e)
         {
-            #if __MonoCS__
+#if __MonoCS__
             MessageBox.Show(this, "This function is not available at LINUX yet");
-            #else
+#else
             bool smooth = true;
-            double vert_fac=2;
+            double vert_fac = 2;
             bool GRAL_Topo = false;
             if (CellHeightsType == 2) // Show GRAL height -> show GRAL 3D
             {
@@ -3916,9 +3936,9 @@ namespace GralDomain
             }
             else
             {
-               Domain3DView(smooth, vert_fac);
+                Domain3DView(smooth, vert_fac);
             }
-            #endif
+#endif
         }
 
         /// <summary>
@@ -3949,7 +3969,7 @@ namespace GralDomain
         /// </summary>
         void ToolBoxToolStripMenuItemClick(object sender, EventArgs e)
         {
-            toolBoxToolStripMenuItem.Checked = ! toolBoxToolStripMenuItem.Checked;
+            toolBoxToolStripMenuItem.Checked = !toolBoxToolStripMenuItem.Checked;
             if (toolBoxToolStripMenuItem.Checked)
             {
                 panel1.Show();
@@ -3960,58 +3980,58 @@ namespace GralDomain
             }
             Cursor = Cursors.Arrow;
         }
-        
+
         void PointSourcesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox4.Checked =! checkBox4.Checked;
+            checkBox4.Checked = !checkBox4.Checked;
             ResetSelectionChecked();
         }
-        
+
         void AreaSourcesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox5.Checked =! checkBox5.Checked;
+            checkBox5.Checked = !checkBox5.Checked;
             ResetSelectionChecked();
         }
-        
+
         void LineSourcesToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox8.Checked =! checkBox8.Checked;
+            checkBox8.Checked = !checkBox8.Checked;
             ResetSelectionChecked();
         }
-        
+
         void TunnelPortalsToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox12.Checked =! checkBox12.Checked;
+            checkBox12.Checked = !checkBox12.Checked;
             ResetSelectionChecked();
         }
-        
+
         void BuildingsToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox15.Checked =! checkBox15.Checked;
+            checkBox15.Checked = !checkBox15.Checked;
             ResetSelectionChecked();
         }
-        
+
         void ReceptorPointsToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox20.Checked =! checkBox20.Checked;
+            checkBox20.Checked = !checkBox20.Checked;
             ResetSelectionChecked();
         }
-        
+
         void WallsToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox25.Checked =! checkBox25.Checked;
+            checkBox25.Checked = !checkBox25.Checked;
             ResetSelectionChecked();
         }
-        
+
         void VegetationToolStripMenuItemClick(object sender, EventArgs e)
         {
-            checkBox26.Checked =! checkBox26.Checked;
+            checkBox26.Checked = !checkBox26.Checked;
             ResetSelectionChecked();
         }
-        
+
         void OnePointAndScaleToolStripMenuItemClick(object sender, EventArgs e)
         {
-            onePointAndScaleToolStripMenuItem.Checked =! onePointAndScaleToolStripMenuItem.Checked;
+            onePointAndScaleToolStripMenuItem.Checked = !onePointAndScaleToolStripMenuItem.Checked;
             toolStripButton3.PerformClick();
         }
         void CloseGeoRef1(object sender, EventArgs e)
@@ -4020,7 +4040,7 @@ namespace GralDomain
         }
         void TwoPointsToolStripMenuItemClick(object sender, EventArgs e)
         {
-            twoPointsToolStripMenuItem.Checked =! twoPointsToolStripMenuItem.Checked;
+            twoPointsToolStripMenuItem.Checked = !twoPointsToolStripMenuItem.Checked;
             toolStripButton4.PerformClick();
         }
         void CloseGeoRef2(object sender, EventArgs e)
@@ -4030,22 +4050,22 @@ namespace GralDomain
         void MoveAndZoomMapToolStripMenuItemClick(object sender, EventArgs e)
         {
             ResetSelectionChecked();
-            moveAndZoomMapToolStripMenuItem.Checked =! moveAndZoomMapToolStripMenuItem.Checked;
+            moveAndZoomMapToolStripMenuItem.Checked = !moveAndZoomMapToolStripMenuItem.Checked;
             toolStripButton1.PerformClick();
         }
-        
+
         /// <summary>
         /// Move toolbar from left to right
         /// </summary>
         void Button46Click(object sender, EventArgs e)
         {
-            #if __MonoCS__
+#if __MonoCS__
             if (panel1.Left < picturebox1.Width / 2)
                 panel1.Left = picturebox1.Width - 150;
             else
                 panel1.Left = 1;
             return;
-            #endif
+#endif
             if (panel1.Dock == DockStyle.Right)
             {
                 panel1.Visible = false;
@@ -4059,8 +4079,8 @@ namespace GralDomain
                 panel1.Visible = true;
             }
         }
-        
-        
+
+
         /// <summary>
         /// Delete all selected items 
         /// </summary>
@@ -4100,7 +4120,7 @@ namespace GralDomain
             }
             else
             {
-                MessageBox.Show(this, "No items selected","GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
+                MessageBox.Show(this, "No items selected", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Information);
             }
 
             Picturebox1_Paint();
@@ -4153,7 +4173,7 @@ namespace GralDomain
             {
                 EditVegetation.FillValues();
             }
-            
+
             Picturebox1_Paint();
         }
 
@@ -4161,18 +4181,18 @@ namespace GralDomain
         {
             Cursor = Cursors.Cross;
         }
-        
+
         void ExitGISWindowToolStripMenuItemClick(object sender, EventArgs e)
         {
             Close();
         }
-        
+
         void ToolStripMenuItem18Click(object sender, EventArgs e)
         {
-            ShowLenghtLabel =! ShowLenghtLabel;
+            ShowLenghtLabel = !ShowLenghtLabel;
             toolStripMenuItem18.Checked = ShowLenghtLabel;
         }
-        
+
         /// <summary>
         /// Read the GRAL geometry from the file GRAL_topofile.txt
         /// </summary>
@@ -4213,12 +4233,12 @@ namespace GralDomain
                     ok = true;
                 }
                 catch
-                {}
-                
+                { }
+
             }
             return ok;
         }
-        
+
         /// <summary>
         /// Write the GRAL geometry to the file GRAL_topofile.txt
         /// </summary>
@@ -4235,7 +4255,7 @@ namespace GralDomain
                     {
                         string[] data;
                         string[] header = new string[6];
-                        
+
                         // read  the header
                         using (StreamReader myReader = new StreamReader(file))
                         {
@@ -4244,12 +4264,12 @@ namespace GralDomain
                                 header[i] = myReader.ReadLine();
                             }
                         }
-                        
+
                         data = header[0].Split(new char[] { ' ', '\t', ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
                         int nx = Convert.ToInt32(data[1]);
                         data = header[1].Split(new char[] { ' ', '\t', ',', ';' }, StringSplitOptions.RemoveEmptyEntries);
                         int ny = Convert.ToInt32(data[1]);
-                        
+
                         if (ny > 0 && nx > 0 && nx <= CellHeights.GetUpperBound(0) && ny <= CellHeights.GetUpperBound(1))
                         {
                             wait.Show();
@@ -4262,7 +4282,7 @@ namespace GralDomain
                                 {
                                     myWriter.WriteLine(header[i]);
                                 }
-                                
+
                                 for (int i = ny; i > 0; i--)
                                 {
                                     if (i % 40 == 0)
@@ -4297,13 +4317,13 @@ namespace GralDomain
                         ok = false;
                     }
                 }
-                
+
             }
             wait.Close();
             wait.Dispose();
             return ok;
         }
-        
+
         /// <summary>
         /// Import the original GRAL Topography from ESRI-ASCII file
         /// </summary>
@@ -4342,10 +4362,10 @@ namespace GralDomain
                     }
                     MessageBox.Show(this, "Unable to write file 'GRAL_topofile.txt'", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
                 }
-                
+
             }
         }
-        
+
         /// <summary>
         /// Change icon & Title if the project is locked
         /// </summary>
@@ -4399,7 +4419,7 @@ namespace GralDomain
                 }
             }
         }
-        
+
         /// <summary>
         /// Modify the GRAL topography
         /// </summary>
@@ -4414,7 +4434,7 @@ namespace GralDomain
             }
             else
             {
-                TopoModifyBlocked = new bool[CellHeights.GetUpperBound(0),CellHeights.GetUpperBound(1)];
+                TopoModifyBlocked = new bool[CellHeights.GetUpperBound(0), CellHeights.GetUpperBound(1)];
             }
 
             // Go to the dialog
@@ -4430,17 +4450,17 @@ namespace GralDomain
                     TopoModify = mod.modify;
                 }
             }
-            
+
             // 4th: set the mousecontrol flag
             MouseControl = MouseMode.GRALTopographyModify;
         }
-        
+
         /// <summary>
         /// Restore an unsafed GRAL topography to its original values
         /// </summary>
         void RestoreGRALTopographyToolStripMenuItemClick(object sender, EventArgs e)
         {
-            if (MessageBox.Show(this, "Restore the GRAL topography?","GRAL GUI", MessageBoxButtons.OKCancel , MessageBoxIcon.Question) == DialogResult.OK)
+            if (MessageBox.Show(this, "Restore the GRAL topography?", "GRAL GUI", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.OK)
             {
                 string file = Path.Combine(Gral.Main.ProjectName, "Computation", "GRAL_topofile.txt");
                 if (File.Exists(file))
@@ -4460,19 +4480,19 @@ namespace GralDomain
                             ReadGralGeometry(); // read restored geometry file
                         }
                         catch
-                        {}
+                        { }
                     }
                 }
             }
         }
-        
+
         /// <summary>
         /// Low pass to the GRAL topography
         /// </summary>
         async void LowPassGRALTopographyToolStripMenuItemClick(object sender, EventArgs e)
         {
-            
-            if (MessageBox.Show(this, "Apply low pass filter to the GRAL topography?","GRAL GUI", MessageBoxButtons.OKCancel , MessageBoxIcon.Question) == DialogResult.OK)
+
+            if (MessageBox.Show(this, "Apply low pass filter to the GRAL topography?", "GRAL GUI", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.OK)
             {
                 await System.Threading.Tasks.Task.Run(() => LowPassGralTopographyApply());
                 MessageBoxTemporary Box = new MessageBoxTemporary("Low pass filter applied", Location);
@@ -4511,7 +4531,7 @@ namespace GralDomain
                 }
             }
         }
-        
+
         /// <summary>
         /// Save the GRAL microscale topography
         /// </summary>
@@ -4527,7 +4547,7 @@ namespace GralDomain
                     File.Copy(file, filecopy);
                 }
                 catch
-                {}
+                { }
             }
 
             if (MessageBox.Show(this, "Write new GRAL_topofile.txt?", "GRAL GUI", MessageBoxButtons.OKCancel, MessageBoxIcon.Question) == DialogResult.OK)
@@ -4636,7 +4656,7 @@ namespace GralDomain
                 {
                     SetCellHeightsType(0);
                 }
-            }      
+            }
         }
 
         /// <summary>
@@ -4719,7 +4739,7 @@ namespace GralDomain
             SendCoors += _selmp.ReceiveClickedCoordinates;
             _selmp.CancelComputation += CancelMetTimeSeries;
             _selmp.StartComputation += ConcentrationTimeSeries;
-            
+
             _selmp.MeteoModel = 0;
             _selmp.StartPosition = FormStartPosition.Manual;
             _selmp.Location = new Point(GralStaticFunctions.St_F.GetScreenAtMousePosition() + 160, St_F.GetTopScreenAtMousePosition() + 150);
@@ -4741,13 +4761,13 @@ namespace GralDomain
             if (sender is SelectMultiplePoints _sl)
             {
                 SendCoors -= _sl.ReceiveClickedCoordinates;
-                
+
                 foreach (System.Data.DataRow row in _sl.PointCoorData.Rows)
                 {
                     if (row[0] != DBNull.Value && row[1] != DBNull.Value && row[2] != DBNull.Value && row[3] != DBNull.Value)
                     {
                         string a = Convert.ToString(row[0]);
-                        
+
                         GralBackgroundworkers.Point_3D item = new GralBackgroundworkers.Point_3D
                         {
                             FileName = a,

--- a/src/GRALDomain/Domain.resx
+++ b/src/GRALDomain/Domain.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->
@@ -10853,8 +10853,29 @@
   <data name="button57.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAIAAAD8GO2jAAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAO
-        wwAADsMBx2+oZAAAAFFJREFUSEvtzTEKACAMQ1Ev4Z29dYXSIUKgiHYpebg4pH9YMQVSR2CN+eXFOdc1
+        vwAADr8BOAVTJAAAAFFJREFUSEvtzTEKACAMQ1Ev4Z29dYXSIUKgiHYpebg4pH9YMQVSR2CN+eXFOdc1
         EP9LdK4AonMFEJ0rgOhcAUTnCiA67xp4fHHONQtUUCBhtgG/5p4IODBamwAAAABJRU5ErkJggg==
+</value>
+  </data>
+  <data name="button58.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+    <value>
+        R0lGODlhJAAkAIcAAAAAAP///wEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
+        AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEB
+        AQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQEBAQABAQAAAAAAAAAAAAAAAAEBAQEB
+        AQEBAQEBAQABAQAAAAAAAAAAAAAAAAEBAQEBAQEBAQEBAQABAQAAAAAAAAAAAAAAAAEBAQEBAQEBAQEB
+        AQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEB
+        AQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEB
+        AQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEB
+        AQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEB
+        AQEBAQABAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQAAAAEBAQEBAQEBAQAAAQEAAAEBAQEBAQEBAQAA
+        AAEBAQEBAQEBAQAAAQEBAAEBAQEBAQEBAQAAAQEBAQEBAQEBAQAAAQEBAQEBAQEBAQEBAQABAQEBAAEB
+        AQEBAQAAAAEBAQEBAQEBAQEBAQEBAQEAAAEBAQEBAQEAAAEBAQEBAQEBAQEBAQEBAQAAAAEBAQABAQEA
+        AAEBAQEBAQEBAQEBAQEBAQAAAQEBAQAAAQEAAAEBAQEBAQEBAQEBAQEBAQABAQEBAAAAAAEAAAEBAQEB
+        AQEBAQEBAQEBAQEBAQEAAAAAAAEAAAEBAQEBAQEBAQEBAQEBAQEBAQAAAAAAAQEAAAEBAQEBAQEBAQEB
+        ASH/C05FVFNDQVBFMi4wAwEBAAAh+QQAAAAAACwAAAAAJAAkAAAIjQADCBxIsKDBgwgTKlzIsKHDhxAj
+        SpxIseJAABYZAtgYYKPHjBc/euQIUqTJkiQ7ckxJ8SPBlRgruiyIkWXEmQdtPsSZU6dGnwZ5LhzZkGhR
+        o0ORHl0qESjNmDehKnQ6VWpCqletIsS6VWvPiVxVgvUalGxSplHRQhzJtm3Ysm7jjo3rFqTdu3jz6t0b
+        EAA7
 </value>
   </data>
   <metadata name="colorDialog1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">

--- a/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
+++ b/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
@@ -24,7 +24,7 @@ using GralMessage;
 namespace GralDomain
 {
     public partial class Domain
-	{
+    {
         /// <summary>
         /// Load and create contour maps
         /// </summary>
@@ -32,29 +32,29 @@ namespace GralDomain
         [System.Runtime.CompilerServices.MethodImpl(System.Runtime.CompilerServices.MethodImplOptions.AggressiveOptimization)]
 #endif
         public void Contours(string file, DrawingObjects _drobj)
-		{
-			CultureInfo ic = CultureInfo.InvariantCulture;
-			int nodata = -9999;
+        {
+            CultureInfo ic = CultureInfo.InvariantCulture;
+            int nodata = -9999;
 
-			if (ReDrawContours == true) // new contour line build blocked?
-			{
-				MessageWindow message = new MessageWindow();
-				message.Show();
-				message.listBox1.Items.Add("Calculate contour lines...");
-				message.Refresh();
-				message.listBox1.Items.Add("Reading data...");
-				Application.DoEvents();
-				
-				int nx = 0;	int ny = 0;
-				double xll = 0;	double yll = 0;	double dx = 0;
-				double [,] zlevel = new double[1,1];
-				double[,] zlevelfilter = new double[1, 1];
-				bool evaluate_terrain = false;
+            if (ReDrawContours == true) // new contour line build blocked?
+            {
+                MessageWindow message = new MessageWindow();
+                message.Show();
+                message.listBox1.Items.Add("Calculate contour lines...");
+                message.Refresh();
+                message.listBox1.Items.Add("Reading data...");
+                Application.DoEvents();
+                
+                int nx = 0;	int ny = 0;
+                double xll = 0;	double yll = 0;	double dx = 0;
+                double [,] zlevel = new double[1,1];
+                double[,] zlevelfilter = new double[1, 1];
+                bool evaluate_terrain = false;
 
                 try
-				{
-					if (file.EndsWith ("scl"))  // Stability class reader
-					{
+                {
+                    if (file.EndsWith ("scl"))  // Stability class reader
+                    {
                         ReadSclUstOblClasses reader = new ReadSclUstOblClasses
                         {
                             FileName = file,
@@ -62,70 +62,70 @@ namespace GralDomain
                         };
 
                         if (reader.ReadSclFile()) // true => reader = OK
-						{
-							zlevel = reader.Stabclasses;
+                        {
+                            zlevel = reader.Stabclasses;
                             // read NX and NY from ggeom.asc
                             GGeomFileIO ggeom = new GGeomFileIO
                             {
                                 PathWindfield = Path.GetDirectoryName(MainForm.GRAMMwindfield)
                             };
                             if (ggeom.ReadGGeomAsc(2) == true)
-							{
-								nx = ggeom.NX;
-								ny = ggeom.NY;
-							}
-							else
+                            {
+                                nx = ggeom.NX;
+                                ny = ggeom.NY;
+                            }
+                            else
                             {
                                 throw new FileNotFoundException("Error reading ggeom.asc");
                             }
 
                             ggeom = null;
-							
-							xll = MainForm.GrammDomRect.West;
-							yll = MainForm.GrammDomRect.South;
-							dx = MainForm.GRAMMHorGridSize;
+                            
+                            xll = MainForm.GrammDomRect.West;
+                            yll = MainForm.GrammDomRect.South;
+                            dx = MainForm.GRAMMHorGridSize;
 
-							zlevelfilter = new double[nx, ny];
-						}
-						else
-						{
-							throw new FileNotFoundException("Error");
-						}
-					}
-					else // Textfile reader
-					{
-						Cursor = Cursors.WaitCursor;
+                            zlevelfilter = new double[nx, ny];
+                        }
+                        else
+                        {
+                            throw new FileNotFoundException("Error");
+                        }
+                    }
+                    else // Textfile reader
+                    {
+                        Cursor = Cursors.WaitCursor;
 
-						// Read ESRI file
-						GralIO.ReadESRIFile readESRIFile = new GralIO.ReadESRIFile();
+                        // Read ESRI file
+                        GralIO.ReadESRIFile readESRIFile = new GralIO.ReadESRIFile();
 #if NET6_0_OR_GREATER
-						(zlevelfilter, GralIO.ESRIHeader header, double min, double max, string exception) = readESRIFile.ReadESRIFileMultiDim(file);
+                        (zlevelfilter, GralIO.ESRIHeader header, double min, double max, string exception) = readESRIFile.ReadESRIFileMultiDim(file);
 #else
-						double min = 0, max = 0;
-						string exception = string.Empty;
-						GralIO.ESRIHeader header = new GralIO.ESRIHeader();
-						zlevelfilter = readESRIFile.ReadESRIFileMultiDim(file, ref header, ref min, ref max, ref exception);
+                        double min = 0, max = 0;
+                        string exception = string.Empty;
+                        GralIO.ESRIHeader header = new GralIO.ESRIHeader();
+                        zlevelfilter = readESRIFile.ReadESRIFileMultiDim(file, ref header, ref min, ref max, ref exception);
 #endif
-						if (zlevelfilter == null)
-						{
-							throw new IOException(exception);
-						}
-
-						if (!_drobj.Filter)
+                        if (zlevelfilter == null)
                         {
-							zlevel = zlevelfilter;
+                            throw new IOException(exception);
                         }
-						else
-                        {
-							zlevel = new double[header.NCols, header.NRows];
-                        }
-						nx = header.NCols;
-						ny = header.NRows;
-						xll = header.XllCorner;
-						yll = header.YllCorner;
-						dx = header.Cellsize;
 
-						List<PointF> VTC_List = new List<PointF>();
+                        if (!_drobj.Filter)
+                        {
+                            zlevel = zlevelfilter;
+                        }
+                        else
+                        {
+                            zlevel = new double[header.NCols, header.NRows];
+                        }
+                        nx = header.NCols;
+                        ny = header.NRows;
+                        xll = header.XllCorner;
+                        yll = header.YllCorner;
+                        dx = header.Cellsize;
+
+                        List<PointF> VTC_List = new List<PointF>();
                         if (header.VerticalConcentrationMap) // Read if map is a vertical concentration profile
                         {
                             PointF pt1 = new PointF((float)header.XllCorner, (float)header.YllCorner);
@@ -141,15 +141,15 @@ namespace GralDomain
                         }
 
                         if (evaluate_terrain) // evaluate terrain for vertical concentration maps
-						{
-							for (int j = 0; j < nx; ++j)
-							{
-								int i = 0;
-								int terrain_index = 0;
-								while (i < ny - 1)
-								{
-									double value = 0;
-									if (_drobj.Filter == true)
+                        {
+                            for (int j = 0; j < nx; ++j)
+                            {
+                                int i = 0;
+                                int terrain_index = 0;
+                                while (i < ny - 1)
+                                {
+                                    double value = 0;
+                                    if (_drobj.Filter == true)
                                     {
                                         value = zlevelfilter[j, i];
                                     }
@@ -159,34 +159,34 @@ namespace GralDomain
                                     }
 
                                     if (Math.Abs (value - nodata) > 0.1) // Value != NODATA
-									{
-										terrain_index = i;
-										i = ny; // break
-									}
-									i++;
-								}
+                                    {
+                                        terrain_index = i;
+                                        i = ny; // break
+                                    }
+                                    i++;
+                                }
 
-								float _xh = (float) (xll + (j) * dx); // coordintaes of this terrain point
-								float _yh = (float) (yll - (ny - terrain_index) * dx);
-								PointF pt_x = new PointF(_xh, _yh);
-								VTC_List.Add (pt_x);
-							}
-							
-							_drobj.ShpPoints = VTC_List; // add terrain data to shppoints
-							//MessageBox.Show (shppoints[index][12].X.ToString () + "/" + shppoints[index][12].Y.ToString () );
-							//MessageBox.Show (shppoints[index][5].X.ToString () + "/" + shppoints[index][5].Y.ToString () );
-						} // evaluate terrain
+                                float _xh = (float) (xll + (j) * dx); // coordintaes of this terrain point
+                                float _yh = (float) (yll - (ny - terrain_index) * dx);
+                                PointF pt_x = new PointF(_xh, _yh);
+                                VTC_List.Add (pt_x);
+                            }
+                            
+                            _drobj.ShpPoints = VTC_List; // add terrain data to shppoints
+                            //MessageBox.Show (shppoints[index][12].X.ToString () + "/" + shppoints[index][12].Y.ToString () );
+                            //MessageBox.Show (shppoints[index][5].X.ToString () + "/" + shppoints[index][5].Y.ToString () );
+                        } // evaluate terrain
 
-					}
-				}
-				catch
-				{
-					MessageBox.Show(this, "Unable to open, read or process the data","Process raster data",MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
-					message.Close();
-					Cursor = Cursors.Default;
-					//picturebox1_Paint();
-					return;
-				}
+                    }
+                }
+                catch
+                {
+                    MessageBox.Show(this, "Unable to open, read or process the data","Process raster data",MessageBoxButtons.OK, MessageBoxIcon.Error, MessageBoxDefaultButton.Button1);
+                    message.Close();
+                    Cursor = Cursors.Default;
+                    //picturebox1_Paint();
+                    return;
+                }
 
                 bool[,] buildingsindex = new bool[nx, ny];
                 if (_drobj.Filter == true)
@@ -200,179 +200,179 @@ namespace GralDomain
 
                 //apply low pass filter
                 if (_drobj.Filter == true)
-				{
-					message.listBox1.Items.Add("Applying low pass filter...");
-					Application.DoEvents();
-					LowPassFilter(zlevel, zlevelfilter, buildingsindex, nx, ny, dx, xll, yll, nodata);				
-				} 
-				// no low-pass - set nodata values to 0 for vertical concentration maps
-				else if (evaluate_terrain) 
-				{
-					Parallel.For (0, nx, i => {
-						for (int j = 0; j < ny; ++j)
-						{
-							if (Math.Abs(zlevel[i, j] - nodata) < 0.001)
-							{
-								zlevel[i, j] = 0;
-							}
-						}
-					});
-				}
+                {
+                    message.listBox1.Items.Add("Applying low pass filter...");
+                    Application.DoEvents();
+                    LowPassFilter(zlevel, zlevelfilter, buildingsindex, nx, ny, dx, xll, yll, nodata);				
+                } 
+                // no low-pass - set nodata values to 0 for vertical concentration maps
+                else if (evaluate_terrain) 
+                {
+                    Parallel.For (0, nx, i => {
+                        for (int j = 0; j < ny; ++j)
+                        {
+                            if (Math.Abs(zlevel[i, j] - nodata) < 0.001)
+                            {
+                                zlevel[i, j] = 0;
+                            }
+                        }
+                    });
+                }
 
-				message.listBox1.Items.Add("Adding geometry...");
+                message.listBox1.Items.Add("Adding geometry...");
                 button56.Visible = true;
-				Application.DoEvents();
-				
-				//clear actual contourpoints
-				_drobj.ContourPoints.Clear();
-				
-				//add a Point-List for each user defined level
-				for (int k = 0; k < _drobj.ItemValues.Count; ++k)
-				{
-					_drobj.ContourPoints.Add(new List<PointF>());
-					_drobj.ContourPoints[k].Clear();
-				}
+                Application.DoEvents();
+                
+                //clear actual contourpoints
+                _drobj.ContourPoints.Clear();
+                
+                //add a Point-List for each user defined level
+                for (int k = 0; k < _drobj.ItemValues.Count; ++k)
+                {
+                    _drobj.ContourPoints.Add(new List<PointF>());
+                    _drobj.ContourPoints[k].Clear();
+                }
 
-				//save geometry information of the raster grid
-				_drobj.ContourGeometry = new DrawingObjects.ContourGeometries(xll, yll, dx, nx, ny);
+                //save geometry information of the raster grid
+                _drobj.ContourGeometry = new DrawingObjects.ContourGeometries(xll, yll, dx, nx, ny);
 
-				// simple_contour algorithm by M.Kuntner
-				if (_drobj.DrawSimpleContour)
-				{
-				    message.listBox1.Items.Add("Computing polygons...");
-					Application.DoEvents();
-					
-				    SimpleContour(zlevel, nx, ny, xll, yll, dx, message, _drobj, buildingsindex);
-				    message.Close();
-				    Cursor = Cursors.Default;
-				    ReDrawContours = false;
-				    return;
-				}
-				
-				// delete Contour Polygons, created by SimpleContour()
-				if (_drobj.ContourPolygons != null)
-				{
-					_drobj.ContourPolygons.Clear();
-					_drobj.ContourPolygons.TrimExcess();
-				}
-				
-				//define integer field for fill colors
-				if (_drobj.Fill == true)
-				{
-					// create new index if array == null or array dimension != nx or ny
-					if (_drobj.ContourColor == null || _drobj.ContourColor.GetUpperBound(0) != (nx - 1) || _drobj.ContourColor.GetUpperBound(1) != (ny - 1))
-					{
-						//MessageBox.Show(contourcolor[index].GetUpperBound(0).ToString() + "/" + contourcolor[index].GetUpperBound(1).ToString() + "/" + nx.ToString() + "/" + ny.ToString());
-						_drobj.ContourColor = new int[nx, ny];
-					}
-					
-					Parallel.For(0, nx, i =>
-		             {
-		             	for (int j = 0; j < ny; ++j)
-		             	{
-		             		_drobj.ContourColor[i, j] = -1;
-		             		for (int k = _drobj.ItemValues.Count - 1; k >= 0; --k)
-		             		{
-		             			if (zlevel[i, j] > _drobj.ItemValues[k])
-		             			{
-		             				_drobj.ContourColor[i, j] = k;
-		             				break;
-		             			}
-		             		}
-		             	}
-		             });
-				}
+                // simple_contour algorithm by M.Kuntner
+                if (_drobj.DrawSimpleContour)
+                {
+                    message.listBox1.Items.Add("Computing polygons...");
+                    Application.DoEvents();
+                    
+                    SimpleContour(zlevel, nx, ny, xll, yll, dx, message, _drobj, buildingsindex);
+                    message.Close();
+                    Cursor = Cursors.Default;
+                    ReDrawContours = false;
+                    return;
+                }
+                
+                // delete Contour Polygons, created by SimpleContour()
+                if (_drobj.ContourPolygons != null)
+                {
+                    _drobj.ContourPolygons.Clear();
+                    _drobj.ContourPolygons.TrimExcess();
+                }
+                
+                //define integer field for fill colors
+                if (_drobj.Fill == true)
+                {
+                    // create new index if array == null or array dimension != nx or ny
+                    if (_drobj.ContourColor == null || _drobj.ContourColor.GetUpperBound(0) != (nx - 1) || _drobj.ContourColor.GetUpperBound(1) != (ny - 1))
+                    {
+                        //MessageBox.Show(contourcolor[index].GetUpperBound(0).ToString() + "/" + contourcolor[index].GetUpperBound(1).ToString() + "/" + nx.ToString() + "/" + ny.ToString());
+                        _drobj.ContourColor = new int[nx, ny];
+                    }
+                    
+                    Parallel.For(0, nx, i =>
+                     {
+                        for (int j = 0; j < ny; ++j)
+                        {
+                            _drobj.ContourColor[i, j] = -1;
+                            for (int k = _drobj.ItemValues.Count - 1; k >= 0; --k)
+                            {
+                                if (zlevel[i, j] > _drobj.ItemValues[k])
+                                {
+                                    _drobj.ContourColor[i, j] = k;
+                                    break;
+                                }
+                            }
+                        }
+                     });
+                }
 
-				if (_drobj.LineWidth > 0)
-				{
-					//compute contour polygons according to Paul D. Bourke
-					//
-					//     Local declarations
-					//
-					message.listBox1.Items.Add("Computing polygons...");
-					Application.DoEvents();
-					
-					bool largeArray = false;
-					if ((nx * ny) > 200000)
+                if (_drobj.LineWidth > 0)
+                {
+                    //compute contour polygons according to Paul D. Bourke
+                    //
+                    //     Local declarations
+                    //
+                    message.listBox1.Items.Add("Computing polygons...");
+                    Application.DoEvents();
+                    
+                    bool largeArray = false;
+                    if ((nx * ny) > 200000)
                     {
                         largeArray = true; // >200.000 raster cells -> draw contour lines faster, reduce vertices
                     }
 
                     int point_counter = 0;
-					List<List<RectangleF>> unsorted = new List<List<RectangleF>>();   // unsorted lines
-					for (int k = 0; k < _drobj.ItemValues.Count; k++)
-					{
-						unsorted.Add(new List<RectangleF>());
-					}
-					
-					Object thisLock = new Object();
-					
-					int[] im = { 0, 1, 1, 0 };
-					int[] jm = { 0, 0, 1, 1 };
-					int[, ,] castab = new int[,,] { { { 0, 0, 8 }, { 0, 2, 5 }, { 7, 6, 9 } }, { { 0, 3, 4 }, { 1, 3, 1 }, { 4, 3, 0 } }, { { 9, 6, 7 }, { 5, 2, 0 }, { 8, 0, 0 } } };
-					double item_max = _drobj.ItemValues[0];
-					double item_min = _drobj.ItemValues[_drobj.ItemValues.Count - 1];
-					Application.DoEvents();
+                    List<List<RectangleF>> unsorted = new List<List<RectangleF>>();   // unsorted lines
+                    for (int k = 0; k < _drobj.ItemValues.Count; k++)
+                    {
+                        unsorted.Add(new List<RectangleF>());
+                    }
+                    
+                    Object thisLock = new Object();
+                    
+                    int[] im = { 0, 1, 1, 0 };
+                    int[] jm = { 0, 0, 1, 1 };
+                    int[, ,] castab = new int[,,] { { { 0, 0, 8 }, { 0, 2, 5 }, { 7, 6, 9 } }, { { 0, 3, 4 }, { 1, 3, 1 }, { 4, 3, 0 } }, { { 9, 6, 7 }, { 5, 2, 0 }, { 8, 0, 0 } } };
+                    double item_max = _drobj.ItemValues[0];
+                    double item_min = _drobj.ItemValues[_drobj.ItemValues.Count - 1];
+                    Application.DoEvents();
 
-					int yOffset = ny - 1;
-					if (CheckForEmptyLastRow(zlevel, nx, ny))
-					{
-						yOffset = ny - 2;
-					}
+                    int yOffset = ny - 1;
+                    if (CheckForEmptyLastRow(zlevel, nx, ny))
+                    {
+                        yOffset = ny - 2;
+                    }
 
-					Parallel.For(0, yOffset , j =>
-		            {
-		             	float[] h = new float[5];
-		             	int[] sh = new int[5];
-		             	float[] xh = new float[5];
-		             	float[] yh = new float[5];
-		             	byte m1;
-		             	byte m2;
-		             	byte m3;
-		             	int case_value;
-		             	float dmin;
-		             	float dmax;
-		             	float x1 = 0.0F;
-		             	float x2 = 0.0F;
-		             	float y1 = 0.0F;
-		             	float y2 = 0.0F;
-		             	float temp;
+                    Parallel.For(0, yOffset , j =>
+                    {
+                        float[] h = new float[5];
+                        int[] sh = new int[5];
+                        float[] xh = new float[5];
+                        float[] yh = new float[5];
+                        byte m1;
+                        byte m2;
+                        byte m3;
+                        int case_value;
+                        float dmin;
+                        float dmax;
+                        float x1 = 0.0F;
+                        float x2 = 0.0F;
+                        float y1 = 0.0F;
+                        float y2 = 0.0F;
+                        float temp;
 
-		             	//
-		             	// scan the arrays, top down, left to right within rows
-		             	//
-		             	//Application.DoEvents();
-		             	for (int i = 0; i < nx - 2; i++)
-		             	{
-		             		dmin = (float) Math.Min(Math.Min(zlevel[i, j], zlevel[i, j + 1]), Math.Min(zlevel[i + 1, j], zlevel[i + 1, j + 1]));
-		             		dmax = (float) Math.Max(Math.Max(zlevel[i, j], zlevel[i, j + 1]), Math.Max(zlevel[i + 1, j], zlevel[i + 1, j + 1]));
-		             		if ((dmax >= item_max) && (dmin <= item_min))
-		             		{
-		             			for (int k = 0; k < _drobj.ItemValues.Count; k++)
-		             			{
-		             				double contour_value = _drobj.ItemValues[k];
-		             				
-		             				if ((contour_value >= dmin) && (contour_value <= dmax))
-		             				{
-		             					byte start;
-		             					byte anz;
-		             					if (!largeArray) // small arrays - 4 triangles
-		             					{
-		             						for (Int16 m = 4; m > -1; m--)
-		             						{
-		             							if (m > 0)
-		             							{
-		             								h[m] = (float) (zlevel[i + im[m - 1], j + jm[m - 1]] - contour_value);
-		             								xh[m] = (float) (xll + (i + im[m - 1]) * dx);
-		             								yh[m] = (float) (yll + (j + jm[m - 1]) * dx);
-		             							}
-		             							else
-		             							{
-		             								h[0] = 0.25F * (h[1] + h[2] + h[3] + h[4]);
-		             								xh[0] = (float) (0.5F * (xll + (i) * dx + xll + (i + 1) * dx));
-		             								yh[0] = (float) (0.5F * (yll + (j) * dx + yll + (j + 1) * dx));
-		             							}
-		             							if (h[m] > 0)
+                        //
+                        // scan the arrays, top down, left to right within rows
+                        //
+                        //Application.DoEvents();
+                        for (int i = 0; i < nx - 2; i++)
+                        {
+                            dmin = (float) Math.Min(Math.Min(zlevel[i, j], zlevel[i, j + 1]), Math.Min(zlevel[i + 1, j], zlevel[i + 1, j + 1]));
+                            dmax = (float) Math.Max(Math.Max(zlevel[i, j], zlevel[i, j + 1]), Math.Max(zlevel[i + 1, j], zlevel[i + 1, j + 1]));
+                            if ((dmax >= item_max) && (dmin <= item_min))
+                            {
+                                for (int k = 0; k < _drobj.ItemValues.Count; k++)
+                                {
+                                    double contour_value = _drobj.ItemValues[k];
+                                    
+                                    if ((contour_value >= dmin) && (contour_value <= dmax))
+                                    {
+                                        byte start;
+                                        byte anz;
+                                        if (!largeArray) // small arrays - 4 triangles
+                                        {
+                                            for (Int16 m = 4; m > -1; m--)
+                                            {
+                                                if (m > 0)
+                                                {
+                                                    h[m] = (float) (zlevel[i + im[m - 1], j + jm[m - 1]] - contour_value);
+                                                    xh[m] = (float) (xll + (i + im[m - 1]) * dx);
+                                                    yh[m] = (float) (yll + (j + jm[m - 1]) * dx);
+                                                }
+                                                else
+                                                {
+                                                    h[0] = 0.25F * (h[1] + h[2] + h[3] + h[4]);
+                                                    xh[0] = (float) (0.5F * (xll + (i) * dx + xll + (i + 1) * dx));
+                                                    yh[0] = (float) (0.5F * (yll + (j) * dx + yll + (j + 1) * dx));
+                                                }
+                                                if (h[m] > 0)
                                                  {
                                                      sh[m] = 2;
                                                  }
@@ -385,18 +385,18 @@ namespace GralDomain
                                                      sh[m] = 1;
                                                  }
                                              }
-		             						anz = 5;
-		             						start = 1;
-		             					}
-		             					else // large aray -faster contour draw 2 triangles
-		             					{
-		             						for (byte m = 0; m < im.Length; m++)
-		             						{
-		             							h[m] = (float) (zlevel[i + im[m], j + jm[m]] - contour_value);
-		             							xh[m] = (float) (xll + (i + im[m]) * dx);
-		             							yh[m] = (float) (yll + (j + jm[m]) * dx);
-		             							
-		             							if (h[m] > 0)
+                                            anz = 5;
+                                            start = 1;
+                                        }
+                                        else // large aray -faster contour draw 2 triangles
+                                        {
+                                            for (byte m = 0; m < im.Length; m++)
+                                            {
+                                                h[m] = (float) (zlevel[i + im[m], j + jm[m]] - contour_value);
+                                                xh[m] = (float) (xll + (i + im[m]) * dx);
+                                                yh[m] = (float) (yll + (j + jm[m]) * dx);
+                                                
+                                                if (h[m] > 0)
                                                  {
                                                      sh[m] = 2;
                                                  }
@@ -427,160 +427,160 @@ namespace GralDomain
                                                  //  */
                                              }
                                              anz = 2;
-		             						start = 0;
-		             					}
-		             					
-		             					//
-		             					// Note: at this stage the relative heights of the corners and the
-		             					// centre are in the h array, and the corresponding coordinates are
-		             					// in the xh and yh arrays. The centre of the box is indexed by 0
-		             					// and the 4 corners by 1 to 4 as shown below.
-		             					// Each triangle is then indexed by the parameter m, and the 3
-		             					// vertices of each triangle are indexed by parameters m1,m2,and
-		             					// m3.
-		             					// It is assumed that the centre of the box is always vertex 2
-		             					// though this isimportant only when all 3 vertices lie exactly on
-		             					// the same contour level, in which case only the side of the box
-		             					// is drawn.
-		             					//
-		             					//
-		             					//      vertex 4 +-------------------+ vertex 3
-		             					//               | \               / |
-		             					//               |   \    m-3    /   |
-		             					//               |     \       /     |
-		             					//               |       \   /       |
-		             					//               |  m=2    X   m=2   |       the centre is vertex 0
-		             					//               |       /   \       |
-		             					//               |     /       \     |
-		             					//               |   /    m=1    \   |
-		             					//               | /               \ |
-		             					//      vertex 1 +-------------------+ vertex 2
-		             					//
-		             					//
-		             					//
-		             					//               Scan each triangle in the box
-		             					//
-		             					m1 = 0; m2 = 1;	m3 = 2;
-		             					for (byte m = start; m < anz; m++)
-		             					{
-		             						if (largeArray == false)
-		             						{
-		             							m1 = m;
-		             							m2 = 0;
-		             							if (m != 4)
-		             							{
-		             								m3 = m;
-		             								m3++;
-		             							}
-		             							else
+                                            start = 0;
+                                        }
+                                        
+                                        //
+                                        // Note: at this stage the relative heights of the corners and the
+                                        // centre are in the h array, and the corresponding coordinates are
+                                        // in the xh and yh arrays. The centre of the box is indexed by 0
+                                        // and the 4 corners by 1 to 4 as shown below.
+                                        // Each triangle is then indexed by the parameter m, and the 3
+                                        // vertices of each triangle are indexed by parameters m1,m2,and
+                                        // m3.
+                                        // It is assumed that the centre of the box is always vertex 2
+                                        // though this isimportant only when all 3 vertices lie exactly on
+                                        // the same contour level, in which case only the side of the box
+                                        // is drawn.
+                                        //
+                                        //
+                                        //      vertex 4 +-------------------+ vertex 3
+                                        //               | \               / |
+                                        //               |   \    m-3    /   |
+                                        //               |     \       /     |
+                                        //               |       \   /       |
+                                        //               |  m=2    X   m=2   |       the centre is vertex 0
+                                        //               |       /   \       |
+                                        //               |     /       \     |
+                                        //               |   /    m=1    \   |
+                                        //               | /               \ |
+                                        //      vertex 1 +-------------------+ vertex 2
+                                        //
+                                        //
+                                        //
+                                        //               Scan each triangle in the box
+                                        //
+                                        m1 = 0; m2 = 1;	m3 = 2;
+                                        for (byte m = start; m < anz; m++)
+                                        {
+                                            if (largeArray == false)
+                                            {
+                                                m1 = m;
+                                                m2 = 0;
+                                                if (m != 4)
+                                                {
+                                                    m3 = m;
+                                                    m3++;
+                                                }
+                                                else
                                                  {
                                                      m3 = 1;
                                                  }
                                              }
-		             						else
-		             						{
-		             							if (m == 1)
-		             							{
-		             								m1 = 2; m2 = 3; m3 = 0 ;
-		             							}
-		             						}
-		             						
-		             						case_value = castab[sh[m1], sh[m2], sh[m3]];
-		             						if (case_value != 0)
-		             						{
-		             							switch (case_value)
-		             							{
-		             								case 1: //line between vertices 1 and 2
-		             									x1 = xh[m1];
-		             									y1 = yh[m1];
-		             									x2 = xh[m2];
-		             									y2 = yh[m2];
-		             									break;
-		             								case 2: //line between vertices 2 and 3
-		             									x1 = xh[m2];
-		             									y1 = yh[m2];
-		             									x2 = xh[m3];
-		             									y2 = yh[m3];
-		             									break;
-		             								case 3: //line between vertices 3 and 1
-		             									x1 = xh[m3];
-		             									y1 = yh[m3];
-		             									x2 = xh[m1];
-		             									y2 = yh[m1];
-		             									break;
-		             								case 4: //line between vertex 1 and side 2-3
-		             									x1 = xh[m1];
-		             									y1 = yh[m1];
-		             									temp = 1 / (h[m3] - h[m2]);
-		             									x2 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
-		             									y2 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
-		             									break;
-		             								case 5: //line between vertex 2 and side 3-1
-		             									x1 = xh[m2];
-		             									y1 = yh[m2];
-		             									temp = 1 / (h[m1] - h[m3]);
-		             									x2 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
-		             									y2 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
-		             									break;
-		             								case 6: //line between vertex 3 and side 1-2
-		             									x1 = xh[m3];
-		             									y1 = yh[m3];
-		             									temp = 1 / (h[m2] - h[m1]);
-		             									x2 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
-		             									y2 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
-		             									break;
-		             								case 7: //line between sides 1-2 and 2-3
-		             									temp  = 1 / (h[m2] - h[m1]);
-		             									x1 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
-		             									y1 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
-		             									temp = 1 / (h[m3] - h[m2]);
-		             									x2 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
-		             									y2 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
-		             									break;
-		             								case 8: //line between sides 2-3 and 3-1
-		             									temp = 1 / (h[m3] - h[m2]);
-		             									x1 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
-		             									y1 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
-		             									temp =  1 / (h[m1] - h[m3]);
-		             									x2 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
-		             									y2 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
-		             									break;
-		             								case 9: //line between sides 3-1 and 1-2
-		             									temp = 1 / (h[m1] - h[m3]);
-		             									x1 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
-		             									y1 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
-		             									temp =  1 / (h[m2] - h[m1]);
-		             									x2 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
-		             									y2 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
-		             									break;
-		             								default:
-		             									break;
-		             							}
-		             							
-		             							RectangleF rect = new RectangleF(x1, y1, x2, y2);
-		             							lock (thisLock) // Kuntner .Add must be locked
-		             							{
-		             								unsorted[k].Add(rect);
+                                            else
+                                            {
+                                                if (m == 1)
+                                                {
+                                                    m1 = 2; m2 = 3; m3 = 0 ;
+                                                }
+                                            }
+                                            
+                                            case_value = castab[sh[m1], sh[m2], sh[m3]];
+                                            if (case_value != 0)
+                                            {
+                                                switch (case_value)
+                                                {
+                                                    case 1: //line between vertices 1 and 2
+                                                        x1 = xh[m1];
+                                                        y1 = yh[m1];
+                                                        x2 = xh[m2];
+                                                        y2 = yh[m2];
+                                                        break;
+                                                    case 2: //line between vertices 2 and 3
+                                                        x1 = xh[m2];
+                                                        y1 = yh[m2];
+                                                        x2 = xh[m3];
+                                                        y2 = yh[m3];
+                                                        break;
+                                                    case 3: //line between vertices 3 and 1
+                                                        x1 = xh[m3];
+                                                        y1 = yh[m3];
+                                                        x2 = xh[m1];
+                                                        y2 = yh[m1];
+                                                        break;
+                                                    case 4: //line between vertex 1 and side 2-3
+                                                        x1 = xh[m1];
+                                                        y1 = yh[m1];
+                                                        temp = 1 / (h[m3] - h[m2]);
+                                                        x2 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
+                                                        y2 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
+                                                        break;
+                                                    case 5: //line between vertex 2 and side 3-1
+                                                        x1 = xh[m2];
+                                                        y1 = yh[m2];
+                                                        temp = 1 / (h[m1] - h[m3]);
+                                                        x2 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
+                                                        y2 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
+                                                        break;
+                                                    case 6: //line between vertex 3 and side 1-2
+                                                        x1 = xh[m3];
+                                                        y1 = yh[m3];
+                                                        temp = 1 / (h[m2] - h[m1]);
+                                                        x2 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
+                                                        y2 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
+                                                        break;
+                                                    case 7: //line between sides 1-2 and 2-3
+                                                        temp  = 1 / (h[m2] - h[m1]);
+                                                        x1 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
+                                                        y1 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
+                                                        temp = 1 / (h[m3] - h[m2]);
+                                                        x2 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
+                                                        y2 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
+                                                        break;
+                                                    case 8: //line between sides 2-3 and 3-1
+                                                        temp = 1 / (h[m3] - h[m2]);
+                                                        x1 = (h[m3] * xh[m2] - h[m2] * xh[m3]) * temp; //xsect(m2, m3, h, xh);
+                                                        y1 = (h[m3] * yh[m2] - h[m2] * yh[m3]) * temp; //ysect(m2, m3, h, yh);
+                                                        temp =  1 / (h[m1] - h[m3]);
+                                                        x2 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
+                                                        y2 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
+                                                        break;
+                                                    case 9: //line between sides 3-1 and 1-2
+                                                        temp = 1 / (h[m1] - h[m3]);
+                                                        x1 = (h[m1] * xh[m3] - h[m3] * xh[m1]) * temp; //xsect(m3, m1, h, xh);
+                                                        y1 = (h[m1] * yh[m3] - h[m3] * yh[m1]) * temp; //ysect(m3, m1, h, yh);
+                                                        temp =  1 / (h[m2] - h[m1]);
+                                                        x2 = (h[m2] * xh[m1] - h[m1] * xh[m2]) * temp; //xsect(m1, m2, h, xh);
+                                                        y2 = (h[m2] * yh[m1] - h[m1] * yh[m2]) * temp; //ysect(m1, m2, h, yh);
+                                                        break;
+                                                    default:
+                                                        break;
+                                                }
+                                                
+                                                RectangleF rect = new RectangleF(x1, y1, x2, y2);
+                                                lock (thisLock) // Kuntner .Add must be locked
+                                                {
+                                                    unsorted[k].Add(rect);
 //														_drobj.ContourPoints[k].Add(new PointF((float)x1, (float)y1));
 //														_drobj.ContourPoints[k].Add(new PointF((float)x2, (float)y2));
-		             							}
-		             							Interlocked.Increment(ref point_counter);
-		             						}
-		             					}
-		             				}
-		             			}
-		             		}
-		             	}
-		             });
-					
-					thisLock = null;
-					
-					//MessageBox.Show(Convert.ToString(point_counter)+"/" +Convert.ToString(nx * ny));
-					List<List<PointF>> _contPts = _drobj.ContourPoints;
-					if (point_counter < 400000) // less than 400.000 line segments
-					{
-						message.listBox1.Items.Add("Sort polygons...");
-						Application.DoEvents();
+                                                }
+                                                Interlocked.Increment(ref point_counter);
+                                            }
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                     });
+                    
+                    thisLock = null;
+                    
+                    //MessageBox.Show(Convert.ToString(point_counter)+"/" +Convert.ToString(nx * ny));
+                    List<List<PointF>> _contPts = _drobj.ContourPoints;
+                    if (point_counter < 400000) // less than 400.000 line segments
+                    {
+                        message.listBox1.Items.Add("Sort polygons...");
+                        Application.DoEvents();
 
                         // conrec done! now sort and filter the lines and write to counterpoints()
                         Parallel.For(0, _drobj.ItemValues.Count, k =>
@@ -589,8 +589,7 @@ namespace GralDomain
                              double area = 0; // area of this contour line
                              int newpolygoncounter = 0;
                              firstline = Math.Max(0, Math.Min(k * 2, unsorted[k].Count - 1)); // move first point
-                                                                                              //Application.DoEvents();
-
+                             //Application.DoEvents();
                              if (unsorted[k].Count > 0)
                              {
                                  //Application.DoEvents();
@@ -609,8 +608,8 @@ namespace GralDomain
                                      int i = 0;
                                      while (i < unsorted[k].Count)
                                      {
-										 RectangleF _unsorted = unsorted[k][i];
-										 if (Math.Abs(xA - _unsorted.X) < 0.01 && Math.Abs(yA - _unsorted.Y) < 0.01)
+                                         RectangleF _unsorted = unsorted[k][i];
+                                         if (Math.Abs(xA - _unsorted.X) < 0.01 && Math.Abs(yA - _unsorted.Y) < 0.01)
                                          {
                                              _contPts[k].Add(new PointF(_unsorted.X, _unsorted.Y));
                                              xA = _unsorted.Width;
@@ -662,38 +661,42 @@ namespace GralDomain
                                  }
                              }
                         });
+
                     }
-					else // do not sort and filter > 400.000 line segments!
-					{
-						//for (int k = 0; k < itemvalue[index].Count; k++)
-						Parallel.For(0, _drobj.ItemValues.Count, k =>
-			             {
-			             	for (int i = 0; i < unsorted[k].Count ; i++)
-			             	{
-			             		_contPts[k].Add(new PointF(unsorted[k][i].X, unsorted[k][i].Y));
-			             		_contPts[k].Add(new PointF(unsorted[k][i].Width, unsorted[k][i].Height));
-			             	}
-			             	
-			             });
-					}
-				}
-				
-				message.Close();
-				Cursor = Cursors.Default;
-				//picturebox1_Paint();
+                    else // do not sort and filter > 400.000 line segments!
+                    {
+                        //for (int k = 0; k < itemvalue[index].Count; k++)
+                        Parallel.For(0, _drobj.ItemValues.Count, k =>
+                        {
+                            for (int i = 0; i < unsorted[k].Count ; i++)
+                            {
+                                _contPts[k].Add(new PointF(unsorted[k][i].X, unsorted[k][i].Y));
+                                _contPts[k].Add(new PointF(unsorted[k][i].Width, unsorted[k][i].Height));
+                            }	             	
+                        });
+                    }
+                    Parallel.For(0, _drobj.ItemValues.Count, k =>
+                    {
+                        gaussianFilter(_contPts[k], (int)_drobj.ContourFilter, _drobj.ContourTension);
+                    });
+                }
+                
+                message.Close();
+                Cursor = Cursors.Default;
+                //picturebox1_Paint();
 
-			}
-			ReDrawContours = false;
+            }
+            ReDrawContours = false;
             _drobj.Rendered = true;
-		}
+        }
 
-		//sub routine needed for contour mapping
-		readonly Func<int, int, double[], double[], double> xsect = (int p1, int p2, double[] h, double[] xh) =>
-			(h[p2] * xh[p1] - h[p1] * xh[p2]) / (h[p2] - h[p1]);
+        //sub routine needed for contour mapping
+        readonly Func<int, int, double[], double[], double> xsect = (int p1, int p2, double[] h, double[] xh) =>
+            (h[p2] * xh[p1] - h[p1] * xh[p2]) / (h[p2] - h[p1]);
 
-		//sub routine needed for contour mapping
-		readonly Func<int, int, double[], double[], double> ysect = (int p1, int p2, double[] h, double[] yh) =>
-			(h[p2] * yh[p1] - h[p1] * yh[p2]) / (h[p2] - h[p1]);
+        //sub routine needed for contour mapping
+        readonly Func<int, int, double[], double[], double> ysect = (int p1, int p2, double[] h, double[] yh) =>
+            (h[p2] * yh[p1] - h[p1] * yh[p2]) / (h[p2] - h[p1]);
 
         /// <summary>
         ///Read building.dat and set all building cells with concentration 0 to true
@@ -732,195 +735,266 @@ namespace GralDomain
             catch { }
         }
 
-		/// <summary>
+        private void gaussianFilter(List<PointF> pts, int filter, float sigma)
+        {
+            if (pts.Count > 3 && filter > 0 && sigma > 0)
+            {
+                float xA = pts[1].X;
+                float yA = pts[1].Y;
+                int start = 1;
+                int ende = 0;
+                List<PointF> ptCopy = new List<PointF>();
+                for (int i = 2; i < pts.Count - 2; i += 2)
+                {
+                    if (Math.Abs(xA - pts[i].X) < 0.01 && Math.Abs(yA - pts[i].Y) < 0.01)
+                    {
+                        xA = pts[i + 1].X;
+                        yA = pts[i + 1].Y;
+                        ende = i;
+                    }
+                    // new segment - filter this segment
+                    else if (ende - start > 3)
+                    {
+                        // copy original values
+                        ptCopy.Clear();
+                        for (int pt = start + 1; pt < ende - 2; pt += 2)
+                        {
+                            ptCopy.Add(new PointF(pts[pt].X, pts[pt].Y));
+                        }
+                        int ptCount = 0;
+                        //loop over all points of this segment
+                        for (int j = start + 1; j < ende - 2; j += 2)
+                        {
+                            double weightedSumX = 0;
+                            double weightedSumY = 0;
+                            double weightedSum = 0;
+                            //loop over all filter points
+                            int gaussStart = Math.Max(0, ptCount - filter);
+                            int gaussEnde = Math.Min(ptCopy.Count - 1, ptCount + filter);
+                            for (int pt = gaussStart; pt < gaussEnde; pt ++)
+                            {
+                                double weight = gaussianWeight((ptCount - pt) / 2, sigma);
+                                weightedSumX += ptCopy[pt].X * weight;
+                                weightedSumY += ptCopy[pt].Y * weight;
+                                weightedSum += weight;
+                            }
+                            if (weightedSum > 0)
+                            {
+                                pts[j] = new PointF((float)(weightedSumX / weightedSum), (float)(weightedSumY / weightedSum));
+                                pts[j - 1] = new PointF(pts[j].X, pts[j].Y);
+                            }
+                            ptCount++;
+                        }
+                        xA = pts[i + 1].X;
+                        yA = pts[i + 1].Y;
+                        start = i + 1;
+                        ende = 0;
+                    }
+                    else
+                    {
+                        xA = pts[i + 1].X;
+                        yA = pts[i + 1].Y;
+                        start = i + 1;
+                        ende = 0;
+                    }
+                }
+            }
+        }
+
+        private double gaussianWeight(int x, float s)
+        {
+            return (1.0F / Math.Sqrt(2 * Math.PI * s * s)) * Math.Exp(-x * x / (2.0F * s *s));
+        }
+
+        /// <summary>
         /// Apply a low pass filter to zlevel for contour lines and buildings
         /// </summary>
-		private void LowPassFilter(double[,] zlevel, double[,] zlevelfilter, bool[,] buildingsindex, int nx, int ny, double dx, double x11, double y11, int nodata)
-		{		
-			Parallel.For(0, nx , i =>
+        private void LowPassFilter(double[,] zlevel, double[,] zlevelfilter, bool[,] buildingsindex, int nx, int ny, double dx, double x11, double y11, int nodata)
+        {		
+            Parallel.For(0, nx , i =>
              {
-             	int i_p1 = i + 1;
-             	int i_p2 = i + 2;
-             	int i_m1 = i - 1;
-             	int i_m2 = i - 2;
-             	for (int j = 0; j < ny; ++j)
-             	{
-					if (i > 1 && j > 1 && i < nx -2 && j < ny - 2)
-					{
-						if (((buildingsindex[i, j] != true) || (zlevelfilter[i, j] != 0)) && Math.Abs(zlevelfilter[i, j] - nodata) > 0.001)
-	             		{
-	             			int j_p1 = j + 1;
-	             			int j_p2 = j + 2;
-	             			int j_m1 = j - 1;
-	             			int j_m2 = j - 2;
-							double _zlevel = 0;
-	  					    
-							double weighting_factor = 0;
-							double _val = zlevelfilter[i_m2, j_p2];
-							if (((buildingsindex[i_m2, j_p2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001 )
-							{
-								_zlevel = 0.354 * _val;
-								weighting_factor += 0.354;
-							}
-							_val = zlevelfilter[i_m2, j_m2];
-							if (((buildingsindex[i_m2, j_m2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.354 * _val;
-								weighting_factor += 0.354;
-							}
-							_val = zlevelfilter[i_p2, j_p2];
-							if (((buildingsindex[i_p2, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.354 * _val;
-								weighting_factor += 0.354;
-							}
-							_val = zlevelfilter[i_p2, j_m2];
-							if (((buildingsindex[i_p2, j_m2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.354 * _val;
-								weighting_factor += 0.354;
-							}
-							_val = zlevelfilter[i_m2, j_p1];
-							if (((buildingsindex[i_m2, j_p1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_m2, j_m1];
-							if (((buildingsindex[i_m2, j_m1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_p2, j_p1];
-							if (((buildingsindex[i_p2, j_p1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_p2, j_m1];
-							if (((buildingsindex[i_p2, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_m1, j_p2];
-							if (((buildingsindex[i_m1, j_p2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 *_val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_m1, j_m2];
-							if (((buildingsindex[i_m1, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_p1, j_p2];
-							if (((buildingsindex[i_p1, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i_p1, j_m2];
-							if (((buildingsindex[i_p1, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.447 * _val;
-								weighting_factor += 0.447;
-							}
-							_val = zlevelfilter[i, j_p2];
-							if (((buildingsindex[i, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.5 * _val;
-								weighting_factor += 0.5;
-							}
-							_val = zlevelfilter[i, j_m2];
-							if (((buildingsindex[i, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.5 * _val;
-								weighting_factor += 0.5;
-							}
-							_val = zlevelfilter[i_p2, j];
-							if (((buildingsindex[i_p2, j] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.5 * _val;
-								weighting_factor += 0.5;
-							}
-							_val = zlevelfilter[i_m2, j];
-							if (((buildingsindex[i_m2, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.5 * _val;
-								weighting_factor += 0.5;
-							}
-							_val = zlevelfilter[i_m1, j];
-							if (((buildingsindex[i_m1, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 1.0 * _val;
-								weighting_factor += 1.0;
-							}
-							_val = zlevelfilter[i_p1, j];
-							if (((buildingsindex[i_p1, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 1.0 * _val;
-								weighting_factor += 1.0;
-							}
-							_val = zlevelfilter[i, j_p1];
-							if (((buildingsindex[i, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 1.0 * _val;
-								weighting_factor += 1.0;
-							}
-							_val = zlevelfilter[i, j_m1];
-							if (((buildingsindex[i, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 1.0 * _val;
-								weighting_factor += 1.0;
-							}
-							_val = zlevelfilter[i_m1, j_p1];
-							if (((buildingsindex[i_m1, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.707 * _val;
-								weighting_factor += 0.707;
-							}
-							_val = zlevelfilter[i_p1, j_p1];
-							if (((buildingsindex[i_p1, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.707 * _val;
-								weighting_factor += 0.707;
-							}
-							_val = zlevelfilter[i_m1, j_m1];
-							if (((buildingsindex[i_m1, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.707 * _val;
-								weighting_factor += 0.707;
-							}
-							_val = zlevelfilter[i_p1, j_m1];
-							if (((buildingsindex[i_p1, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 0.707 * _val;
-								weighting_factor += 0.707;
-							}
-							_val = zlevelfilter[i, j];
-							if (((buildingsindex[i, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
-							{
-								_zlevel += 2.0 * _val;
-								weighting_factor += 2.0;
-							}
+                int i_p1 = i + 1;
+                int i_p2 = i + 2;
+                int i_m1 = i - 1;
+                int i_m2 = i - 2;
+                for (int j = 0; j < ny; ++j)
+                {
+                    if (i > 1 && j > 1 && i < nx -2 && j < ny - 2)
+                    {
+                        if (((buildingsindex[i, j] != true) || (zlevelfilter[i, j] != 0)) && Math.Abs(zlevelfilter[i, j] - nodata) > 0.001)
+                        {
+                            int j_p1 = j + 1;
+                            int j_p2 = j + 2;
+                            int j_m1 = j - 1;
+                            int j_m2 = j - 2;
+                            double _zlevel = 0;
+                            
+                            double weighting_factor = 0;
+                            double _val = zlevelfilter[i_m2, j_p2];
+                            if (((buildingsindex[i_m2, j_p2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001 )
+                            {
+                                _zlevel = 0.354 * _val;
+                                weighting_factor += 0.354;
+                            }
+                            _val = zlevelfilter[i_m2, j_m2];
+                            if (((buildingsindex[i_m2, j_m2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.354 * _val;
+                                weighting_factor += 0.354;
+                            }
+                            _val = zlevelfilter[i_p2, j_p2];
+                            if (((buildingsindex[i_p2, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.354 * _val;
+                                weighting_factor += 0.354;
+                            }
+                            _val = zlevelfilter[i_p2, j_m2];
+                            if (((buildingsindex[i_p2, j_m2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.354 * _val;
+                                weighting_factor += 0.354;
+                            }
+                            _val = zlevelfilter[i_m2, j_p1];
+                            if (((buildingsindex[i_m2, j_p1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_m2, j_m1];
+                            if (((buildingsindex[i_m2, j_m1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_p2, j_p1];
+                            if (((buildingsindex[i_p2, j_p1] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_p2, j_m1];
+                            if (((buildingsindex[i_p2, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_m1, j_p2];
+                            if (((buildingsindex[i_m1, j_p2] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 *_val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_m1, j_m2];
+                            if (((buildingsindex[i_m1, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_p1, j_p2];
+                            if (((buildingsindex[i_p1, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i_p1, j_m2];
+                            if (((buildingsindex[i_p1, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.447 * _val;
+                                weighting_factor += 0.447;
+                            }
+                            _val = zlevelfilter[i, j_p2];
+                            if (((buildingsindex[i, j_p2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.5 * _val;
+                                weighting_factor += 0.5;
+                            }
+                            _val = zlevelfilter[i, j_m2];
+                            if (((buildingsindex[i, j_m2] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.5 * _val;
+                                weighting_factor += 0.5;
+                            }
+                            _val = zlevelfilter[i_p2, j];
+                            if (((buildingsindex[i_p2, j] != true)  || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.5 * _val;
+                                weighting_factor += 0.5;
+                            }
+                            _val = zlevelfilter[i_m2, j];
+                            if (((buildingsindex[i_m2, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.5 * _val;
+                                weighting_factor += 0.5;
+                            }
+                            _val = zlevelfilter[i_m1, j];
+                            if (((buildingsindex[i_m1, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 1.0 * _val;
+                                weighting_factor += 1.0;
+                            }
+                            _val = zlevelfilter[i_p1, j];
+                            if (((buildingsindex[i_p1, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 1.0 * _val;
+                                weighting_factor += 1.0;
+                            }
+                            _val = zlevelfilter[i, j_p1];
+                            if (((buildingsindex[i, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 1.0 * _val;
+                                weighting_factor += 1.0;
+                            }
+                            _val = zlevelfilter[i, j_m1];
+                            if (((buildingsindex[i, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 1.0 * _val;
+                                weighting_factor += 1.0;
+                            }
+                            _val = zlevelfilter[i_m1, j_p1];
+                            if (((buildingsindex[i_m1, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.707 * _val;
+                                weighting_factor += 0.707;
+                            }
+                            _val = zlevelfilter[i_p1, j_p1];
+                            if (((buildingsindex[i_p1, j_p1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.707 * _val;
+                                weighting_factor += 0.707;
+                            }
+                            _val = zlevelfilter[i_m1, j_m1];
+                            if (((buildingsindex[i_m1, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.707 * _val;
+                                weighting_factor += 0.707;
+                            }
+                            _val = zlevelfilter[i_p1, j_m1];
+                            if (((buildingsindex[i_p1, j_m1] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 0.707 * _val;
+                                weighting_factor += 0.707;
+                            }
+                            _val = zlevelfilter[i, j];
+                            if (((buildingsindex[i, j] != true) || (_val > 0)) && Math.Abs(_val - nodata) > 0.001)
+                            {
+                                _zlevel += 2.0 * _val;
+                                weighting_factor += 2.0;
+                            }
 
-							zlevel[i, j] = _zlevel / weighting_factor;
-	             			
-						}
-						else
-						{
-							zlevel[i, j] = 0;
-						}
-					} // buildingsindex inside +- 2 cells 
-					else
-					{
-							zlevel[i, j] = zlevelfilter[i, j];
-					}
-             	}
+                            zlevel[i, j] = _zlevel / weighting_factor;
+                            
+                        }
+                        else
+                        {
+                            zlevel[i, j] = 0;
+                        }
+                    } // buildingsindex inside +- 2 cells 
+                    else
+                    {
+                            zlevel[i, j] = zlevelfilter[i, j];
+                    }
+                }
              });		    
-		}
-	}
+        }
+    }
 }

--- a/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
+++ b/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
@@ -779,7 +779,7 @@ namespace GralDomain
                             int gaussEnde = Math.Min(ptCopy.Count - 1, ptCount + filter);
                             for (int pt = gaussStart; pt < gaussEnde; pt ++)
                             {
-                                double weight = weightingFactors[Math.Max(0, Math.Min(weightingFactors.Length - 1, (ptCount - pt) / 2 - weightingMid))]; // gaussianWeight((ptCount - pt) / 2, sigma);
+                                double weight = weightingFactors[Math.Max(0, Math.Min(weightingFactors.Length - 1, weightingMid + (ptCount - pt)))]; // gaussianWeight((ptCount - pt) / 2, sigma);
                                 weightedSumX += ptCopy[pt].X * weight;
                                 weightedSumY += ptCopy[pt].Y * weight;
                                 weightedSum += weight;

--- a/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
+++ b/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
@@ -737,13 +737,19 @@ namespace GralDomain
 
         private void gaussianFilter(List<PointF> pts, int filter, float sigma)
         {
-            if (pts.Count > 3 && filter > 0 && sigma > 0)
+            if (pts.Count > 5 && filter > 0 && sigma > 0)
             {
                 float xA = pts[1].X;
                 float yA = pts[1].Y;
                 int start = 1;
                 int ende = 0;
                 List<PointF> ptCopy = new List<PointF>();
+                double[] weightingFactors = new double[2 * filter + 4];
+                int weightingMid = filter + 2;
+                for (int i = 0; i < weightingFactors.Length; i++)
+                {
+                    weightingFactors[i] = gaussianWeight((i - weightingMid), sigma);
+                }
                 for (int i = 2; i < pts.Count - 2; i += 2)
                 {
                     if (Math.Abs(xA - pts[i].X) < 0.01 && Math.Abs(yA - pts[i].Y) < 0.01)
@@ -773,7 +779,7 @@ namespace GralDomain
                             int gaussEnde = Math.Min(ptCopy.Count - 1, ptCount + filter);
                             for (int pt = gaussStart; pt < gaussEnde; pt ++)
                             {
-                                double weight = gaussianWeight((ptCount - pt) / 2, sigma);
+                                double weight = weightingFactors[Math.Max(0, Math.Min(weightingFactors.Length - 1, (ptCount - pt) / 2 - weightingMid))]; // gaussianWeight((ptCount - pt) / 2, sigma);
                                 weightedSumX += ptCopy[pt].X * weight;
                                 weightedSumY += ptCopy[pt].Y * weight;
                                 weightedSum += weight;

--- a/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
+++ b/src/GRALDomain/Domain_Contour_LoadRasterMaps.cs
@@ -577,9 +577,9 @@ namespace GralDomain
                     
                     //MessageBox.Show(Convert.ToString(point_counter)+"/" +Convert.ToString(nx * ny));
                     List<List<PointF>> _contPts = _drobj.ContourPoints;
-                    if (point_counter < 400000) // less than 400.000 line segments
+                    if (point_counter < 500000) // less than 500.000 line segments
                     {
-                        message.listBox1.Items.Add("Sort polygons...");
+                        message.listBox1.Items.Add("Sort line segments...");
                         Application.DoEvents();
 
                         // conrec done! now sort and filter the lines and write to counterpoints()
@@ -609,7 +609,7 @@ namespace GralDomain
                                      while (i < unsorted[k].Count)
                                      {
                                          RectangleF _unsorted = unsorted[k][i];
-                                         if (Math.Abs(xA - _unsorted.X) < 0.01 && Math.Abs(yA - _unsorted.Y) < 0.01)
+                                         if (Math.Abs(xA - _unsorted.X) < 0.1 && Math.Abs(yA - _unsorted.Y) < 0.1)
                                          {
                                              _contPts[k].Add(new PointF(_unsorted.X, _unsorted.Y));
                                              xA = _unsorted.Width;
@@ -618,7 +618,7 @@ namespace GralDomain
                                              area += ((xA - _unsorted.X) * _unsorted.Y + (xA - _unsorted.X) * (yA - _unsorted.Y) / 2);
 
                                              unsorted[k].RemoveAt(i);
-                                             if (Math.Abs(xA - xf) < 0.01 && Math.Abs(yA - yf) < 0.01) // contour line closed
+                                             if (Math.Abs(xA - xf) < 0.1 && Math.Abs(yA - yf) < 0.1) // contour line closed
                                              {
                                                  i = unsorted[k].Count; // start new contour line
                                              }
@@ -627,7 +627,7 @@ namespace GralDomain
                                                  i = -1; // start searching
                                              }
                                          }
-                                         else if (Math.Abs(xA - _unsorted.Width) < 0.01 && Math.Abs(yA - _unsorted.Height) < 0.01)
+                                         else if (Math.Abs(xA - _unsorted.Width) < 0.1 && Math.Abs(yA - _unsorted.Height) < 0.1)
                                          {
                                              _contPts[k].Add(new PointF(_unsorted.Width, _unsorted.Height)); // reverse order in list
                                              xA = _unsorted.X;
@@ -636,7 +636,7 @@ namespace GralDomain
                                              area += ((xA - _unsorted.Width) * _unsorted.Height + (xA - _unsorted.Width) * (yA - _unsorted.Height) / 2);
 
                                              unsorted[k].RemoveAt(i);
-                                             if (Math.Abs(xA - xf) < 0.01 && Math.Abs(yA - yf) < 0.01) // contour line closed
+                                             if (Math.Abs(xA - xf) < 0.1 && Math.Abs(yA - yf) < 0.1) // contour line closed
                                              {
                                                  i = unsorted[k].Count; // start new contour line
                                              }
@@ -661,9 +661,14 @@ namespace GralDomain
                                  }
                              }
                         });
-
+                        message.listBox1.Items.Add("Filter polylines...");
+                        Application.DoEvents();
+                        Parallel.For(0, _drobj.ItemValues.Count, k =>
+                        {
+                            gaussianFilter(_contPts[k], (int)_drobj.ContourFilter, _drobj.ContourTension);
+                        });
                     }
-                    else // do not sort and filter > 400.000 line segments!
+                    else // do not sort and filter > 500.000 line segments!
                     {
                         //for (int k = 0; k < itemvalue[index].Count; k++)
                         Parallel.For(0, _drobj.ItemValues.Count, k =>
@@ -674,11 +679,7 @@ namespace GralDomain
                                 _contPts[k].Add(new PointF(unsorted[k][i].Width, unsorted[k][i].Height));
                             }	             	
                         });
-                    }
-                    Parallel.For(0, _drobj.ItemValues.Count, k =>
-                    {
-                        gaussianFilter(_contPts[k], (int)_drobj.ContourFilter, _drobj.ContourTension);
-                    });
+                    }       
                 }
                 
                 message.Close();
@@ -752,7 +753,7 @@ namespace GralDomain
                 }
                 for (int i = 2; i < pts.Count - 2; i += 2)
                 {
-                    if (Math.Abs(xA - pts[i].X) < 0.01 && Math.Abs(yA - pts[i].Y) < 0.01)
+                    if (Math.Abs(xA - pts[i].X) < 0.1 && Math.Abs(yA - pts[i].Y) < 0.1)
                     {
                         xA = pts[i + 1].X;
                         yA = pts[i + 1].Y;
@@ -804,6 +805,8 @@ namespace GralDomain
                         ende = 0;
                     }
                 }
+                ptCopy.Clear();
+                ptCopy.TrimExcess();
             }
         }
 

--- a/src/GRALDomain/Domain_Domain_Load.cs
+++ b/src/GRALDomain/Domain_Domain_Load.cs
@@ -256,6 +256,7 @@ namespace GralDomain
             if (EditB.ItemData.Count > 0)
             {
                 button16.Visible = true;
+                button58.Visible = true;
             }
             // import Vegetation
             EditVegetation.ReloadItemData();

--- a/src/GRALDomain/DrawMap/Domain_DrawWindrose.cs
+++ b/src/GRALDomain/DrawMap/Domain_DrawWindrose.cs
@@ -135,7 +135,7 @@ namespace GralDomain
                                         {
                                             if (drawFrame)
                                             {
-                                                g.DrawPie(PenGray, new Rectangle(y0 - radius, y0- radius, radius * 2, radius * 2), startAngle, sectorAnglePie);
+                                                g.DrawPie(PenGray, new Rectangle(x0 - radius, y0- radius, radius * 2, radius * 2), startAngle, sectorAnglePie);
                                             }
                                             else
                                             {

--- a/src/GRALDomain/DrawMap/Domain_DrawWindrose.cs
+++ b/src/GRALDomain/DrawMap/Domain_DrawWindrose.cs
@@ -110,44 +110,39 @@ namespace GralDomain
                             
                             for (int n = 7; n >= 0; n--)
                             {
-                                int l = 1;
                                 for (int i = 0; i < 16; i++)
                                 {
-                                    //coordinates wind rose - drawing
-                                    int x1 = 0; int y1 = 0; int x2 = 0; int y2 = 0;
-                                    try
-                                    {
-                                        x1 = Convert.ToInt32(Math.Sin(sectorangle * i - sectorwidth) * sektsum[i] * scale);
-                                        y1 = Convert.ToInt32(Math.Cos(sectorangle * i - sectorwidth) * sektsum[i] * scale);
-                                        x2 = Convert.ToInt32(Math.Sin(sectorangle * i + sectorwidth) * sektsum[i] * scale);
-                                        y2 = Convert.ToInt32(Math.Cos(sectorangle * i + sectorwidth) * sektsum[i] * scale);
-                                    }
-                                    catch
-                                    {}
-                                    windrosepoints[i + l - 1] = new Point(x0, y0);
-                                    windrosepoints[i + l] = new Point(x0 + x1, y0 - y1);
-                                    windrosepoints[i + l + 1] = new Point(x0 + x2, y0 - y2);
-                                    windrosepoints[i + l + 2] = new Point(x0, y0);
-                                    
+                                    int radius = Convert.ToInt32(sektsum[i] * scale);
+                                    float startAngle = (float)(sectorangle * i - sectorwidth) * 180 / MathF.PI - 90;
+                                    float sectorAnglePie = (float)(sectorwidth * 2) * 180 / MathF.PI;
+
                                     if (n % 2 == 0)
                                     {
-                                        sektsum[i] = sektsum[i] - _ptList[1 + i * 4 + (int) (n / 2)].X;
+                                        sektsum[i] = sektsum[i] - _ptList[1 + i * 4 + (int)(n / 2)].X;
                                     }
                                     else
                                     {
-                                        sektsum[i] = sektsum[i] - _ptList[1 + i * 4 + (int) (n / 2)].Y;
+                                        sektsum[i] = sektsum[i] - _ptList[1 + i * 4 + (int)(n / 2)].Y;
                                     }
-                                    l += 2;
-                                }
-                                
-                                g.FillPolygon(windbrush[n], windrosepoints);
-                                if (drawFrame)
-                                {
-                                    g.DrawPolygon(PenGray, windrosepoints);
-                                }
-                                else
-                                {
-                                    g.DrawPolygon(windpen[n], windrosepoints);
+
+                                    if (radius > 0)
+                                    {
+                                        if (n >= 0 && n < windbrush.Length)
+                                        {
+                                            g.FillPie(windbrush[n], new Rectangle(x0 - radius, y0 - radius, radius * 2, radius * 2), startAngle, sectorAnglePie);
+                                        }
+                                        if (n >= 0 && n < windpen.Length)
+                                        {
+                                            if (drawFrame)
+                                            {
+                                                g.DrawPie(PenGray, new Rectangle(y0 - radius, y0- radius, radius * 2, radius * 2), startAngle, sectorAnglePie);
+                                            }
+                                            else
+                                            {
+                                                g.DrawPie(windpen[n], new Rectangle(x0- radius, y0 - radius, radius * 2, radius * 2), startAngle, sectorAnglePie);
+                                            }
+                                        }
+                                    }
                                 }
                             }
 

--- a/src/GRALIO/IO_InDat.cs
+++ b/src/GRALIO/IO_InDat.cs
@@ -10,11 +10,11 @@
 ///</remarks>
 #endregion
 
-using System;
-using System.Windows.Forms;
-using System.IO;
-using System.Globalization;
 using GralStaticFunctions;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Forms;
 
 namespace GralIO
 {
@@ -127,6 +127,8 @@ namespace GralIO
                     }
 
                     myWriter.WriteLine(_data.AVX512Usage.ToString(ic) + "\t ! Use the AVX512 instructions Yes = 1, No = 0");
+                    int reproducibleResults = _data.ReproducibleResults == true ? 1 : 0;
+                    myWriter.WriteLine(reproducibleResults.ToString(ic) + "\t ! Use the GRAL reproducible results option Yes = 1, No = 0");
                 }
 
             }
@@ -343,6 +345,21 @@ namespace GralIO
                             if (int.TryParse(text[0], NumberStyles.Any, ic, out int _val))
                             {
                                 _data.AVX512Usage = Convert.ToInt32(_val);
+                            }
+                        }
+                    }
+
+                    _data.ReproducibleResults = false;
+                    if (myreader.EndOfStream == false) // read reproducible results option
+                    {
+                        int reproducibleResults = _data.ReproducibleResults == true ? 1 : 0;  
+                        text = myreader.ReadLine().Split(new char[] { ',', '!', ' ' });
+                        if (text.Length > 0)
+                        {
+                            if (int.TryParse(text[0], NumberStyles.Any, ic, out int _val))
+                            {
+                                reproducibleResults = Convert.ToInt32(_val);
+                                _data.ReproducibleResults = reproducibleResults == 1;
                             }
                         }
                     }

--- a/src/GRALIO/IO_InDatData.cs
+++ b/src/GRALIO/IO_InDatData.cs
@@ -216,7 +216,12 @@ namespace GralIO
         /// </summary>
         public int AVX512Usage  { get; set; }
 
-    public InDatVariables()
+        public bool ReproducibleResults { get; set; }
+        /// <summary>
+        ///GRAL reproducible results option
+        /// </summary>
+
+        public InDatVariables()
         {
             InDatPath = String.Empty;
             ParticleNumber = 100;
@@ -242,6 +247,7 @@ namespace GralIO
             AdaptiveRoughness = 0;
             PrognosticSubDomainsSizeSourceRadius = 0;
             AVX512Usage = 0;
+            ReproducibleResults = false;
         }
 
         public InDatVariables(InDatVariables other)
@@ -273,6 +279,7 @@ namespace GralIO
             PrognosticSubDomainsSizeSourceRadius = other.PrognosticSubDomainsSizeSourceRadius;
             UseGRALOnlineFunctions = other.UseGRALOnlineFunctions;
             AVX512Usage = other.AVX512Usage;
+            ReproducibleResults = other.ReproducibleResults;   
         }
 
     }

--- a/src/GRALItemForms/EditLineSources.cs
+++ b/src/GRALItemForms/EditLineSources.cs
@@ -1230,9 +1230,11 @@ namespace GralItemForms
                 string sg_name = listBox2.SelectedItem.ToString();
                 int sg_nr = St_F.GetSgNumber(sg_name);
                 int indexold = GetPollutantListIndex(sg_nr);
-
-                SourceGroupEmission.RemoveAt(indexold);
-                listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+                if (indexold >= 0)
+                {
+                    SourceGroupEmission.RemoveAt(indexold);
+                    listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+                }
             }
             SaveArray(true);
             // fill in new values

--- a/src/GRALItemForms/EditPortalSources.cs
+++ b/src/GRALItemForms/EditPortalSources.cs
@@ -1123,9 +1123,11 @@ namespace GralItemForms
                 string sg_name = listBox2.SelectedItem.ToString();
                 int sg_nr = St_F.GetSgNumber(sg_name);
                 int indexold = GetPollutantListIndex(sg_nr);
-                
-                SourceGroupEmission.RemoveAt(indexold);
-                listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+                if (indexold >= 0)
+                {
+                    SourceGroupEmission.RemoveAt(indexold);
+                    listBox2.Items.RemoveAt(listBox2.SelectedIndex);
+                }
             }
             SaveArray(true);
             // fill in new values

--- a/src/GRALItemForms/LayoutManager.Designer.cs
+++ b/src/GRALItemForms/LayoutManager.Designer.cs
@@ -803,10 +803,10 @@
             // 
             // label12
             // 
-            label12.Location = new System.Drawing.Point(12, 24);
+            label12.Location = new System.Drawing.Point(388, 491);
             label12.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label12.Name = "label12";
-            label12.Size = new System.Drawing.Size(117, 15);
+            label12.Size = new System.Drawing.Size(141, 17);
             label12.TabIndex = 39;
             label12.Text = "Filter Lines [m]";
             label12.Visible = false;
@@ -815,7 +815,7 @@
             // 
             numericUpDown7.DecimalPlaces = 1;
             numericUpDown7.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
-            numericUpDown7.Location = new System.Drawing.Point(10, 43);
+            numericUpDown7.Location = new System.Drawing.Point(386, 510);
             numericUpDown7.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             numericUpDown7.Maximum = new decimal(new int[] { 50, 0, 0, 0 });
             numericUpDown7.Name = "numericUpDown7";
@@ -823,13 +823,14 @@
             numericUpDown7.TabIndex = 18;
             numericUpDown7.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             numericUpDown7.Value = new decimal(new int[] { 1, 0, 0, 65536 });
+            numericUpDown7.Visible = false;
             // 
             // label13
             // 
-            label13.Location = new System.Drawing.Point(12, 74);
+            label13.Location = new System.Drawing.Point(389, 539);
             label13.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label13.Name = "label13";
-            label13.Size = new System.Drawing.Size(117, 15);
+            label13.Size = new System.Drawing.Size(140, 17);
             label13.TabIndex = 41;
             label13.Text = "Spline Tension";
             label13.Visible = false;
@@ -838,7 +839,7 @@
             // 
             numericUpDown8.DecimalPlaces = 1;
             numericUpDown8.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
-            numericUpDown8.Location = new System.Drawing.Point(9, 92);
+            numericUpDown8.Location = new System.Drawing.Point(386, 557);
             numericUpDown8.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             numericUpDown8.Maximum = new decimal(new int[] { 1, 0, 0, 0 });
             numericUpDown8.Name = "numericUpDown8";
@@ -846,6 +847,7 @@
             numericUpDown8.TabIndex = 19;
             numericUpDown8.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
             numericUpDown8.Value = new decimal(new int[] { 1, 0, 0, 65536 });
+            numericUpDown8.Visible = false;
             // 
             // label14
             // 
@@ -895,7 +897,7 @@
             // 
             // label3
             // 
-            label3.Location = new System.Drawing.Point(13, 127);
+            label3.Location = new System.Drawing.Point(11, 21);
             label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             label3.Name = "label3";
             label3.Size = new System.Drawing.Size(117, 15);
@@ -905,7 +907,7 @@
             // 
             // numericUpDown10
             // 
-            numericUpDown10.Location = new System.Drawing.Point(10, 145);
+            numericUpDown10.Location = new System.Drawing.Point(8, 39);
             numericUpDown10.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             numericUpDown10.Maximum = new decimal(new int[] { 60, 0, 0, 0 });
             numericUpDown10.Name = "numericUpDown10";
@@ -916,16 +918,12 @@
             // groupBox6
             // 
             groupBox6.Controls.Add(label3);
-            groupBox6.Controls.Add(numericUpDown7);
             groupBox6.Controls.Add(numericUpDown10);
-            groupBox6.Controls.Add(label12);
-            groupBox6.Controls.Add(numericUpDown8);
-            groupBox6.Controls.Add(label13);
-            groupBox6.Location = new System.Drawing.Point(388, 491);
+            groupBox6.Location = new System.Drawing.Point(387, 600);
             groupBox6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             groupBox6.Name = "groupBox6";
             groupBox6.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            groupBox6.Size = new System.Drawing.Size(141, 181);
+            groupBox6.Size = new System.Drawing.Size(141, 72);
             groupBox6.TabIndex = 48;
             groupBox6.TabStop = false;
             groupBox6.Text = "Spline Lines";
@@ -979,9 +977,13 @@
             ClientSize = new System.Drawing.Size(539, 831);
             ControlBox = false;
             Controls.Add(groupBox7);
+            Controls.Add(numericUpDown7);
+            Controls.Add(numericUpDown8);
+            Controls.Add(label13);
             Controls.Add(groupBox6);
             Controls.Add(groupBox5);
             Controls.Add(checkBox7);
+            Controls.Add(label12);
             Controls.Add(checkBox6);
             Controls.Add(radioButton2);
             Controls.Add(radioButton1);

--- a/src/GRALItemForms/LayoutManager.cs
+++ b/src/GRALItemForms/LayoutManager.cs
@@ -211,7 +211,7 @@ namespace GralItemForms
                         numericUpDown7.Increment = 1;
                         numericUpDown7.Value = (decimal)(Math.Round(DrawObject.ContourFilter, 0));
                         label13.Text = "Filter sigma";
-                        numericUpDown8.Maximum = 3;
+                        numericUpDown8.Maximum = 10;
                     }
                     radioButton1.Visible = true;
                     radioButton2.Visible = true;
@@ -2554,7 +2554,7 @@ namespace GralItemForms
                     numericUpDown7.Value = 0;
                     numericUpDown7.DecimalPlaces = 0;
                     numericUpDown7.Increment = 1;
-                    numericUpDown8.Maximum = 3;
+                    numericUpDown8.Maximum = 10;
                 }
                 checkBox6.Enabled = false;
                 groupBox6.Enabled = false;

--- a/src/GRALItemForms/LayoutManager.cs
+++ b/src/GRALItemForms/LayoutManager.cs
@@ -199,21 +199,29 @@ namespace GralItemForms
                         radioButton2.Checked = true;
                         checkBox6.Enabled = true;
                         groupBox6.Enabled = true;
+                        numericUpDown7.Value = (decimal)(Math.Round(DrawObject.ContourFilter, 1));
                     }
                     else
                     {
                         radioButton1.Checked = true;
                         checkBox6.Enabled = false;
                         groupBox6.Enabled = false;
+                        label12.Text = "Number of filter points";
+                        numericUpDown7.DecimalPlaces = 0;
+                        numericUpDown7.Increment = 1;
+                        numericUpDown7.Value = (decimal)(Math.Round(DrawObject.ContourFilter, 0));
+                        label13.Text = "Filter sigma";
+                        numericUpDown8.Maximum = 3;
                     }
                     radioButton1.Visible = true;
                     radioButton2.Visible = true;
                     checkBox6.Visible = true;
 
+                    numericUpDown8.Visible = true;
+                    numericUpDown7.Visible = true;
                     label12.Visible = true;
                     label13.Visible = true;
                     checkBox6.Checked = DrawObject.ContourDrawBorder;
-                    numericUpDown7.Value = (decimal)(Math.Round(DrawObject.ContourFilter, 1));
                     numericUpDown8.Value = (decimal)(Math.Round(DrawObject.ContourTension, 1));
                     numericUpDown10.Value = (decimal)(DrawObject.RemoveSpikes);
                     groupBox6.Visible = true;
@@ -2540,6 +2548,13 @@ namespace GralItemForms
                 {
                     DrawObject.DrawSimpleContour = false;
                     domain.ReDrawContours = true;
+                    label12.Text = "Number of filter points";
+                    label13.Text = "Filter sigma value";
+                    numericUpDown7.Enabled = true;
+                    numericUpDown7.Value = 0;
+                    numericUpDown7.DecimalPlaces = 0;
+                    numericUpDown7.Increment = 1;
+                    numericUpDown8.Maximum = 3;
                 }
                 checkBox6.Enabled = false;
                 groupBox6.Enabled = false;
@@ -2559,6 +2574,14 @@ namespace GralItemForms
                 {
                     DrawObject.DrawSimpleContour = true;
                     domain.ReDrawContours = true;
+                    label12.Text = "Filter lines [m]";
+                    label13.Text = "Spline Tension";
+                    numericUpDown7.Enabled = true;
+                    numericUpDown7.Value = 0.1M;
+                    numericUpDown7.DecimalPlaces = 1;
+                    numericUpDown7.Increment = 0.1M;
+                    numericUpDown8.Value = 0.1M;
+                    numericUpDown8.Maximum = 1;
                 }
                 checkBox6.Enabled = true;
                 groupBox6.Enabled = true;

--- a/src/GRALItemForms/LayoutManager.resx
+++ b/src/GRALItemForms/LayoutManager.resx
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
   <!--
-    Microsoft ResX Schema 
+    Microsoft ResX Schema
 
     Version 2.0
 
@@ -48,7 +48,7 @@
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
-    
+
     mimetype: application/x-microsoft.net.object.soap.base64
     value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter

--- a/src/GRALMainFunctions/Main_AnalyzingTools.cs
+++ b/src/GRALMainFunctions/Main_AnalyzingTools.cs
@@ -386,6 +386,10 @@ namespace Gral
                         sel_sg.checkBox1.Visible = false;
                         sel_sg.checkBox2.Visible = false;
                         sel_sg.checkBox3.Visible = false;
+                        if (numericUpDown4.Value < 3600)
+                        {
+                            sel_sg.EnableHourlyMeanValuesCheckbox = true;
+                        }
                         sel_sg.Prefix = FilePrefix;
 
                         if (sel_sg.ShowDialog() == DialogResult.OK)
@@ -442,6 +446,7 @@ namespace Gral
                                 DataCollection.UserText += Environment.NewLine + "The process may take some minutes";
 
                                 DataCollection.BackgroundWorkerFunction = GralBackgroundworkers.BWMode.HighPercentiles; // 40 = compute high percentils
+                                DataCollection.SubHourlyToMeanHourlyConcentrations = sel_sg.HourlyMeanValuesChecked;
 
                                 GralBackgroundworkers.ProgressFormBackgroundworker BackgroundStart = new GralBackgroundworkers.ProgressFormBackgroundworker(DataCollection)
                                 {
@@ -479,6 +484,10 @@ namespace Gral
                         sel_sg.checkBox1.Visible = false;
                         sel_sg.checkBox2.Visible = false;
                         sel_sg.checkBox3.Visible = false;
+                        if (numericUpDown4.Value < 3600)
+                        {
+                            sel_sg.EnableHourlyMeanValuesCheckbox = true;
+                        }
                         sel_sg.Prefix = FilePrefix;
 
                         if (sel_sg.ShowDialog() == DialogResult.OK)
@@ -601,6 +610,8 @@ namespace Gral
                                             }
                                         }
                                         catch { }
+
+                                        DataCollection.SubHourlyToMeanHourlyConcentrations = sel_sg.HourlyMeanValuesChecked;
 
                                         GralBackgroundworkers.ProgressFormBackgroundworker BackgroundStart = new GralBackgroundworkers.ProgressFormBackgroundworker(DataCollection)
                                         {

--- a/src/GRALMainFunctions/Main_AnalyzingTools.cs
+++ b/src/GRALMainFunctions/Main_AnalyzingTools.cs
@@ -675,7 +675,10 @@ namespace Gral
                                     WriteGralLogFile(2, DataCollection.UserText, DataCollection.Caption); // Write Gral-Logfile
                                     DataCollection.UserText += Environment.NewLine + "Result file name: Mean_Odour_" + sel_sg.Prefix + DataCollection.Pollutant + "_..._" + DataCollection.Slicename;
                                     DataCollection.UserText += Environment.NewLine + "The process may take some minutes";
-
+                                    DataCollection.PathEmissionModulation = sel_sg.PathToEmissionModulation;
+                                    DataCollection.PathEvaluationResults = ProjectSetting.EvaluationPath;
+                                    DataCollection.SubHourlyToMeanHourlyConcentrations = sel_sg.HourlyMeanValuesChecked;
+                                    DataCollection.SubHourlyTimeSpan = (int)numericUpDown4.Value;
                                     DataCollection.BackgroundWorkerFunction = GralBackgroundworkers.BWMode.OdorConcentrationPercentile; // 23 = Compute Odour concentration percentiles
 
                                     //check if GRAL simulations were carried out in transient mode

--- a/src/GRALMainFunctions/Main_AnalyzingTools.cs
+++ b/src/GRALMainFunctions/Main_AnalyzingTools.cs
@@ -386,7 +386,7 @@ namespace Gral
                         sel_sg.checkBox1.Visible = false;
                         sel_sg.checkBox2.Visible = false;
                         sel_sg.checkBox3.Visible = false;
-                        if (numericUpDown4.Value < 3600)
+                        if (numericUpDown4.Value < 3600 && (3600 / numericUpDown4.Value) == (int) (3600 / numericUpDown4.Value))
                         {
                             sel_sg.EnableHourlyMeanValuesCheckbox = true;
                         }
@@ -447,6 +447,7 @@ namespace Gral
 
                                 DataCollection.BackgroundWorkerFunction = GralBackgroundworkers.BWMode.HighPercentiles; // 40 = compute high percentils
                                 DataCollection.SubHourlyToMeanHourlyConcentrations = sel_sg.HourlyMeanValuesChecked;
+                                DataCollection.SubHourlyTimeSpan = (int) numericUpDown4.Value;
 
                                 GralBackgroundworkers.ProgressFormBackgroundworker BackgroundStart = new GralBackgroundworkers.ProgressFormBackgroundworker(DataCollection)
                                 {
@@ -612,6 +613,7 @@ namespace Gral
                                         catch { }
 
                                         DataCollection.SubHourlyToMeanHourlyConcentrations = sel_sg.HourlyMeanValuesChecked;
+                                        DataCollection.SubHourlyTimeSpan = (int)numericUpDown4.Value;
 
                                         GralBackgroundworkers.ProgressFormBackgroundworker BackgroundStart = new GralBackgroundworkers.ProgressFormBackgroundworker(DataCollection)
                                         {

--- a/src/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/src/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -320,7 +320,7 @@ namespace Gral
             {
                 version = version.Substring(0, 2) + "." + version.Substring(2);
             }
-            g.DrawString("GRAL GUI V" + version + " RC2 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+            g.DrawString("GRAL GUI V" + version + " - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
 #if __MonoCS__
             g.DrawString("Compiled for Linux - MONO", subtitlefont, Solid_blue, x, 25 + distance, format1);
 #else

--- a/src/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/src/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -320,7 +320,7 @@ namespace Gral
             {
                 version = version.Substring(0, 2) + "." + version.Substring(2);
             }
-            g.DrawString("GRAL GUI V" + version + " Beta1 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+            g.DrawString("GRAL GUI V" + version + " Beta2 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
 #if __MonoCS__
             g.DrawString("Compiled for Linux - MONO", subtitlefont, Solid_blue, x, 25 + distance, format1);
 #else

--- a/src/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/src/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -320,7 +320,7 @@ namespace Gral
             {
                 version = version.Substring(0, 2) + "." + version.Substring(2);
             }
-            g.DrawString("GRAL GUI V" + version + " - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+            g.DrawString("GRAL GUI V" + version + " Beta1 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
 #if __MonoCS__
             g.DrawString("Compiled for Linux - MONO", subtitlefont, Solid_blue, x, 25 + distance, format1);
 #else

--- a/src/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/src/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -320,7 +320,7 @@ namespace Gral
             {
                 version = version.Substring(0, 2) + "." + version.Substring(2);
             }
-            g.DrawString("GRAL GUI V" + version + " RC1 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+            g.DrawString("GRAL GUI V" + version + " RC2 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
 #if __MonoCS__
             g.DrawString("Compiled for Linux - MONO", subtitlefont, Solid_blue, x, 25 + distance, format1);
 #else

--- a/src/GRALMainFunctions/Main_DrawModulationPreview.cs
+++ b/src/GRALMainFunctions/Main_DrawModulationPreview.cs
@@ -320,7 +320,7 @@ namespace Gral
             {
                 version = version.Substring(0, 2) + "." + version.Substring(2);
             }
-            g.DrawString("GRAL GUI V" + version + " Beta2 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
+            g.DrawString("GRAL GUI V" + version + " RC1 - Graz Lagrangian Model", titlefont, Solid_blue, x, 25, format1);
 #if __MonoCS__
             g.DrawString("Compiled for Linux - MONO", subtitlefont, Solid_blue, x, 25 + distance, format1);
 #else

--- a/src/GRALMainSubForms/Main_SpecialSettings.Designer.cs
+++ b/src/GRALMainSubForms/Main_SpecialSettings.Designer.cs
@@ -28,278 +28,278 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Main_SpecialSettings));
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            this.label1 = new System.Windows.Forms.Label();
-            this.checkBox2 = new System.Windows.Forms.CheckBox();
-            this.button1 = new System.Windows.Forms.Button();
-            this.button2 = new System.Windows.Forms.Button();
-            this.checkBox3 = new System.Windows.Forms.CheckBox();
-            this.label2 = new System.Windows.Forms.Label();
-            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.checkBox4 = new System.Windows.Forms.CheckBox();
-            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.checkBox5 = new System.Windows.Forms.CheckBox();
-            this.groupBox1.SuspendLayout();
-            this.groupBox2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
-            this.groupBox3.SuspendLayout();
-            this.SuspendLayout();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            checkBox1 = new System.Windows.Forms.CheckBox();
+            groupBox2 = new System.Windows.Forms.GroupBox();
+            numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            label1 = new System.Windows.Forms.Label();
+            checkBox2 = new System.Windows.Forms.CheckBox();
+            button1 = new System.Windows.Forms.Button();
+            button2 = new System.Windows.Forms.Button();
+            checkBox3 = new System.Windows.Forms.CheckBox();
+            label2 = new System.Windows.Forms.Label();
+            numericUpDown2 = new System.Windows.Forms.NumericUpDown();
+            toolTip1 = new System.Windows.Forms.ToolTip(components);
+            checkBox4 = new System.Windows.Forms.CheckBox();
+            numericUpDown3 = new System.Windows.Forms.NumericUpDown();
+            checkBox5 = new System.Windows.Forms.CheckBox();
+            checkBox6 = new System.Windows.Forms.CheckBox();
+            groupBox3 = new System.Windows.Forms.GroupBox();
+            label3 = new System.Windows.Forms.Label();
+            groupBox1.SuspendLayout();
+            groupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown1).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown2).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown3).BeginInit();
+            groupBox3.SuspendLayout();
+            SuspendLayout();
             // 
             // groupBox1
             // 
-            this.groupBox1.Controls.Add(this.checkBox1);
-            this.groupBox1.Location = new System.Drawing.Point(15, 15);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Size = new System.Drawing.Size(290, 56);
-            this.groupBox1.TabIndex = 0;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Write additional ASCii result files";
+            groupBox1.Controls.Add(checkBox1);
+            groupBox1.Location = new System.Drawing.Point(18, 17);
+            groupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Size = new System.Drawing.Size(338, 65);
+            groupBox1.TabIndex = 0;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Write additional ASCii result files";
             // 
             // checkBox1
             // 
-            this.checkBox1.AutoSize = true;
-            this.checkBox1.Location = new System.Drawing.Point(10, 22);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(71, 17);
-            this.checkBox1.TabIndex = 0;
-            this.checkBox1.Text = "Activated";
-            this.toolTip1.SetToolTip(this.checkBox1, "Write result files in ASCii format");
-            this.checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.AutoSize = true;
+            checkBox1.Location = new System.Drawing.Point(12, 25);
+            checkBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new System.Drawing.Size(76, 19);
+            checkBox1.TabIndex = 0;
+            checkBox1.Text = "Activated";
+            toolTip1.SetToolTip(checkBox1, "Write result files in ASCii format");
+            checkBox1.UseVisualStyleBackColor = true;
             // 
             // groupBox2
             // 
-            this.groupBox2.Controls.Add(this.numericUpDown1);
-            this.groupBox2.Controls.Add(this.label1);
-            this.groupBox2.Controls.Add(this.checkBox2);
-            this.groupBox2.Location = new System.Drawing.Point(15, 86);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Size = new System.Drawing.Size(290, 85);
-            this.groupBox2.TabIndex = 1;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Read temp. transient files when restarting with situation 1";
+            groupBox2.Controls.Add(numericUpDown1);
+            groupBox2.Controls.Add(label1);
+            groupBox2.Controls.Add(checkBox2);
+            groupBox2.Location = new System.Drawing.Point(18, 99);
+            groupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Size = new System.Drawing.Size(338, 98);
+            groupBox2.TabIndex = 1;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Read temp. transient files when restarting with situation 1";
             // 
             // numericUpDown1
             // 
-            this.numericUpDown1.Location = new System.Drawing.Point(176, 48);
-            this.numericUpDown1.Maximum = new decimal(new int[] {
-            240,
-            0,
-            0,
-            0});
-            this.numericUpDown1.Minimum = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(46, 20);
-            this.numericUpDown1.TabIndex = 3;
-            this.numericUpDown1.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            numericUpDown1.Location = new System.Drawing.Point(205, 55);
+            numericUpDown1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown1.Maximum = new decimal(new int[] { 240, 0, 0, 0 });
+            numericUpDown1.Minimum = new decimal(new int[] { 1, 0, 0, 0 });
+            numericUpDown1.Name = "numericUpDown1";
+            numericUpDown1.Size = new System.Drawing.Size(54, 23);
+            numericUpDown1.TabIndex = 3;
+            numericUpDown1.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // label1
             // 
-            this.label1.AutoSize = true;
-            this.label1.Location = new System.Drawing.Point(7, 50);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(151, 13);
-            this.label1.TabIndex = 2;
-            this.label1.Text = "Save interval of temporary files";
+            label1.AutoSize = true;
+            label1.Location = new System.Drawing.Point(8, 58);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(169, 15);
+            label1.TabIndex = 2;
+            label1.Text = "Save interval of temporary files";
             // 
             // checkBox2
             // 
-            this.checkBox2.AutoSize = true;
-            this.checkBox2.Location = new System.Drawing.Point(10, 22);
-            this.checkBox2.Name = "checkBox2";
-            this.checkBox2.Size = new System.Drawing.Size(71, 17);
-            this.checkBox2.TabIndex = 1;
-            this.checkBox2.Text = "Activated";
-            this.toolTip1.SetToolTip(this.checkBox2, "Override the default continuation of a calculation and start a calculation again " +
-        "with\r\nSituation 1 by reusing the temporary concentration ");
-            this.checkBox2.UseVisualStyleBackColor = true;
+            checkBox2.AutoSize = true;
+            checkBox2.Location = new System.Drawing.Point(12, 25);
+            checkBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox2.Name = "checkBox2";
+            checkBox2.Size = new System.Drawing.Size(76, 19);
+            checkBox2.TabIndex = 1;
+            checkBox2.Text = "Activated";
+            toolTip1.SetToolTip(checkBox2, "Override the default continuation of a calculation and start a calculation again with\r\nSituation 1 by reusing the temporary concentration ");
+            checkBox2.UseVisualStyleBackColor = true;
             // 
             // button1
             // 
-            this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.button1.Location = new System.Drawing.Point(15, 392);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(90, 29);
-            this.button1.TabIndex = 2;
-            this.button1.Text = "&OK";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            button1.DialogResult = System.Windows.Forms.DialogResult.OK;
+            button1.Location = new System.Drawing.Point(18, 488);
+            button1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(105, 33);
+            button1.TabIndex = 2;
+            button1.Text = "&OK";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
             // 
             // button2
             // 
-            this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(215, 392);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(90, 29);
-            this.button2.TabIndex = 2;
-            this.button2.Text = "&Cancel";
-            this.button2.UseVisualStyleBackColor = true;
+            button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            button2.Location = new System.Drawing.Point(251, 488);
+            button2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            button2.Name = "button2";
+            button2.Size = new System.Drawing.Size(105, 33);
+            button2.TabIndex = 2;
+            button2.Text = "&Cancel";
+            button2.UseVisualStyleBackColor = true;
             // 
             // checkBox3
             // 
-            this.checkBox3.AutoSize = true;
-            this.checkBox3.Checked = true;
-            this.checkBox3.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 3.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter);
-            this.checkBox3.Location = new System.Drawing.Point(15, 323);
-            this.checkBox3.Name = "checkBox3";
-            this.checkBox3.Size = new System.Drawing.Size(201, 20);
-            this.checkBox3.TabIndex = 60;
-            this.checkBox3.Text = "Keystroke when exiting GRAL";
-            this.toolTip1.SetToolTip(this.checkBox3, "Wait for a keystroke at the end of a calculation");
-            this.checkBox3.UseVisualStyleBackColor = true;
-            this.checkBox3.CheckedChanged += new System.EventHandler(this.checkBox3_CheckedChanged);
+            checkBox3.AutoSize = true;
+            checkBox3.Checked = true;
+            checkBox3.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox3.Font = new System.Drawing.Font("Microsoft Sans Serif", 3.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter);
+            checkBox3.Location = new System.Drawing.Point(18, 373);
+            checkBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox3.Name = "checkBox3";
+            checkBox3.Size = new System.Drawing.Size(200, 20);
+            checkBox3.TabIndex = 60;
+            checkBox3.Text = "Keystroke when exiting GRAL";
+            toolTip1.SetToolTip(checkBox3, "Wait for a keystroke at the end of a calculation");
+            checkBox3.UseVisualStyleBackColor = true;
+            checkBox3.CheckedChanged += checkBox3_CheckedChanged;
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(22, 294);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(50, 13);
-            this.label2.TabIndex = 2;
-            this.label2.Text = "Log level";
+            label2.AutoSize = true;
+            label2.Location = new System.Drawing.Point(26, 339);
+            label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(54, 15);
+            label2.TabIndex = 2;
+            label2.Text = "Log level";
             // 
             // numericUpDown2
             // 
-            this.numericUpDown2.Location = new System.Drawing.Point(89, 292);
-            this.numericUpDown2.Maximum = new decimal(new int[] {
-            3,
-            0,
-            0,
-            0});
-            this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(46, 20);
-            this.numericUpDown2.TabIndex = 3;
-            this.toolTip1.SetToolTip(this.numericUpDown2, "Enables an additional output for troubleshooting or for checking the internal par" +
-        "ticle assignment\r\nand the number of reflections or time loops. This value is not" +
-        " stored.");
+            numericUpDown2.Location = new System.Drawing.Point(104, 337);
+            numericUpDown2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown2.Maximum = new decimal(new int[] { 3, 0, 0, 0 });
+            numericUpDown2.Name = "numericUpDown2";
+            numericUpDown2.Size = new System.Drawing.Size(54, 23);
+            numericUpDown2.TabIndex = 3;
+            toolTip1.SetToolTip(numericUpDown2, "Enables an additional output for troubleshooting or for checking the internal particle assignment\r\nand the number of reflections or time loops. This value is not stored.");
             // 
             // checkBox4
             // 
-            this.checkBox4.AutoSize = true;
-            this.checkBox4.Location = new System.Drawing.Point(10, 25);
-            this.checkBox4.Name = "checkBox4";
-            this.checkBox4.Size = new System.Drawing.Size(71, 17);
-            this.checkBox4.TabIndex = 1;
-            this.checkBox4.Text = "Activated";
-            this.toolTip1.SetToolTip(this.checkBox4, "Override the default continuation of a calculation and start a calculation again " +
-        "with\r\nSituation 1 by reusing the temporary concentration ");
-            this.checkBox4.UseVisualStyleBackColor = true;
-            this.checkBox4.CheckedChanged += new System.EventHandler(this.checkBox4_CheckedChanged);
+            checkBox4.AutoSize = true;
+            checkBox4.Location = new System.Drawing.Point(12, 29);
+            checkBox4.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox4.Name = "checkBox4";
+            checkBox4.Size = new System.Drawing.Size(76, 19);
+            checkBox4.TabIndex = 1;
+            checkBox4.Text = "Activated";
+            toolTip1.SetToolTip(checkBox4, "Override the default continuation of a calculation and start a calculation again with\r\nSituation 1 by reusing the temporary concentration ");
+            checkBox4.UseVisualStyleBackColor = true;
+            checkBox4.CheckedChanged += checkBox4_CheckedChanged;
             // 
             // numericUpDown3
             // 
-            this.numericUpDown3.Enabled = false;
-            this.numericUpDown3.Increment = new decimal(new int[] {
-            10,
-            0,
-            0,
-            0});
-            this.numericUpDown3.Location = new System.Drawing.Point(160, 51);
-            this.numericUpDown3.Maximum = new decimal(new int[] {
-            10000,
-            0,
-            0,
-            0});
-            this.numericUpDown3.Minimum = new decimal(new int[] {
-            50,
-            0,
-            0,
-            0});
-            this.numericUpDown3.Name = "numericUpDown3";
-            this.numericUpDown3.Size = new System.Drawing.Size(62, 20);
-            this.numericUpDown3.TabIndex = 3;
-            this.toolTip1.SetToolTip(this.numericUpDown3, "Beyond this radius around sources, the wind field is calculated diagnostically \r\n" +
-        "even in the presence of buildings or vegetation areas");
-            this.numericUpDown3.Value = new decimal(new int[] {
-            150,
-            0,
-            0,
-            0});
-            this.numericUpDown3.ValueChanged += new System.EventHandler(this.numericUpDown3_ValueChanged);
-            // 
-            // groupBox3
-            // 
-            this.groupBox3.Controls.Add(this.numericUpDown3);
-            this.groupBox3.Controls.Add(this.label3);
-            this.groupBox3.Controls.Add(this.checkBox4);
-            this.groupBox3.Location = new System.Drawing.Point(15, 188);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(290, 89);
-            this.groupBox3.TabIndex = 4;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Reduce the size of prognostic sub domains";
-            // 
-            // label3
-            // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(7, 53);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(68, 13);
-            this.label3.TabIndex = 2;
-            this.label3.Text = "Radius in [m]";
+            numericUpDown3.Enabled = false;
+            numericUpDown3.Increment = new decimal(new int[] { 10, 0, 0, 0 });
+            numericUpDown3.Location = new System.Drawing.Point(187, 59);
+            numericUpDown3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown3.Maximum = new decimal(new int[] { 10000, 0, 0, 0 });
+            numericUpDown3.Minimum = new decimal(new int[] { 50, 0, 0, 0 });
+            numericUpDown3.Name = "numericUpDown3";
+            numericUpDown3.Size = new System.Drawing.Size(72, 23);
+            numericUpDown3.TabIndex = 3;
+            toolTip1.SetToolTip(numericUpDown3, "Beyond this radius around sources, the wind field is calculated diagnostically \r\neven in the presence of buildings or vegetation areas");
+            numericUpDown3.Value = new decimal(new int[] { 150, 0, 0, 0 });
+            numericUpDown3.ValueChanged += numericUpDown3_ValueChanged;
             // 
             // checkBox5
             // 
-            this.checkBox5.AutoSize = true;
-            this.checkBox5.Checked = true;
-            this.checkBox5.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 3.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter);
-            this.checkBox5.Location = new System.Drawing.Point(15, 349);
-            this.checkBox5.Name = "checkBox5";
-            this.checkBox5.Size = new System.Drawing.Size(214, 20);
-            this.checkBox5.TabIndex = 61;
-            this.checkBox5.Text = "Disable GRAL Online Functions";
-            this.toolTip1.SetToolTip(this.checkBox5, "Wait for a keystroke at the end of a calculation");
-            this.checkBox5.UseVisualStyleBackColor = true;
+            checkBox5.AutoSize = true;
+            checkBox5.Checked = true;
+            checkBox5.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox5.Font = new System.Drawing.Font("Microsoft Sans Serif", 3.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter);
+            checkBox5.Location = new System.Drawing.Point(18, 403);
+            checkBox5.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox5.Name = "checkBox5";
+            checkBox5.Size = new System.Drawing.Size(213, 20);
+            checkBox5.TabIndex = 61;
+            checkBox5.Text = "Disable GRAL Online Functions";
+            toolTip1.SetToolTip(checkBox5, "Wait for a keystroke at the end of a calculation");
+            checkBox5.UseVisualStyleBackColor = true;
+            // 
+            // checkBox6
+            // 
+            checkBox6.AutoSize = true;
+            checkBox6.Checked = true;
+            checkBox6.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox6.Font = new System.Drawing.Font("Microsoft Sans Serif", 3.2F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Millimeter);
+            checkBox6.Location = new System.Drawing.Point(18, 433);
+            checkBox6.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            checkBox6.Name = "checkBox6";
+            checkBox6.Size = new System.Drawing.Size(195, 20);
+            checkBox6.TabIndex = 62;
+            checkBox6.Text = "GRAL Reproducible Results";
+            toolTip1.SetToolTip(checkBox6, "This GRAL option gives reproducible results, but the flow field calculation is significantly slower\r\nGRAL V24.09 or higher is required");
+            checkBox6.UseVisualStyleBackColor = true;
+            checkBox6.CheckedChanged += checkBox6_CheckedChanged;
+            // 
+            // groupBox3
+            // 
+            groupBox3.Controls.Add(numericUpDown3);
+            groupBox3.Controls.Add(label3);
+            groupBox3.Controls.Add(checkBox4);
+            groupBox3.Location = new System.Drawing.Point(18, 217);
+            groupBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox3.Name = "groupBox3";
+            groupBox3.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox3.Size = new System.Drawing.Size(338, 103);
+            groupBox3.TabIndex = 4;
+            groupBox3.TabStop = false;
+            groupBox3.Text = "Reduce the size of prognostic sub domains";
+            // 
+            // label3
+            // 
+            label3.AutoSize = true;
+            label3.Location = new System.Drawing.Point(8, 61);
+            label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(77, 15);
+            label3.TabIndex = 2;
+            label3.Text = "Radius in [m]";
             // 
             // Main_SpecialSettings
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(320, 444);
-            this.Controls.Add(this.checkBox5);
-            this.Controls.Add(this.groupBox3);
-            this.Controls.Add(this.numericUpDown2);
-            this.Controls.Add(this.checkBox3);
-            this.Controls.Add(this.label2);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Name = "Main_SpecialSettings";
-            this.Text = "Special GRAL Settings";
-            this.Load += new System.EventHandler(this.Main_SpecialSettings_Load);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox3.PerformLayout();
-            this.ResumeLayout(false);
-            this.PerformLayout();
-
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            ClientSize = new System.Drawing.Size(373, 546);
+            Controls.Add(checkBox6);
+            Controls.Add(checkBox5);
+            Controls.Add(groupBox3);
+            Controls.Add(numericUpDown2);
+            Controls.Add(checkBox3);
+            Controls.Add(label2);
+            Controls.Add(button2);
+            Controls.Add(button1);
+            Controls.Add(groupBox2);
+            Controls.Add(groupBox1);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            Name = "Main_SpecialSettings";
+            Text = "Special GRAL Settings";
+            Load += Main_SpecialSettings_Load;
+            groupBox1.ResumeLayout(false);
+            groupBox1.PerformLayout();
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown1).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown2).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown3).EndInit();
+            groupBox3.ResumeLayout(false);
+            groupBox3.PerformLayout();
+            ResumeLayout(false);
+            PerformLayout();
         }
 
         #endregion
@@ -321,5 +321,6 @@
         private System.Windows.Forms.Label label3;
         private System.Windows.Forms.CheckBox checkBox4;
         private System.Windows.Forms.CheckBox checkBox5;
+        private System.Windows.Forms.CheckBox checkBox6;
     }
 }

--- a/src/GRALMainSubForms/Main_SpecialSettings.cs
+++ b/src/GRALMainSubForms/Main_SpecialSettings.cs
@@ -11,6 +11,7 @@ namespace GralMainForms
         public int LogLevel = 0;
         public int RadiusForPrognosticFlowField = 0;
         public bool GRALOnlineFunctions = true;
+        public bool GRALReproducibleResults = false;
 
         public Main_SpecialSettings()
         {
@@ -28,7 +29,7 @@ namespace GralMainForms
             {
                 WriteASCiiOutput = checkBox1.Checked;
                 GRALOnlineFunctions = !checkBox5.Checked;
-                LogLevel = (int) numericUpDown2.Value;
+                LogLevel = (int)numericUpDown2.Value;
 
                 string KeepTransientPath = Path.Combine(Gral.Main.ProjectName, "Computation", "KeepAndReadTransientTempFiles.dat");
 
@@ -117,6 +118,7 @@ namespace GralMainForms
                 button1.Enabled = true;
                 button2.Enabled = true;
             }
+            checkBox6.Checked = GRALReproducibleResults;
         }
 
         private void checkBox3_CheckedChanged(object sender, EventArgs e)
@@ -138,9 +140,15 @@ namespace GralMainForms
             }
         }
 
+
         private void numericUpDown3_ValueChanged(object sender, EventArgs e)
         {
             RadiusForPrognosticFlowField = Convert.ToInt32(numericUpDown3.Value);
+        }
+
+        private void checkBox6_CheckedChanged(object sender, EventArgs e)
+        {
+            GRALReproducibleResults = checkBox6.Checked;
         }
     }
 }

--- a/src/GRALMainSubForms/Main_SpecialSettings.resx
+++ b/src/GRALMainSubForms/Main_SpecialSettings.resx
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <root>
-  <!-- 
+  <!--
     Microsoft ResX Schema 
-    
+
     Version 2.0
-    
-    The primary goals of this format is to allow a simple XML format 
-    that is mostly human readable. The generation and parsing of the 
-    various data types are done through the TypeConverter classes 
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
     associated with the data types.
-    
+
     Example:
-    
+
     ... ado.net/XML headers & schema ...
     <resheader name="resmimetype">text/microsoft-resx</resheader>
     <resheader name="version">2.0</resheader>
@@ -26,36 +26,36 @@
         <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
         <comment>This is a comment</comment>
     </data>
-                
-    There are any number of "resheader" rows that contain simple 
+
+    There are any number of "resheader" rows that contain simple
     name/value pairs.
-    
-    Each data row contains a name, and value. The row also contains a 
-    type or mimetype. Type corresponds to a .NET class that support 
-    text/value conversion through the TypeConverter architecture. 
-    Classes that don't support this are serialized and stored with the 
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
     mimetype set.
-    
-    The mimetype is used for serialized objects, and tells the 
-    ResXResourceReader how to depersist the object. This is currently not 
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
     extensible. For a given mimetype the value must be set accordingly:
-    
-    Note - application/x-microsoft.net.object.binary.base64 is the format 
-    that the ResXResourceWriter will generate, however the reader can 
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
     read any of the formats listed below.
-    
+
     mimetype: application/x-microsoft.net.object.binary.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
             : and then encoded with base64 encoding.
     
     mimetype: application/x-microsoft.net.object.soap.base64
-    value   : The object must be serialized with 
+    value   : The object must be serialized with
             : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
             : and then encoded with base64 encoding.
 
     mimetype: application/x-microsoft.net.object.bytearray.base64
-    value   : The object must be serialized into a byte array 
+    value   : The object must be serialized into a byte array
             : using a System.ComponentModel.TypeConverter
             : and then encoded with base64 encoding.
     -->

--- a/src/GRALMainSubForms/SelectSourcegroups.Designer.cs
+++ b/src/GRALMainSubForms/SelectSourcegroups.Designer.cs
@@ -28,428 +28,424 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
+            components = new System.ComponentModel.Container();
             System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SelectSourcegroups));
-            this.listBox1 = new System.Windows.Forms.ListBox();
-            this.button1 = new System.Windows.Forms.Button();
-            this.checkBox1 = new System.Windows.Forms.CheckBox();
-            this.checkBox2 = new System.Windows.Forms.CheckBox();
-            this.checkBox3 = new System.Windows.Forms.CheckBox();
-            this.label1 = new System.Windows.Forms.Label();
-            this.textBox1 = new System.Windows.Forms.TextBox();
-            this.groupBox1 = new System.Windows.Forms.GroupBox();
-            this.label5 = new System.Windows.Forms.Label();
-            this.label4 = new System.Windows.Forms.Label();
-            this.numericUpDown3 = new System.Windows.Forms.NumericUpDown();
-            this.label2 = new System.Windows.Forms.Label();
-            this.numericUpDown1 = new System.Windows.Forms.NumericUpDown();
-            this.radioButton2 = new System.Windows.Forms.RadioButton();
-            this.radioButton1 = new System.Windows.Forms.RadioButton();
-            this.groupBox2 = new System.Windows.Forms.GroupBox();
-            this.label3 = new System.Windows.Forms.Label();
-            this.numericUpDown2 = new System.Windows.Forms.NumericUpDown();
-            this.button2 = new System.Windows.Forms.Button();
-            this.groupBox3 = new System.Windows.Forms.GroupBox();
-            this.buttonResultPath = new System.Windows.Forms.Button();
-            this.buttonModulationPath = new System.Windows.Forms.Button();
-            this.textBox3 = new System.Windows.Forms.TextBox();
-            this.label7 = new System.Windows.Forms.Label();
-            this.textBox2 = new System.Windows.Forms.TextBox();
-            this.label6 = new System.Windows.Forms.Label();
-            this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
-            this.groupBox1.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).BeginInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).BeginInit();
-            this.groupBox2.SuspendLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).BeginInit();
-            this.groupBox3.SuspendLayout();
-            this.SuspendLayout();
+            listBox1 = new System.Windows.Forms.ListBox();
+            button1 = new System.Windows.Forms.Button();
+            checkBox1 = new System.Windows.Forms.CheckBox();
+            checkBox2 = new System.Windows.Forms.CheckBox();
+            checkBox3 = new System.Windows.Forms.CheckBox();
+            label1 = new System.Windows.Forms.Label();
+            textBox1 = new System.Windows.Forms.TextBox();
+            groupBox1 = new System.Windows.Forms.GroupBox();
+            label5 = new System.Windows.Forms.Label();
+            label4 = new System.Windows.Forms.Label();
+            numericUpDown3 = new System.Windows.Forms.NumericUpDown();
+            label2 = new System.Windows.Forms.Label();
+            numericUpDown1 = new System.Windows.Forms.NumericUpDown();
+            radioButton2 = new System.Windows.Forms.RadioButton();
+            radioButton1 = new System.Windows.Forms.RadioButton();
+            groupBox2 = new System.Windows.Forms.GroupBox();
+            label3 = new System.Windows.Forms.Label();
+            numericUpDown2 = new System.Windows.Forms.NumericUpDown();
+            button2 = new System.Windows.Forms.Button();
+            groupBox3 = new System.Windows.Forms.GroupBox();
+            buttonResultPath = new System.Windows.Forms.Button();
+            buttonModulationPath = new System.Windows.Forms.Button();
+            textBox3 = new System.Windows.Forms.TextBox();
+            label7 = new System.Windows.Forms.Label();
+            textBox2 = new System.Windows.Forms.TextBox();
+            label6 = new System.Windows.Forms.Label();
+            toolTip1 = new System.Windows.Forms.ToolTip(components);
+            checkBox4 = new System.Windows.Forms.CheckBox();
+            checkBox5 = new System.Windows.Forms.CheckBox();
+            groupBox1.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown3).BeginInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown1).BeginInit();
+            groupBox2.SuspendLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown2).BeginInit();
+            groupBox3.SuspendLayout();
+            SuspendLayout();
             // 
             // listBox1
             // 
-            this.listBox1.FormattingEnabled = true;
-            this.listBox1.ItemHeight = 15;
-            this.listBox1.Location = new System.Drawing.Point(0, 0);
-            this.listBox1.Margin = new System.Windows.Forms.Padding(2);
-            this.listBox1.Name = "listBox1";
-            this.listBox1.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
-            this.listBox1.Size = new System.Drawing.Size(413, 199);
-            this.listBox1.TabIndex = 0;
-            this.toolTip1.SetToolTip(this.listBox1, "Calculated source groups");
+            listBox1.FormattingEnabled = true;
+            listBox1.ItemHeight = 15;
+            listBox1.Location = new System.Drawing.Point(0, 0);
+            listBox1.Margin = new System.Windows.Forms.Padding(2);
+            listBox1.Name = "listBox1";
+            listBox1.SelectionMode = System.Windows.Forms.SelectionMode.MultiExtended;
+            listBox1.Size = new System.Drawing.Size(413, 199);
+            listBox1.TabIndex = 0;
+            toolTip1.SetToolTip(listBox1, "Calculated source groups");
             // 
             // button1
             // 
-            this.button1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.button1.DialogResult = System.Windows.Forms.DialogResult.OK;
-            this.button1.Location = new System.Drawing.Point(13, 530);
-            this.button1.Margin = new System.Windows.Forms.Padding(2);
-            this.button1.Name = "button1";
-            this.button1.Size = new System.Drawing.Size(105, 40);
-            this.button1.TabIndex = 8;
-            this.button1.Text = "&OK";
-            this.button1.UseVisualStyleBackColor = true;
-            this.button1.Click += new System.EventHandler(this.button1_Click);
+            button1.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            button1.DialogResult = System.Windows.Forms.DialogResult.OK;
+            button1.Location = new System.Drawing.Point(13, 532);
+            button1.Margin = new System.Windows.Forms.Padding(2);
+            button1.Name = "button1";
+            button1.Size = new System.Drawing.Size(105, 40);
+            button1.TabIndex = 8;
+            button1.Text = "&OK";
+            button1.UseVisualStyleBackColor = true;
+            button1.Click += button1_Click;
             // 
             // checkBox1
             // 
-            this.checkBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.checkBox1.Location = new System.Drawing.Point(262, 401);
-            this.checkBox1.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBox1.Name = "checkBox1";
-            this.checkBox1.Size = new System.Drawing.Size(150, 36);
-            this.checkBox1.TabIndex = 3;
-            this.checkBox1.Text = "Calculate\r\nmax. concentrations";
-            this.checkBox1.UseVisualStyleBackColor = true;
+            checkBox1.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            checkBox1.Location = new System.Drawing.Point(262, 403);
+            checkBox1.Margin = new System.Windows.Forms.Padding(2);
+            checkBox1.Name = "checkBox1";
+            checkBox1.Size = new System.Drawing.Size(150, 36);
+            checkBox1.TabIndex = 3;
+            checkBox1.Text = "Calculate\r\nmax. concentrations";
+            checkBox1.UseVisualStyleBackColor = true;
             // 
             // checkBox2
             // 
-            this.checkBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.checkBox2.Checked = true;
-            this.checkBox2.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox2.Location = new System.Drawing.Point(262, 362);
-            this.checkBox2.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBox2.Name = "checkBox2";
-            this.checkBox2.Size = new System.Drawing.Size(150, 36);
-            this.checkBox2.TabIndex = 2;
-            this.checkBox2.Text = "Calculate\r\nmean concentrations";
-            this.checkBox2.UseVisualStyleBackColor = true;
-            this.checkBox2.CheckedChanged += new System.EventHandler(this.checkBox2_CheckedChanged);
+            checkBox2.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            checkBox2.Checked = true;
+            checkBox2.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox2.Location = new System.Drawing.Point(262, 364);
+            checkBox2.Margin = new System.Windows.Forms.Padding(2);
+            checkBox2.Name = "checkBox2";
+            checkBox2.Size = new System.Drawing.Size(150, 36);
+            checkBox2.TabIndex = 2;
+            checkBox2.Text = "Calculate\r\nmean concentrations";
+            checkBox2.UseVisualStyleBackColor = true;
+            checkBox2.CheckedChanged += checkBox2_CheckedChanged;
             // 
             // checkBox3
             // 
-            this.checkBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.checkBox3.Checked = true;
-            this.checkBox3.CheckState = System.Windows.Forms.CheckState.Checked;
-            this.checkBox3.Location = new System.Drawing.Point(262, 441);
-            this.checkBox3.Margin = new System.Windows.Forms.Padding(2);
-            this.checkBox3.Name = "checkBox3";
-            this.checkBox3.Size = new System.Drawing.Size(150, 36);
-            this.checkBox3.TabIndex = 4;
-            this.checkBox3.Text = "Calculate daily\r\nmax. concentrations";
-            this.checkBox3.UseVisualStyleBackColor = true;
+            checkBox3.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            checkBox3.Checked = true;
+            checkBox3.CheckState = System.Windows.Forms.CheckState.Checked;
+            checkBox3.Location = new System.Drawing.Point(262, 443);
+            checkBox3.Margin = new System.Windows.Forms.Padding(2);
+            checkBox3.Name = "checkBox3";
+            checkBox3.Size = new System.Drawing.Size(150, 36);
+            checkBox3.TabIndex = 4;
+            checkBox3.Text = "Calculate daily\r\nmax. concentrations";
+            checkBox3.UseVisualStyleBackColor = true;
             // 
             // label1
             // 
-            this.label1.Location = new System.Drawing.Point(8, 102);
-            this.label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label1.Name = "label1";
-            this.label1.Size = new System.Drawing.Size(110, 28);
-            this.label1.TabIndex = 5;
-            this.label1.Text = "Result file-prefix";
+            label1.Location = new System.Drawing.Point(8, 102);
+            label1.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label1.Name = "label1";
+            label1.Size = new System.Drawing.Size(110, 28);
+            label1.TabIndex = 5;
+            label1.Text = "Result file-prefix";
             // 
             // textBox1
             // 
-            this.textBox1.Location = new System.Drawing.Point(164, 99);
-            this.textBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.textBox1.Name = "textBox1";
-            this.textBox1.Size = new System.Drawing.Size(219, 23);
-            this.textBox1.TabIndex = 1;
-            this.toolTip1.SetToolTip(this.textBox1, "A file prefix for the result files");
-            this.textBox1.TextChanged += new System.EventHandler(this.TextBox1TextChanged);
+            textBox1.Location = new System.Drawing.Point(164, 99);
+            textBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox1.Name = "textBox1";
+            textBox1.Size = new System.Drawing.Size(219, 23);
+            textBox1.TabIndex = 1;
+            toolTip1.SetToolTip(textBox1, "A file prefix for the result files");
+            textBox1.TextChanged += TextBox1TextChanged;
             // 
             // groupBox1
             // 
-            this.groupBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.groupBox1.Controls.Add(this.label5);
-            this.groupBox1.Controls.Add(this.label4);
-            this.groupBox1.Controls.Add(this.numericUpDown3);
-            this.groupBox1.Controls.Add(this.label2);
-            this.groupBox1.Controls.Add(this.numericUpDown1);
-            this.groupBox1.Controls.Add(this.radioButton2);
-            this.groupBox1.Controls.Add(this.radioButton1);
-            this.groupBox1.Location = new System.Drawing.Point(14, 355);
-            this.groupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBox1.Name = "groupBox1";
-            this.groupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBox1.Size = new System.Drawing.Size(229, 156);
-            this.groupBox1.TabIndex = 7;
-            this.groupBox1.TabStop = false;
-            this.groupBox1.Text = "Odour";
+            groupBox1.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox1.Controls.Add(checkBox5);
+            groupBox1.Controls.Add(label5);
+            groupBox1.Controls.Add(label4);
+            groupBox1.Controls.Add(numericUpDown3);
+            groupBox1.Controls.Add(label2);
+            groupBox1.Controls.Add(numericUpDown1);
+            groupBox1.Controls.Add(radioButton2);
+            groupBox1.Controls.Add(radioButton1);
+            groupBox1.Location = new System.Drawing.Point(14, 357);
+            groupBox1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Name = "groupBox1";
+            groupBox1.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox1.Size = new System.Drawing.Size(229, 170);
+            groupBox1.TabIndex = 7;
+            groupBox1.TabStop = false;
+            groupBox1.Text = "Odour";
             // 
             // label5
             // 
-            this.label5.AutoSize = true;
-            this.label5.Location = new System.Drawing.Point(183, 52);
-            this.label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label5.Name = "label5";
-            this.label5.Size = new System.Drawing.Size(44, 15);
-            this.label5.TabIndex = 6;
-            this.label5.Text = "OU/m³";
+            label5.AutoSize = true;
+            label5.Location = new System.Drawing.Point(183, 52);
+            label5.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label5.Name = "label5";
+            label5.Size = new System.Drawing.Size(44, 15);
+            label5.TabIndex = 6;
+            label5.Text = "OU/m³";
             // 
             // label4
             // 
-            this.label4.AutoSize = true;
-            this.label4.Location = new System.Drawing.Point(23, 52);
-            this.label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label4.Name = "label4";
-            this.label4.Size = new System.Drawing.Size(94, 15);
-            this.label4.TabIndex = 5;
-            this.label4.Text = "Odour threshold";
+            label4.AutoSize = true;
+            label4.Location = new System.Drawing.Point(23, 52);
+            label4.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label4.Name = "label4";
+            label4.Size = new System.Drawing.Size(94, 15);
+            label4.TabIndex = 5;
+            label4.Text = "Odour threshold";
             // 
             // numericUpDown3
             // 
-            this.numericUpDown3.DecimalPlaces = 1;
-            this.numericUpDown3.Enabled = false;
-            this.numericUpDown3.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            this.numericUpDown3.Location = new System.Drawing.Point(126, 46);
-            this.numericUpDown3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.numericUpDown3.Name = "numericUpDown3";
-            this.numericUpDown3.Size = new System.Drawing.Size(56, 23);
-            this.numericUpDown3.TabIndex = 4;
-            this.numericUpDown3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.numericUpDown3.Value = new decimal(new int[] {
-            1,
-            0,
-            0,
-            0});
+            numericUpDown3.DecimalPlaces = 1;
+            numericUpDown3.Enabled = false;
+            numericUpDown3.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
+            numericUpDown3.Location = new System.Drawing.Point(126, 46);
+            numericUpDown3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown3.Name = "numericUpDown3";
+            numericUpDown3.Size = new System.Drawing.Size(56, 23);
+            numericUpDown3.TabIndex = 4;
+            numericUpDown3.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            numericUpDown3.Value = new decimal(new int[] { 1, 0, 0, 0 });
             // 
             // label2
             // 
-            this.label2.AutoSize = true;
-            this.label2.Location = new System.Drawing.Point(23, 117);
-            this.label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label2.Name = "label2";
-            this.label2.Size = new System.Drawing.Size(59, 15);
-            this.label2.TabIndex = 3;
-            this.label2.Text = "Percentile";
+            label2.AutoSize = true;
+            label2.Location = new System.Drawing.Point(23, 115);
+            label2.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label2.Name = "label2";
+            label2.Size = new System.Drawing.Size(59, 15);
+            label2.TabIndex = 3;
+            label2.Text = "Percentile";
             // 
             // numericUpDown1
             // 
-            this.numericUpDown1.DecimalPlaces = 1;
-            this.numericUpDown1.Enabled = false;
-            this.numericUpDown1.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            this.numericUpDown1.Location = new System.Drawing.Point(126, 112);
-            this.numericUpDown1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.numericUpDown1.Name = "numericUpDown1";
-            this.numericUpDown1.Size = new System.Drawing.Size(56, 23);
-            this.numericUpDown1.TabIndex = 6;
-            this.numericUpDown1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.toolTip1.SetToolTip(this.numericUpDown1, "Percentile to be evaluated");
-            this.numericUpDown1.Value = new decimal(new int[] {
-            98,
-            0,
-            0,
-            0});
+            numericUpDown1.DecimalPlaces = 1;
+            numericUpDown1.Enabled = false;
+            numericUpDown1.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
+            numericUpDown1.Location = new System.Drawing.Point(126, 110);
+            numericUpDown1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown1.Name = "numericUpDown1";
+            numericUpDown1.Size = new System.Drawing.Size(56, 23);
+            numericUpDown1.TabIndex = 6;
+            numericUpDown1.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            toolTip1.SetToolTip(numericUpDown1, "Percentile to be evaluated");
+            numericUpDown1.Value = new decimal(new int[] { 98, 0, 0, 0 });
             // 
             // radioButton2
             // 
-            this.radioButton2.AutoSize = true;
-            this.radioButton2.Location = new System.Drawing.Point(8, 85);
-            this.radioButton2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.radioButton2.Name = "radioButton2";
-            this.radioButton2.Size = new System.Drawing.Size(136, 19);
-            this.radioButton2.TabIndex = 7;
-            this.radioButton2.Text = "Odour concentration";
-            this.radioButton2.UseVisualStyleBackColor = true;
+            radioButton2.AutoSize = true;
+            radioButton2.Location = new System.Drawing.Point(8, 85);
+            radioButton2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            radioButton2.Name = "radioButton2";
+            radioButton2.Size = new System.Drawing.Size(136, 19);
+            radioButton2.TabIndex = 7;
+            radioButton2.Text = "Odour concentration";
+            radioButton2.UseVisualStyleBackColor = true;
             // 
             // radioButton1
             // 
-            this.radioButton1.AutoSize = true;
-            this.radioButton1.Checked = true;
-            this.radioButton1.Location = new System.Drawing.Point(8, 23);
-            this.radioButton1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.radioButton1.Name = "radioButton1";
-            this.radioButton1.Size = new System.Drawing.Size(143, 19);
-            this.radioButton1.TabIndex = 0;
-            this.radioButton1.TabStop = true;
-            this.radioButton1.Text = "Odour hour frequency";
-            this.radioButton1.UseVisualStyleBackColor = true;
-            this.radioButton1.CheckedChanged += new System.EventHandler(this.radioButton1_CheckedChanged);
+            radioButton1.AutoSize = true;
+            radioButton1.Checked = true;
+            radioButton1.Location = new System.Drawing.Point(8, 23);
+            radioButton1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            radioButton1.Name = "radioButton1";
+            radioButton1.Size = new System.Drawing.Size(143, 19);
+            radioButton1.TabIndex = 0;
+            radioButton1.TabStop = true;
+            radioButton1.Text = "Odour hour frequency";
+            radioButton1.UseVisualStyleBackColor = true;
+            radioButton1.CheckedChanged += radioButton1_CheckedChanged;
             // 
             // groupBox2
             // 
-            this.groupBox2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.groupBox2.Controls.Add(this.label3);
-            this.groupBox2.Controls.Add(this.numericUpDown2);
-            this.groupBox2.Location = new System.Drawing.Point(13, 355);
-            this.groupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBox2.Name = "groupBox2";
-            this.groupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.groupBox2.Size = new System.Drawing.Size(230, 75);
-            this.groupBox2.TabIndex = 8;
-            this.groupBox2.TabStop = false;
-            this.groupBox2.Text = "Percentile Evaluation";
+            groupBox2.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox2.Controls.Add(checkBox4);
+            groupBox2.Controls.Add(label3);
+            groupBox2.Controls.Add(numericUpDown2);
+            groupBox2.Location = new System.Drawing.Point(13, 357);
+            groupBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Name = "groupBox2";
+            groupBox2.Padding = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            groupBox2.Size = new System.Drawing.Size(230, 75);
+            groupBox2.TabIndex = 8;
+            groupBox2.TabStop = false;
+            groupBox2.Text = "Percentile Evaluation";
             // 
             // label3
             // 
-            this.label3.AutoSize = true;
-            this.label3.Location = new System.Drawing.Point(24, 33);
-            this.label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label3.Name = "label3";
-            this.label3.Size = new System.Drawing.Size(59, 15);
-            this.label3.TabIndex = 3;
-            this.label3.Text = "Percentile";
+            label3.AutoSize = true;
+            label3.Location = new System.Drawing.Point(24, 25);
+            label3.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label3.Name = "label3";
+            label3.Size = new System.Drawing.Size(59, 15);
+            label3.TabIndex = 3;
+            label3.Text = "Percentile";
             // 
             // numericUpDown2
             // 
-            this.numericUpDown2.DecimalPlaces = 1;
-            this.numericUpDown2.Enabled = false;
-            this.numericUpDown2.Increment = new decimal(new int[] {
-            1,
-            0,
-            0,
-            65536});
-            this.numericUpDown2.Location = new System.Drawing.Point(127, 31);
-            this.numericUpDown2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.numericUpDown2.Minimum = new decimal(new int[] {
-            90,
-            0,
-            0,
-            0});
-            this.numericUpDown2.Name = "numericUpDown2";
-            this.numericUpDown2.Size = new System.Drawing.Size(56, 23);
-            this.numericUpDown2.TabIndex = 5;
-            this.numericUpDown2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
-            this.toolTip1.SetToolTip(this.numericUpDown2, "Percentile to be evaluated");
-            this.numericUpDown2.Value = new decimal(new int[] {
-            98,
-            0,
-            0,
-            0});
+            numericUpDown2.DecimalPlaces = 1;
+            numericUpDown2.Enabled = false;
+            numericUpDown2.Increment = new decimal(new int[] { 1, 0, 0, 65536 });
+            numericUpDown2.Location = new System.Drawing.Point(127, 23);
+            numericUpDown2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            numericUpDown2.Minimum = new decimal(new int[] { 90, 0, 0, 0 });
+            numericUpDown2.Name = "numericUpDown2";
+            numericUpDown2.Size = new System.Drawing.Size(56, 23);
+            numericUpDown2.TabIndex = 5;
+            numericUpDown2.TextAlign = System.Windows.Forms.HorizontalAlignment.Right;
+            toolTip1.SetToolTip(numericUpDown2, "Percentile to be evaluated");
+            numericUpDown2.Value = new decimal(new int[] { 98, 0, 0, 0 });
             // 
             // button2
             // 
-            this.button2.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.button2.Location = new System.Drawing.Point(295, 530);
-            this.button2.Margin = new System.Windows.Forms.Padding(2);
-            this.button2.Name = "button2";
-            this.button2.Size = new System.Drawing.Size(105, 40);
-            this.button2.TabIndex = 9;
-            this.button2.Text = "&Cancel";
-            this.button2.UseVisualStyleBackColor = true;
-            this.button2.Click += new System.EventHandler(this.button1_Click);
+            button2.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right;
+            button2.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+            button2.Location = new System.Drawing.Point(295, 532);
+            button2.Margin = new System.Windows.Forms.Padding(2);
+            button2.Name = "button2";
+            button2.Size = new System.Drawing.Size(105, 40);
+            button2.TabIndex = 9;
+            button2.Text = "&Cancel";
+            button2.UseVisualStyleBackColor = true;
+            button2.Click += button1_Click;
             // 
             // groupBox3
             // 
-            this.groupBox3.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
-            this.groupBox3.Controls.Add(this.buttonResultPath);
-            this.groupBox3.Controls.Add(this.buttonModulationPath);
-            this.groupBox3.Controls.Add(this.textBox3);
-            this.groupBox3.Controls.Add(this.label7);
-            this.groupBox3.Controls.Add(this.textBox2);
-            this.groupBox3.Controls.Add(this.label6);
-            this.groupBox3.Controls.Add(this.textBox1);
-            this.groupBox3.Controls.Add(this.label1);
-            this.groupBox3.Location = new System.Drawing.Point(14, 209);
-            this.groupBox3.Name = "groupBox3";
-            this.groupBox3.Size = new System.Drawing.Size(390, 135);
-            this.groupBox3.TabIndex = 10;
-            this.groupBox3.TabStop = false;
-            this.groupBox3.Text = "Emission Modulation/Result Files";
+            groupBox3.Anchor = System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left;
+            groupBox3.Controls.Add(buttonResultPath);
+            groupBox3.Controls.Add(buttonModulationPath);
+            groupBox3.Controls.Add(textBox3);
+            groupBox3.Controls.Add(label7);
+            groupBox3.Controls.Add(textBox2);
+            groupBox3.Controls.Add(label6);
+            groupBox3.Controls.Add(textBox1);
+            groupBox3.Controls.Add(label1);
+            groupBox3.Location = new System.Drawing.Point(14, 211);
+            groupBox3.Name = "groupBox3";
+            groupBox3.Size = new System.Drawing.Size(390, 135);
+            groupBox3.TabIndex = 10;
+            groupBox3.TabStop = false;
+            groupBox3.Text = "Emission Modulation/Result Files";
             // 
             // buttonResultPath
             // 
-            this.buttonResultPath.BackColor = System.Drawing.Color.Gainsboro;
-            this.buttonResultPath.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("buttonResultPath.BackgroundImage")));
-            this.buttonResultPath.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.buttonResultPath.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.buttonResultPath.Location = new System.Drawing.Point(119, 60);
-            this.buttonResultPath.Name = "buttonResultPath";
-            this.buttonResultPath.Size = new System.Drawing.Size(32, 32);
-            this.buttonResultPath.TabIndex = 47;
-            this.toolTip1.SetToolTip(this.buttonResultPath, "Set the path for the result files");
-            this.buttonResultPath.UseVisualStyleBackColor = false;
-            this.buttonResultPath.Click += new System.EventHandler(this.buttonSelectPath_Click);
+            buttonResultPath.BackColor = System.Drawing.Color.Gainsboro;
+            buttonResultPath.BackgroundImage = (System.Drawing.Image)resources.GetObject("buttonResultPath.BackgroundImage");
+            buttonResultPath.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            buttonResultPath.Font = new System.Drawing.Font("Segoe UI", 9F);
+            buttonResultPath.Location = new System.Drawing.Point(119, 60);
+            buttonResultPath.Name = "buttonResultPath";
+            buttonResultPath.Size = new System.Drawing.Size(32, 32);
+            buttonResultPath.TabIndex = 47;
+            toolTip1.SetToolTip(buttonResultPath, "Set the path for the result files");
+            buttonResultPath.UseVisualStyleBackColor = false;
+            buttonResultPath.Click += buttonSelectPath_Click;
             // 
             // buttonModulationPath
             // 
-            this.buttonModulationPath.BackColor = System.Drawing.Color.Gainsboro;
-            this.buttonModulationPath.BackgroundImage = ((System.Drawing.Image)(resources.GetObject("buttonModulationPath.BackgroundImage")));
-            this.buttonModulationPath.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
-            this.buttonModulationPath.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
-            this.buttonModulationPath.Location = new System.Drawing.Point(119, 22);
-            this.buttonModulationPath.Name = "buttonModulationPath";
-            this.buttonModulationPath.Size = new System.Drawing.Size(32, 32);
-            this.buttonModulationPath.TabIndex = 46;
-            this.toolTip1.SetToolTip(this.buttonModulationPath, "Set the path with emission modulation files for one evaluation");
-            this.buttonModulationPath.UseVisualStyleBackColor = false;
-            this.buttonModulationPath.Click += new System.EventHandler(this.buttonSelectPath_Click);
+            buttonModulationPath.BackColor = System.Drawing.Color.Gainsboro;
+            buttonModulationPath.BackgroundImage = (System.Drawing.Image)resources.GetObject("buttonModulationPath.BackgroundImage");
+            buttonModulationPath.BackgroundImageLayout = System.Windows.Forms.ImageLayout.Zoom;
+            buttonModulationPath.Font = new System.Drawing.Font("Segoe UI", 9F);
+            buttonModulationPath.Location = new System.Drawing.Point(119, 22);
+            buttonModulationPath.Name = "buttonModulationPath";
+            buttonModulationPath.Size = new System.Drawing.Size(32, 32);
+            buttonModulationPath.TabIndex = 46;
+            toolTip1.SetToolTip(buttonModulationPath, "Set the path with emission modulation files for one evaluation");
+            buttonModulationPath.UseVisualStyleBackColor = false;
+            buttonModulationPath.Click += buttonSelectPath_Click;
             // 
             // textBox3
             // 
-            this.textBox3.Enabled = false;
-            this.textBox3.Location = new System.Drawing.Point(164, 64);
-            this.textBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.textBox3.Name = "textBox3";
-            this.textBox3.Size = new System.Drawing.Size(219, 23);
-            this.textBox3.TabIndex = 9;
-            this.textBox3.WordWrap = false;
+            textBox3.Enabled = false;
+            textBox3.Location = new System.Drawing.Point(164, 64);
+            textBox3.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox3.Name = "textBox3";
+            textBox3.Size = new System.Drawing.Size(219, 23);
+            textBox3.TabIndex = 9;
+            textBox3.WordWrap = false;
             // 
             // label7
             // 
-            this.label7.Location = new System.Drawing.Point(8, 67);
-            this.label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label7.Name = "label7";
-            this.label7.Size = new System.Drawing.Size(109, 28);
-            this.label7.TabIndex = 8;
-            this.label7.Text = "Path for result files";
+            label7.Location = new System.Drawing.Point(8, 67);
+            label7.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label7.Name = "label7";
+            label7.Size = new System.Drawing.Size(109, 28);
+            label7.TabIndex = 8;
+            label7.Text = "Path for result files";
             // 
             // textBox2
             // 
-            this.textBox2.Enabled = false;
-            this.textBox2.Location = new System.Drawing.Point(164, 24);
-            this.textBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.textBox2.Name = "textBox2";
-            this.textBox2.Size = new System.Drawing.Size(219, 23);
-            this.textBox2.TabIndex = 7;
-            this.textBox2.WordWrap = false;
+            textBox2.Enabled = false;
+            textBox2.Location = new System.Drawing.Point(164, 24);
+            textBox2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            textBox2.Name = "textBox2";
+            textBox2.Size = new System.Drawing.Size(219, 23);
+            textBox2.TabIndex = 7;
+            textBox2.WordWrap = false;
             // 
             // label6
             // 
-            this.label6.Location = new System.Drawing.Point(8, 24);
-            this.label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
-            this.label6.Name = "label6";
-            this.label6.Size = new System.Drawing.Size(109, 35);
-            this.label6.TabIndex = 6;
-            this.label6.Text = "Path to emission modulation files";
+            label6.Location = new System.Drawing.Point(8, 24);
+            label6.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
+            label6.Name = "label6";
+            label6.Size = new System.Drawing.Size(109, 35);
+            label6.TabIndex = 6;
+            label6.Text = "Path to emission modulation files";
+            // 
+            // checkBox4
+            // 
+            checkBox4.AutoSize = true;
+            checkBox4.Location = new System.Drawing.Point(26, 53);
+            checkBox4.Name = "checkBox4";
+            checkBox4.Size = new System.Drawing.Size(180, 19);
+            checkBox4.TabIndex = 6;
+            checkBox4.Text = "based on hourly mean values";
+            checkBox4.UseVisualStyleBackColor = true;
+            // 
+            // checkBox5
+            // 
+            checkBox5.AutoSize = true;
+            checkBox5.Location = new System.Drawing.Point(25, 143);
+            checkBox5.Name = "checkBox5";
+            checkBox5.Size = new System.Drawing.Size(180, 19);
+            checkBox5.TabIndex = 8;
+            checkBox5.Text = "based on hourly mean values";
+            checkBox5.UseVisualStyleBackColor = true;
             // 
             // SelectSourcegroups
             // 
-            this.AcceptButton = this.button1;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.button2;
-            this.ClientSize = new System.Drawing.Size(413, 583);
-            this.ControlBox = false;
-            this.Controls.Add(this.groupBox3);
-            this.Controls.Add(this.groupBox2);
-            this.Controls.Add(this.groupBox1);
-            this.Controls.Add(this.checkBox3);
-            this.Controls.Add(this.checkBox2);
-            this.Controls.Add(this.checkBox1);
-            this.Controls.Add(this.button2);
-            this.Controls.Add(this.button1);
-            this.Controls.Add(this.listBox1);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.Margin = new System.Windows.Forms.Padding(2);
-            this.MinimumSize = new System.Drawing.Size(370, 600);
-            this.Name = "SelectSourcegroups";
-            this.StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
-            this.Text = "Select Source Groups";
-            this.Load += new System.EventHandler(this.SelectSourcegroups_Load);
-            this.Shown += new System.EventHandler(this.SelectSourcegroupsShown);
-            this.ResizeEnd += new System.EventHandler(this.SelectSourcegroupsResizeEnd);
-            this.groupBox1.ResumeLayout(false);
-            this.groupBox1.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown3)).EndInit();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown1)).EndInit();
-            this.groupBox2.ResumeLayout(false);
-            this.groupBox2.PerformLayout();
-            ((System.ComponentModel.ISupportInitialize)(this.numericUpDown2)).EndInit();
-            this.groupBox3.ResumeLayout(false);
-            this.groupBox3.PerformLayout();
-            this.ResumeLayout(false);
-
+            AcceptButton = button1;
+            AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
+            AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            CancelButton = button2;
+            ClientSize = new System.Drawing.Size(413, 586);
+            ControlBox = false;
+            Controls.Add(groupBox3);
+            Controls.Add(groupBox2);
+            Controls.Add(groupBox1);
+            Controls.Add(checkBox3);
+            Controls.Add(checkBox2);
+            Controls.Add(checkBox1);
+            Controls.Add(button2);
+            Controls.Add(button1);
+            Controls.Add(listBox1);
+            Icon = (System.Drawing.Icon)resources.GetObject("$this.Icon");
+            Margin = new System.Windows.Forms.Padding(2);
+            MinimumSize = new System.Drawing.Size(370, 600);
+            Name = "SelectSourcegroups";
+            StartPosition = System.Windows.Forms.FormStartPosition.CenterParent;
+            Text = "Select Source Groups";
+            Load += SelectSourcegroups_Load;
+            Shown += SelectSourcegroupsShown;
+            ResizeEnd += SelectSourcegroupsResizeEnd;
+            groupBox1.ResumeLayout(false);
+            groupBox1.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown3).EndInit();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown1).EndInit();
+            groupBox2.ResumeLayout(false);
+            groupBox2.PerformLayout();
+            ((System.ComponentModel.ISupportInitialize)numericUpDown2).EndInit();
+            groupBox3.ResumeLayout(false);
+            groupBox3.PerformLayout();
+            ResumeLayout(false);
         }
+
         private System.Windows.Forms.Label label5;
         public System.Windows.Forms.NumericUpDown numericUpDown3;
         private System.Windows.Forms.Label label4;
@@ -480,5 +476,7 @@
         private System.Windows.Forms.Button buttonResultPath;
         private System.Windows.Forms.Button buttonModulationPath;
         private System.Windows.Forms.ToolTip toolTip1;
+        private System.Windows.Forms.CheckBox checkBox5;
+        private System.Windows.Forms.CheckBox checkBox4;
     }
 }

--- a/src/GRALMainSubForms/SelectSourcegroups.cs
+++ b/src/GRALMainSubForms/SelectSourcegroups.cs
@@ -27,10 +27,12 @@ namespace GralMainForms
         private int Mode = 0;
         private bool transientMode = false;
         public string PathToEmissionModulation = string.Empty;
-        public string PathForResultFiles = string.Empty;             
-		public string Prefix
-		{ get 
-        	{ if (_prefix.Length > 0)
+        public string PathForResultFiles = string.Empty;
+        public string Prefix
+        {
+            get
+            {
+                if (_prefix.Length > 0)
                 {
                     return _prefix + "_";
                 }
@@ -38,8 +40,17 @@ namespace GralMainForms
                 {
                     return String.Empty;
                 }
-            } set {_prefix = value;}
-		}
+            }
+            set { _prefix = value; }
+        }
+        /// <summary>
+        /// Enable checkbox for the evaluation of hourly mean values before calculating the percentiles
+        /// </summary>
+        public bool EnableHourlyMeanValuesCheckbox = false;
+        /// <summary>
+        /// Checkbox for the evaluation of hourly mean values before calculating the percentiles checked?
+        /// </summary>
+        public bool HourlyMeanValuesChecked = false;
 
         /// <summary>
         /// 
@@ -48,12 +59,12 @@ namespace GralMainForms
         /// <param name="_mode"> 0 = default, 1 = Percentile, 2 = Odour</param>
         /// <param name="_PathToEmissionModulation"></param>
         /// <param name="_PathForResultFiles"></param>
-        public SelectSourcegroups (Main f, int _mode, string _PathToEmissionModulation, string _PathForResultFiles, bool TransientMode)
-		{
-			Mode = _mode; // 0 = standard, 1 = Percentile, 2 = Odour
+        public SelectSourcegroups(Main f, int _mode, string _PathToEmissionModulation, string _PathForResultFiles, bool TransientMode)
+        {
+            Mode = _mode; // 0 = standard, 1 = Percentile, 2 = Odour
             transientMode = TransientMode;
 
-			if (!string.IsNullOrEmpty(_PathToEmissionModulation))
+            if (!string.IsNullOrEmpty(_PathToEmissionModulation))
             {
                 PathToEmissionModulation = _PathToEmissionModulation;
             }
@@ -62,29 +73,32 @@ namespace GralMainForms
                 PathForResultFiles = _PathForResultFiles;
             }
 
-			InitializeComponent ();
-			form1 = f;
-						
-			#if __MonoCS__
+            InitializeComponent();
+            form1 = f;
+
+#if __MonoCS__
 			    // set Numericupdowns-Alignement to Left in Linux
 				var allNumUpDowns  = Main.GetAllControls<NumericUpDown>(this);
 				foreach (NumericUpDown nu in allNumUpDowns)
 				{
 					nu.TextAlign = HorizontalAlignment.Left;
 				}
-			#else
-			    //
-			#endif
-		}
+#else
+            //
+#endif
+        }
 
         private void button1_Click(object sender, EventArgs e) // OK or Cancel button
         {
+            HourlyMeanValuesChecked = checkBox4.Checked | checkBox5.Checked;
             Hide();
         }
 
         private void SelectSourcegroups_Load(object sender, EventArgs e)
         {
-        	//fill listbox with source groups
+            checkBox4.Enabled = EnableHourlyMeanValuesCheckbox;
+            checkBox5.Enabled = EnableHourlyMeanValuesCheckbox;
+            //fill listbox with source groups
             if (Main.DefinedSourceGroups.Count > 0)
             {
                 for (int i = 0; i < form1.listView1.Items.Count; i++)
@@ -110,29 +124,29 @@ namespace GralMainForms
             if (transientMode)
             {
                 textBox2.Enabled = false;
-                buttonModulationPath.Enabled = false;  
+                buttonModulationPath.Enabled = false;
                 label6.Enabled = false;
             }
 
             if (Mode == 0) // do not show odour group box
-			{
-				groupBox1.Visible = false;
-				groupBox2.Visible = false;				
-			}
-			
-			if (Mode == 1)
-			{
-				groupBox2.Visible = true;
-				numericUpDown2.Enabled = true;
-				groupBox1.Visible = false;
-			}
-			
-			if (Mode == 2)
-			{
-				groupBox1.Visible = true;
-				groupBox2.Visible = false;		
-				radioButton1.Checked = true;
-				numericUpDown3.Enabled = true;
+            {
+                groupBox1.Visible = false;
+                groupBox2.Visible = false;
+            }
+
+            if (Mode == 1)
+            {
+                groupBox2.Visible = true;
+                numericUpDown2.Enabled = true;
+                groupBox1.Visible = false;
+            }
+
+            if (Mode == 2)
+            {
+                groupBox1.Visible = true;
+                groupBox2.Visible = false;
+                radioButton1.Checked = true;
+                numericUpDown3.Enabled = true;
             }
 
             if (Mode == 3)
@@ -150,7 +164,7 @@ namespace GralMainForms
                 numericUpDown1.Visible = false;
                 label2.Visible = false;
                 numericUpDown3.Enabled = true;
-            }        
+            }
         }
 
         private void SetPathTextBoxes()
@@ -158,16 +172,16 @@ namespace GralMainForms
             GralStaticFunctions.St_F.SetTrimmedTextToTextBox(textBox2, PathToEmissionModulation);
             GralStaticFunctions.St_F.SetTrimmedTextToTextBox(textBox3, PathForResultFiles);
         }
-             
+
         private void checkBox2_CheckedChanged(object sender, EventArgs e)
         {
 
         }
-        
+
         void SelectSourcegroupsResizeEnd(object sender, EventArgs e)
         {
-        	listBox1.Width = ClientSize.Width - 5;
-        	listBox1.Height = Math.Max(30, groupBox3.Top - 10);
+            listBox1.Width = ClientSize.Width - 5;
+            listBox1.Height = Math.Max(30, groupBox3.Top - 10);
             groupBox3.Width = Math.Max(10, ClientSize.Width - groupBox3.Left - 15);
             textBox1.Width = Math.Max(10, groupBox3.Width - textBox1.Left - 5);
             textBox2.Width = Math.Max(10, groupBox3.Width - textBox2.Left - 5);
@@ -177,17 +191,17 @@ namespace GralMainForms
             l1 = TextRenderer.MeasureText(PathForResultFiles, textBox3.Font).Width;
             textBox3.Text = GralStaticFunctions.St_F.ReduceFileNameLenght(PathForResultFiles, (int)(PathForResultFiles.Length * (textBox3.Width / l1)));
         }
-        
+
         void TextBox1TextChanged(object sender, EventArgs e)
         {
-        	_prefix = textBox1.Text;
-        	_prefix = string.Join("_", _prefix.Split(Path.GetInvalidFileNameChars()));
-        	//label1.Text = _prefix;
+            _prefix = textBox1.Text;
+            _prefix = string.Join("_", _prefix.Split(Path.GetInvalidFileNameChars()));
+            //label1.Text = _prefix;
         }
-        
+
         void SelectSourcegroupsShown(object sender, EventArgs e)
         {
-        	
+
         }
 
         private void radioButton2_CheckedChanged(object sender, EventArgs e)
@@ -232,7 +246,7 @@ namespace GralMainForms
                 path = PathToEmissionModulation;
                 descripton = "Select the path to the emission modulation files";
             }
-            if(!path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture)) 
+            if (!path.EndsWith(Path.DirectorySeparatorChar.ToString(), StringComparison.InvariantCulture))
             {
                 path += Path.DirectorySeparatorChar;
             }

--- a/src/GRALMainSubForms/SelectSourcegroups.resx
+++ b/src/GRALMainSubForms/SelectSourcegroups.resx
@@ -1,4 +1,64 @@
-﻿<root>
+﻿<?xml version="1.0" encoding="utf-8"?>
+<root>
+  <!--
+    Microsoft ResX Schema 
+
+    Version 2.0
+
+    The primary goals of this format is to allow a simple XML format
+    that is mostly human readable. The generation and parsing of the
+    various data types are done through the TypeConverter classes
+    associated with the data types.
+
+    Example:
+
+    ... ado.net/XML headers & schema ...
+    <resheader name="resmimetype">text/microsoft-resx</resheader>
+    <resheader name="version">2.0</resheader>
+    <resheader name="reader">System.Resources.ResXResourceReader, System.Windows.Forms, ...</resheader>
+    <resheader name="writer">System.Resources.ResXResourceWriter, System.Windows.Forms, ...</resheader>
+    <data name="Name1"><value>this is my long string</value><comment>this is a comment</comment></data>
+    <data name="Color1" type="System.Drawing.Color, System.Drawing">Blue</data>
+    <data name="Bitmap1" mimetype="application/x-microsoft.net.object.binary.base64">
+        <value>[base64 mime encoded serialized .NET Framework object]</value>
+    </data>
+    <data name="Icon1" type="System.Drawing.Icon, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
+        <value>[base64 mime encoded string representing a byte array form of the .NET Framework object]</value>
+        <comment>This is a comment</comment>
+    </data>
+
+    There are any number of "resheader" rows that contain simple
+    name/value pairs.
+
+    Each data row contains a name, and value. The row also contains a
+    type or mimetype. Type corresponds to a .NET class that support
+    text/value conversion through the TypeConverter architecture.
+    Classes that don't support this are serialized and stored with the
+    mimetype set.
+
+    The mimetype is used for serialized objects, and tells the
+    ResXResourceReader how to depersist the object. This is currently not
+    extensible. For a given mimetype the value must be set accordingly:
+
+    Note - application/x-microsoft.net.object.binary.base64 is the format
+    that the ResXResourceWriter will generate, however the reader can
+    read any of the formats listed below.
+
+    mimetype: application/x-microsoft.net.object.binary.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Binary.BinaryFormatter
+            : and then encoded with base64 encoding.
+    
+    mimetype: application/x-microsoft.net.object.soap.base64
+    value   : The object must be serialized with
+            : System.Runtime.Serialization.Formatters.Soap.SoapFormatter
+            : and then encoded with base64 encoding.
+
+    mimetype: application/x-microsoft.net.object.bytearray.base64
+    value   : The object must be serialized into a byte array
+            : using a System.ComponentModel.TypeConverter
+            : and then encoded with base64 encoding.
+    -->
   <xsd:schema id="root" xmlns="" xmlns:xsd="http://www.w3.org/2001/XMLSchema" xmlns:msdata="urn:schemas-microsoft-com:xml-msdata">
     <xsd:import namespace="http://www.w3.org/XML/1998/namespace" />
     <xsd:element name="root" msdata:IsDataSet="true">
@@ -95,6 +155,9 @@
         lRxLoUm1yyrfsi/nd/8WPEITWSW3UmBS5dJqssq37D9S2f+lNWjwFzry7wwQMZ8VAAAAAElFTkSuQmCC
 </value>
   </data>
+  <metadata name="toolTip1.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+    <value>17, 17</value>
+  </metadata>
   <data name="buttonModulationPath.BackgroundImage" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAABGdBTUEAALGPC/xhBQAAAAlwSFlzAAAu

--- a/src/GRALMainSubForms/Windrose.cs
+++ b/src/GRALMainSubForms/Windrose.cs
@@ -14,6 +14,8 @@ using System;
 using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Drawing2D;
+using System.Drawing.Text;
+using System.Linq;
 using System.Windows.Forms;
 using GralStaticFunctions;
 
@@ -24,10 +26,9 @@ namespace GralMainForms
     /// </summary>
     public partial class Windrose : Form
     {
-        private Point[] WindRosePoints;
         public double[,] SectFrequ = new double[16, 8];
         public double[] WndClasses = new double[7];
-        public string MetFileName;
+public string MetFileName;
         public List<GralData.WindData> WindData;
         public int WindSectorCount = 16;
 
@@ -56,6 +57,11 @@ namespace GralMainForms
         private Pen PenDarkRed = new Pen(Color.DarkRed);
         private Pen PenBrown = new Pen(Color.Brown);
         private Pen PenGray = new Pen(Color.Gray, 1);
+        private Pen PenBlack = new Pen(Color.Black, 1);
+        private Pen[] pensWind;
+        private Pen[] pensSC;
+        private Brush[] brushesWind;
+        private Brush[] brushesSC;
         private Pen PenGrayTransparent = new Pen(Color.FromArgb(60, Color.Gray), 1);
 
         private Brush BrushBlue = new SolidBrush(Color.Blue);
@@ -72,7 +78,7 @@ namespace GralMainForms
         private StringFormat StringFormatNearFar;
 
         private Rectangle LegendPosition = St_F.WindRoseLegend;
-        private Point MousedXdY = new Point();
+        private System.Drawing.Point MousedXdY = new System.Drawing.Point();
         private bool MoveLegend = false;
         private Rectangle InfoPosition = St_F.WindRoseInfo;
         private bool MoveInfo = false;
@@ -137,8 +143,6 @@ namespace GralMainForms
 
         private void Form3_Load(object sender, EventArgs e)
         {
-            WindRosePoints = new Point[WindSectorCount * 3 + 1];
-
             if (St_F.WindRoseFormSize.Height > 100)
             {
                 this.Size = St_F.WindRoseFormSize;
@@ -161,7 +165,13 @@ namespace GralMainForms
             pictureBox1.Height = Math.Max(1, ClientRectangle.Height - 1);
             LegendPosition = St_F.WindRoseLegend;
             InfoPosition = St_F.WindRoseInfo;
-            MouseWheel += new MouseEventHandler(form_MouseWheel); 
+            MouseWheel += new MouseEventHandler(form_MouseWheel);
+            pensWind = new Pen[] { PenBlue, PenLightBlue, PenGreen, PenYellowGreen, PenYellow, PenOrange, PenRed, PenBrown };
+            brushesWind = new Brush[] { BrushBlue, BrushRedGreen, BrushGreen, BrushYellowGreen, BrushYellow, BrushOrange, BrushRed, BrushBrown };
+            pensSC = new Pen[] { PenBlue, PenBlue, PenLightBlue, PenGreen, PenYellowGreen, PenOrange, PenRed, PenDarkRed };
+            brushesSC = new Brush[] { BrushBlue, BrushBlue, BrushLightBlue, BrushGreen, BrushYellowGreen, BrushOrange, BrushRed, BrushDarkRed };
+            PenBlack.Width = 1.3F;
+            PenBlack.Alignment = PenAlignment.Inset;
         }
 
         void PictureBox1Paint(object sender, PaintEventArgs e)
@@ -174,9 +184,12 @@ namespace GralMainForms
             int mid_x = pictureBox1.Width / 2; // Kuntner
             int mid_y = pictureBox1.Height / 2;
 
-            //draw file name
+            e.Graphics.Clear(Color.White);
+            e.Graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            e.Graphics.TextRenderingHint = System.Drawing.Text.TextRenderingHint.ClearTypeGridFit;
             Graphics g = e.Graphics;
 
+            //draw file name
             StringFormat format2 = new StringFormat
             {
                 Alignment = StringAlignment.Center
@@ -404,36 +417,22 @@ namespace GralMainForms
 
             for (int n = 7; n >= 0; n--)
             {
-                int l = 1;
                 for (int i = 0; i < WindSectorCount; i++)
                 {
-                    //coordinates wind rose - drawing
-                    int x1 = 0; int y1 = 0; int x2 = 0; int y2 = 0;
-                    try
-                    {
-                        x1 = Convert.ToInt32(Math.Sin(sectorangle * i - sectorwidth) * sektsum[i] * scale);
-                        y1 = Convert.ToInt32(Math.Cos(sectorangle * i - sectorwidth) * sektsum[i] * scale);
-                        x2 = Convert.ToInt32(Math.Sin(sectorangle * i + sectorwidth) * sektsum[i] * scale);
-                        y2 = Convert.ToInt32(Math.Cos(sectorangle * i + sectorwidth) * sektsum[i] * scale);
-                    }
-                    catch
-                    {
-                    }
-                    WindRosePoints[i + l - 1] = new Point(mid_x, mid_y);
-                    WindRosePoints[i + l] = new Point(mid_x + x1, mid_y - y1);
-                    WindRosePoints[i + l + 1] = new Point(mid_x + x2, mid_y - y2);
-                    WindRosePoints[i + l + 2] = new Point(mid_x, mid_y);
+                    int radius = Convert.ToInt32(sektsum[i] * scale);
+                    float startAngle = (float)(sectorangle * i - sectorwidth) * 180 / MathF.PI - 90;
+                    float sectorAnglePie = (float)(sectorwidth * 2) * 180 / MathF.PI;
+                    
                     sektsum[i] = sektsum[i] - SectFrequ[i, n];
-                    l += 2;
-                }
-
-                if (DrawingMode == 0)
-                {
-                    DrawWindSpeedRose(g, n);
-                }
-                else if (DrawingMode == 1)
-                {
-                    DrawWindSCRose(g, n);
+                    
+                    if (DrawingMode == 0)
+                    {
+                        DrawWindSpeedRose(g, pensWind, brushesWind, n, mid_x, mid_y, radius, startAngle, sectorAnglePie);
+                    }
+                    else if (DrawingMode == 1 && n > 0)
+                    {
+                        DrawWindSpeedRose(g, pensSC, brushesSC, 8 - n, mid_x, mid_y, radius, startAngle, sectorAnglePie);
+                    }
                 }
 
                 PenGrayTransparent.DashStyle = DashStyle.Dot;
@@ -461,101 +460,47 @@ namespace GralMainForms
         private void DrawWindSpeedScale(Graphics g, int n, int VertDist, int y0, Font kleinfont)
         {
             int x_legend = LegendPosition.X * CopyToClipboardScale;
-
-            switch (n)
+           
+           
+            if (n >= 0 && n < 8 && n < pensWind.Length && n < brushesWind.Length)
             {
-                case 7:
-                    g.DrawRectangle(PenBlue, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushBlue, x_legend, y0, 20, VertDist);
-                    g.DrawString("0.0 - " + Convert.ToString(WndClasses[0]) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 6:
-                    g.DrawRectangle(PenLightBlue, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushRedGreen, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[0]).PadLeft(2) + " -" + Convert.ToString(WndClasses[1]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 5:
-                    g.DrawRectangle(PenGreen, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushGreen, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[1]).PadLeft(2) + " -" + Convert.ToString(WndClasses[2]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 4:
-                    g.DrawRectangle(PenYellowGreen, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushYellowGreen, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[2]).PadLeft(2) + " -" + Convert.ToString(WndClasses[3]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 3:
-                    g.DrawRectangle(PenYellow, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushYellow, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[3]).PadLeft(2) + " -" + Convert.ToString(WndClasses[4]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 2:
-                    g.DrawRectangle(PenOrange, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushOrange, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[4]).PadLeft(2) + " -" + Convert.ToString(WndClasses[5]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 1:
-                    g.DrawRectangle(PenRed, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushRed, x_legend, y0, 20, VertDist);
-                    g.DrawString(Convert.ToString(WndClasses[5]).PadLeft(2) + " -" + Convert.ToString(WndClasses[6]).PadLeft(2) + " m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
-                case 0:
-                    g.DrawRectangle(PenBrown, x_legend, y0, 20, VertDist);
-                    g.FillRectangle(BrushBrown, x_legend, y0, 20, VertDist);
-                    g.DrawString(">" + Convert.ToString(WndClasses[6]).PadLeft(2) + "m/s",
-                                 kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
-                    break;
+                switch (n)
+                {
+                    case 7:
+                        g.DrawRectangle(pensWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.FillRectangle(brushesWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.DrawString("0.0 - " + Convert.ToString(WndClasses[0]) + " m/s",
+                                     kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
+                        break;
+                    case 1:
+                    case 2:
+                    case 3:
+                    case 4:
+                    case 5:
+                    case 6:
+                        g.DrawRectangle(pensWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.FillRectangle(brushesWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.DrawString(Convert.ToString(WndClasses[6 - n]).PadLeft(2) + " -" + Convert.ToString(WndClasses[7 - n]).PadLeft(2) + " m/s",
+                                     kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
+                        break;
+                    case 0:
+                        g.DrawRectangle(pensWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.FillRectangle(brushesWind[7 - n], x_legend, y0, 20, VertDist);
+                        g.DrawString(">" + Convert.ToString(WndClasses[6]).PadLeft(2) + "m/s",
+                                     kleinfont, BrushBlack, x_legend + 26, y0, StringFormatNearFar);
+                        break;
+                }
             }
         }
 
         private void DrawWindSCScale(Graphics g, int n, int VertDist, int y0, Font kleinfont)
         {
-            int x_legend = LegendPosition.X * CopyToClipboardScale;
-
-            switch (n)
+            if (n > 0 && n < 8 && n < pensSC.Length && n < brushesSC.Length)
             {
-                case 7:
-                    g.DrawRectangle(PenDarkRed, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushDarkRed, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 1", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 6:
-                    g.DrawRectangle(PenRed, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushRed, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 2", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 5:
-                    g.DrawRectangle(PenOrange, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushOrange, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 3", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 4:
-                    g.DrawRectangle(PenYellowGreen, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushYellowGreen, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 4", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 3:
-                    g.DrawRectangle(PenGreen, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushGreen, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 5", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 2:
-                    g.DrawRectangle(PenLightBlue, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushLightBlue, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 6", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
-                case 1:
-                    g.DrawRectangle(PenBlue, x_legend, y0, 25, VertDist);
-                    g.FillRectangle(BrushBlue, x_legend, y0, 25, VertDist);
-                    g.DrawString("SC 7", kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
-                    break;
+                int x_legend = LegendPosition.X * CopyToClipboardScale;
+                g.DrawRectangle(pensSC[n], x_legend, y0, 25, VertDist);
+                g.FillRectangle(brushesSC[n], x_legend, y0, 25, VertDist);
+                g.DrawString("SC " + (8 - n).ToString(), kleinfont, BrushBlack, x_legend + 30, y0, StringFormatNearFar);
             }
         }
 
@@ -564,187 +509,25 @@ namespace GralMainForms
         /// </summary>
         /// <param name="g"></param>
         /// <param name="n"></param>
-        private void DrawWindSpeedRose(Graphics g, int n)
+        private void DrawWindSpeedRose(Graphics g, Pen[] pen, Brush[] brush, int n, int mid_x, int mid_y, int radius, float startAngle, float sectorAngle)
         {
-            switch (n)
+            if (radius > 0)
             {
-                case 7:
-                    g.FillPolygon(BrushBrown, WindRosePoints);
-                    if (!DrawFrames)
+                if (n >= 0 && n < brush.Length)
+                {
+                    g.FillPie(brush[n], new Rectangle(mid_x - radius, mid_y - radius, radius * 2, radius * 2), startAngle, sectorAngle);
+                }
+                if (n >= 0 && n < brush.Length)
+                {
+                    if (DrawFrames)
                     {
-                        g.DrawPolygon(PenBrown, WindRosePoints);
+                        g.DrawPie(PenBlack, new Rectangle(mid_x - radius, mid_y - radius, radius * 2, radius * 2), startAngle, sectorAngle);
                     }
                     else
                     {
-                        g.DrawPolygon(PenGray, WindRosePoints);
+                        g.DrawPie(pen[n], new Rectangle(mid_x - radius, mid_y - radius, radius * 2, radius * 2), startAngle, sectorAngle);
                     }
-                    break;
-                case 6:
-                    g.FillPolygon(BrushRed, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenRed, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 5:
-                    g.FillPolygon(BrushOrange, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenOrange, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 4:
-                    g.FillPolygon(BrushYellow, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenYellow, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 3:
-                    g.FillPolygon(BrushYellowGreen, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenYellowGreen, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 2:
-                    g.FillPolygon(BrushGreen, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenGreen, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 1:
-                    g.FillPolygon(BrushRedGreen, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenLightBlue, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 0:
-                    g.FillPolygon(BrushBlue, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenBlue, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-            }
-        }
-
-        /// <summary>
-        /// Draw Stability Class Wind Rose Sectors
-        /// </summary>
-        /// <param name="g"></param>
-        /// <param name="n"></param>
-        private void DrawWindSCRose(Graphics g, int n)
-        {
-            switch (n)
-            {
-                case 7:
-                    g.FillPolygon(BrushBlue, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenBlue, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 6:
-                    g.FillPolygon(BrushLightBlue, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenLightBlue, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 5:
-                    g.FillPolygon(BrushGreen, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenGreen, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 4:
-                    g.FillPolygon(BrushYellowGreen, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenYellowGreen, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 3:
-                    g.FillPolygon(BrushOrange, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenOrange, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 2:
-                    g.FillPolygon(BrushRed, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenRed, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
-                case 1:
-                    g.FillPolygon(BrushDarkRed, WindRosePoints);
-                    if (!DrawFrames)
-                    {
-                        g.DrawPolygon(PenDarkRed, WindRosePoints);
-                    }
-                    else
-                    {
-                        g.DrawPolygon(PenGray, WindRosePoints);
-                    }
-                    break;
+                }             
             }
         }
 
@@ -764,7 +547,7 @@ namespace GralMainForms
             pictureBox1.Height *= CopyToClipboardScale;
             IniScale *= CopyToClipboardScale;
             pictureBox1.Refresh();
-            Application.DoEvents();
+            System.Windows.Forms.Application.DoEvents();
             Bitmap bitMap = new Bitmap(pictureBox1.Width, pictureBox1.Height);
             pictureBox1.DrawToBitmap(bitMap, new Rectangle(0, 0, pictureBox1.Width, pictureBox1.Height));
             Clipboard.SetDataObject(bitMap);
@@ -819,6 +602,7 @@ namespace GralMainForms
             PenYellowGreen.Dispose();
             PenYellow.Dispose();
             PenGray.Dispose();
+            PenBlack.Dispose();
             PenDarkRed.Dispose();
             PenGrayTransparent.Dispose();
 

--- a/src/GRALShapeFiles/ShapeWriterBourkeLines.cs
+++ b/src/GRALShapeFiles/ShapeWriterBourkeLines.cs
@@ -1,0 +1,280 @@
+﻿#region Copyright
+///<remarks>
+/// <GRAL Graphical User Interface GUI>
+/// Copyright (C) [2024]  [Markus Kuntner]
+/// This program is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by
+/// the Free Software Foundation version 3 of the License
+/// This program is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of
+/// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+/// You should have received a copy of the GNU General Public License along with this program.  If not, see <https://www.gnu.org/licenses/>.
+///</remarks>
+#endregion
+
+using GralDomain;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.IO;
+
+namespace GralShape
+{
+    /// <summary>
+    /// Write a shape file
+    /// </summary>
+    public partial class ShapeWriter
+    {
+#if __MonoCS__
+        public void WriteBourkeLineShapeFile(string filename, DrawingObjects _drobj, ref DataSet dsline)
+        {
+            Byte[] data = new Byte[4];
+            Byte[] data8 = new Byte[8];
+#else
+        public void WriteBourkeLineShapeFile(string filename, DrawingObjects _drobj, ref readonly DataSet dsline)
+        {
+            Span<byte> data = stackalloc byte[4];
+            Span<byte> data8 = stackalloc Byte[8];
+#endif
+            //shape Type PolyLine
+            const int shapetype = 3;
+
+            //bounding box
+            xMin = double.MaxValue;
+            yMin = double.MaxValue;
+            xMax = double.MinValue;
+            yMax = double.MinValue;
+            double x1, y1, x2, y2 = 0;
+            
+            // loop over all contour points, create the bounding box
+            for (int i = 0; i < _drobj.ContourPoints.Count; i++)
+            {
+                int step = -2;
+                int step_max = _drobj.ContourPoints[i].Count - 3;
+                System.Drawing.PointF[] contourpoints_name_i = _drobj.ContourPoints[i].ToArray();
+                while (step < step_max)
+                {
+                    step += 2;
+                    x1 = contourpoints_name_i[step].X;
+                    y1 = contourpoints_name_i[step].Y;
+                    x2 = contourpoints_name_i[step + 1].X;
+                    y2 = contourpoints_name_i[step + 1].Y;
+                    xMin = Math.Min(xMin, x1);
+                    xMin = Math.Min(xMin, x2);
+                    yMin = Math.Min(yMin, y1);
+                    yMin = Math.Min(yMin, y2);
+                    xMax = Math.Max(xMax, x1);
+                    xMax = Math.Max(xMax, x2);
+                    yMax = Math.Max(yMax, y1);
+                    yMax = Math.Max(yMax, y2);
+                }
+            }
+
+            // loop over all contour points, creation of polylines that are as contiguous as possible
+            List<BourkeLineData> points = new List<BourkeLineData>();
+            for (int i = 0; i < _drobj.ContourPoints.Count; i++)
+            {
+                int step = 0;
+                int step_max = _drobj.ContourPoints[i].Count - 2;
+                System.Drawing.PointF[] contourpoints_name_i = _drobj.ContourPoints[i].ToArray();
+                byte[] used = new byte[contourpoints_name_i.Length];
+
+                while (step < step_max)
+                {
+                    // add the next polyline 
+                    if (used[step] == 0)
+                    {
+                        //add the 1st and 2nd point
+                        points.Add(new BourkeLineData());
+                        int recentPolyline = points.Count - 1;
+                        points[recentPolyline].ItemValue = _drobj.ItemValues[i];
+                        points[recentPolyline].Pt.Add(new PointD(contourpoints_name_i[step].X, contourpoints_name_i[step].Y));
+                        used[step] = 1;
+                        points[recentPolyline].Pt.Add(new PointD(contourpoints_name_i[step + 1].X, contourpoints_name_i[step + 1].Y));
+                        used[step + 1] = 1;
+
+                        //search additional points
+                        int innerLoop = 2;
+                        while (innerLoop < step_max)
+                        {
+                            if (used[innerLoop] == 0)
+                            {
+                                // add a contigous line segment and start searching
+                                if (Math.Abs(points[recentPolyline].Pt[points[recentPolyline].Pt.Count - 1].X - contourpoints_name_i[innerLoop].X) < 0.4 &&
+                                    Math.Abs(points[recentPolyline].Pt[points[recentPolyline].Pt.Count - 1].Y - contourpoints_name_i[innerLoop].Y) < 0.4)
+                                {
+                                    used[innerLoop] = 1;
+                                    points[recentPolyline].Pt.Add(new PointD(contourpoints_name_i[innerLoop + 1].X, contourpoints_name_i[innerLoop + 1].Y));
+                                    used[innerLoop + 1] = 1;
+                                    innerLoop = 0;
+                                }
+                                // add a contigous line segment and start searching
+                                if (innerLoop > 2 && Math.Abs(points[recentPolyline].Pt[points[recentPolyline].Pt.Count - 1].X - contourpoints_name_i[innerLoop + 1].X) < 0.4 &&
+                                    Math.Abs(points[recentPolyline].Pt[points[recentPolyline].Pt.Count - 1].Y - contourpoints_name_i[innerLoop + 1].Y) < 0.4)
+                                {
+                                    used[innerLoop] = 1;
+                                    points[recentPolyline].Pt.Add(new PointD(contourpoints_name_i[innerLoop].X, contourpoints_name_i[innerLoop].Y));
+                                    used[innerLoop + 1] = 1;
+                                    innerLoop = 0;
+                                }
+                            }
+                            innerLoop += 2;
+                        }
+                    }
+                    step += 2;
+                }
+            }
+
+            for (int loop = 0; loop < points.Count; loop++)
+            {
+                if (points[loop].Pt.Count == 0)
+                {
+                    points.RemoveAt(loop);
+                    loop = 0;
+                }
+            }
+
+            //write main file header
+            (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, points.Count);
+            if (fs != null && fshx != null)
+            {
+                //write bounding box
+                data8 = WriteDoubleLittle(xMin);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(yMin);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(xMax);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(yMax);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(0);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(0);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(0);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                data8 = WriteDoubleLittle(0);
+                writeBytes(fs, data8);
+                writeBytes(fshx, data8);
+                int recordNumber = 0;
+                int offset = 50;
+
+                //write records: header and record to .shp file
+                //offset and index to .shx file
+                foreach (BourkeLineData _pts in points)
+                {
+                    if (_pts.Pt.Count > 0)
+                    {
+                        dsline.Tables[0].Rows.Add(_pts.ItemValue.ToString(), _drobj.LegendUnit.Replace("µ", "u").Replace("³", "3").Replace("²", "2"));
+                        recordNumber += 1;
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        writeBytes(fs, data);
+                        //offset
+                        data = WriteIntBig(offset);
+                        writeBytes(fshx, data);
+                        offset = offset + 4 + 24 + 8 * _pts.Pt.Count;
+                        //content length
+                        data = WriteIntBig(24 + 8 * _pts.Pt.Count);
+                        writeBytes(fs, data);
+                        writeBytes(fshx, data);
+                        //shape type
+                        data = WriteIntLittle(3);
+                        writeBytes(fs, data);
+                        //Box
+                        xMin = double.MaxValue;
+                        yMin = double.MaxValue;
+                        xMax = double.MinValue;
+                        yMax = double.MinValue;
+                        for (int i = 0; i < _pts.Pt.Count - 1; i++)
+                        {
+                            x1 = _pts.Pt[i].X;
+                            y1 = _pts.Pt[i].Y;
+                            x2 = _pts.Pt[i + 1].X;
+                            y2 = _pts.Pt[i + 1].Y;
+                            xMin = Math.Min(xMin, x1);
+                            xMin = Math.Min(xMin, x2);
+                            yMin = Math.Min(yMin, y1);
+                            yMin = Math.Min(yMin, y2);
+                            xMax = Math.Max(xMax, x1);
+                            xMax = Math.Max(xMax, x2);
+                            yMax = Math.Max(yMax, y1);
+                            yMax = Math.Max(yMax, y2);
+                        }
+                        data8 = WriteDoubleLittle(xMin);
+                        writeBytes(fs, data8);
+                        data8 = WriteDoubleLittle(yMin);
+                        writeBytes(fs, data8);
+                        data8 = WriteDoubleLittle(xMax);
+                        writeBytes(fs, data8);
+                        data8 = WriteDoubleLittle(yMax);
+                        writeBytes(fs, data8);
+                        //the number of parts in the polyline
+                        data = WriteIntLittle(1);
+                        writeBytes(fs, data);
+                        //the total number of points of all polylines
+                        data = WriteIntLittle(_pts.Pt.Count);
+                        writeBytes(fs, data);
+                        //index of first point of each polyline
+                        data = WriteIntLittle(0);
+                        writeBytes(fs, data);
+                        //points of each polyline
+                        for (int i = 0; i < _pts.Pt.Count; i++)
+                        {
+                            x1 = _pts.Pt[i].X;
+                            y1 = _pts.Pt[i].Y;
+                            data8 = WriteDoubleLittle(x1);
+                            writeBytes(fs, data8);
+                            data8 = WriteDoubleLittle(y1);
+                            writeBytes(fs, data8);
+                        }
+                    }
+                }
+
+                //filelength updated
+                long dummy = fs.Length / 2;
+                int filelength = (int)dummy;
+                data = WriteIntBig(filelength);
+                fs.Position = 24;
+                writeBytes(fs, data);
+                fs.Close(); fshx.Close();
+                fs.Dispose(); fshx.Dispose();
+                //clean point list
+                foreach (BourkeLineData _pts in points)
+                {
+                    _pts.Pt.Clear();
+                    _pts.Pt.TrimExcess();
+                }
+                points.Clear();
+                points.TrimExcess();
+            }
+        }
+#if !__MonoCS__
+        private void writeBytes(FileStream fs, Span<byte> bytes)
+        {
+            fs.Write(bytes);
+        }
+#endif
+        private void writeBytes(FileStream fs, byte[] bytes)
+        {
+            fs.Write(bytes, 0, bytes.Length);
+        }
+
+        private class BourkeLineData
+        {
+            public double ItemValue { get; set; }
+            public List<PointD> Pt { get; set; }
+
+            public BourkeLineData()
+            {
+                ItemValue = 0;
+                Pt = new List<PointD>();
+            }
+        }
+    }
+}

--- a/src/GRALShapeFiles/Shapereader.cs
+++ b/src/GRALShapeFiles/Shapereader.cs
@@ -261,7 +261,7 @@ namespace GralShape
                         if (polygon.NumParts > 1)
                         {
                             parts --;
-                            for (int i = polygon.NumPoints; i < (polygon.NumPoints + polygon.NumParts -1); i++)
+                            for (int i = polygon.NumPoints; i < (polygon.NumPoints + polygon.NumParts - 1); i++)
                             {
                                 polygon.Points[i].X = ruecksprung[parts].X;
                                 polygon.Points[i].Y = ruecksprung[parts].Y;

--- a/src/GRALShapeFiles/Shapewriter.cs
+++ b/src/GRALShapeFiles/Shapewriter.cs
@@ -653,9 +653,9 @@ namespace GralShape
                         //offset
                         data = WriteIntBig(offset);
                         fshx.Write(data, 0, 4);
-                        offset = offset + 4 + 24 + 8 * (_bu.Pt.Count);
+                        offset = offset + 4 + 24 + 8 * (_bu.Pt.Count + 1);
                         //content length
-                        data = WriteIntBig(24 + 8 * (_bu.Pt.Count));
+                        data = WriteIntBig(24 + 8 * (_bu.Pt.Count + 1));
                         fs.Write(data, 0, 4);
                         fshx.Write(data, 0, 4);
                         //shape type
@@ -688,7 +688,7 @@ namespace GralShape
                         data = WriteIntLittle(1);
                         fs.Write(data, 0, 4);
                         //the total number of points of all polylines
-                        data = WriteIntLittle(_bu.Pt.Count);
+                        data = WriteIntLittle(_bu.Pt.Count + 1);
                         fs.Write(data, 0, 4);
                         //index of first point of each polyline
                         data = WriteIntLittle(0);
@@ -770,7 +770,13 @@ namespace GralShape
                                 data8 = WriteDoubleLittle(y1);
                                 fs.Write(data8, 0, 8);
                             }
-                            //write first point again to close the polygon
+                            //Write the first point again, so that the polygon is closed
+                            x1 = Convert.ToDouble(_bu.Pt[0].X);
+                            y1 = Convert.ToDouble(_bu.Pt[0].Y);
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
                         }
                         else
                         {
@@ -783,6 +789,13 @@ namespace GralShape
                                 data8 = WriteDoubleLittle(y1);
                                 fs.Write(data8, 0, 8);
                             }
+                            //Write the first point again, so that the polygon is closed
+                            x1 = Convert.ToDouble(_bu.Pt[_bu.Pt.Count - 1].X);
+                            y1 = Convert.ToDouble(_bu.Pt[_bu.Pt.Count - 1].Y);
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
                         }
                     }
 
@@ -808,9 +821,9 @@ namespace GralShape
                 {
                     //bounding box
                     xMin = domain.MainForm.GralDomRect.West;
-                    yMin = domain.MainForm.GralDomRect.North;
+                    yMin = domain.MainForm.GralDomRect.South;
                     xMax = domain.MainForm.GralDomRect.East;
-                    yMax = domain.MainForm.GralDomRect.South;
+                    yMax = domain.MainForm.GralDomRect.North;
 
                     data8 = WriteDoubleLittle(xMin);
                     fs.Write(data8, 0, 8);

--- a/src/GRALShapeFiles/Shapewriter.cs
+++ b/src/GRALShapeFiles/Shapewriter.cs
@@ -37,278 +37,803 @@ namespace GralShape
 
         public void WriteShapeFile(string filename, int shapetype)
         {
-            //construct file name for index file .shx
-            ShxFile = filename.Replace(".shp", ".shx");
+            Byte[] data = new Byte[4];
+            Byte[] data8 = new Byte[8];
             //export line sources
             if (shapetype == 3)
             {
                 //write main file header
-                FileStream fs = new FileStream(filename, FileMode.Create);
-                FileStream fshx = new FileStream(ShxFile, FileMode.Create);
-                Byte[] data = new Byte[4];
-                Byte[] data8 = new Byte[8];
-                //version
-                data = WriteIntBig(9994);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //not used
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //filelength (needs to be updated at the end of the stream
-                data = WriteIntBig(1000);
-                fs.Write(data, 0, 4);
-                //filelength of .shx file =50+4*records
-                int filelong = 50 + 4 * domain.EditLS.ItemData.Count;
-                data = WriteIntBig(filelong);
-                fshx.Write(data, 0, 4);
-                //version
-                data = WriteIntLittle(1000);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //shape type
-                data = WriteIntLittle(shapetype);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //bounding box
-                xMin = 10000000;
-                yMin = 10000000;
-                xMax = -10000000;
-                yMax = -10000000;
-                double x1 = 0;
-                double y1 = 0;
-                double x2 = 0;
-                double y2 = 0;
-                string[] text1 = new string[1000];
-                foreach (LineSourceData _ls in domain.EditLS.ItemData)
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, domain.EditLS.ItemData.Count);
+                if (fs != null && fshx != null)
                 {
-                    for (int i = 0; i < _ls.Pt.Count - 1; i++)
-                    {
-                        x1 = _ls.Pt[i].X;
-                        y1 = _ls.Pt[i].Y;
-                        x2 = _ls.Pt[i + 1].X;
-                        y2 = _ls.Pt[i + 1].Y;
-                        xMin = Math.Min(xMin, x1);
-                        xMin = Math.Min(xMin, x2);
-                        yMin = Math.Min(yMin, y1);
-                        yMin = Math.Min(yMin, y2);
-                        xMax = Math.Max(xMax, x1);
-                        xMax = Math.Max(xMax, x2);
-                        yMax = Math.Max(yMax, y1);
-                        yMax = Math.Max(yMax, y2);
-                    }
-                }
-                
-                data8 = WriteDoubleLittle(xMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(xMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                int recordNumber = 0;
-                int offset = 50;
-                //write records: header and record to .shp file
-                //offset and index to .shx file
-                foreach (LineSourceData _ls in domain.EditLS.ItemData)
-                {
-                    recordNumber += 1;
-                    int sourcegroups = _ls.Poll.Count;
-                    //record number
-                    data = WriteIntBig(recordNumber);
-                    fs.Write(data, 0, 4);
-                    //offset
-                    data = WriteIntBig(offset);
-                    fshx.Write(data, 0, 4);
-                    offset = offset + 4 + 24 + 8 * _ls.Pt.Count;
-                    //content length
-                    data = WriteIntBig(24 + 8 *  _ls.Pt.Count);
-                    fs.Write(data, 0, 4);
-                    fshx.Write(data, 0, 4);
-                    //shape type
-                    data = WriteIntLittle(3);
-                    fs.Write(data, 0, 4);
-                    //Box
+                    //bounding box
                     xMin = 10000000;
                     yMin = 10000000;
                     xMax = -10000000;
                     yMax = -10000000;
-                    for (int i = 0; i < _ls.Pt.Count - 1; i++)
+                    double x1 = 0;
+                    double y1 = 0;
+                    double x2 = 0;
+                    double y2 = 0;
+                    string[] text1 = new string[1000];
+                    foreach (LineSourceData _ls in domain.EditLS.ItemData)
                     {
-                        x1 = _ls.Pt[i].X;
-                        y1 = _ls.Pt[i].Y;
-                        x2 = _ls.Pt[i + 1].X;
-                        y2 = _ls.Pt[i + 1].Y;
-                        xMin = Math.Min(xMin, x1);
-                        xMin = Math.Min(xMin, x2);
-                        yMin = Math.Min(yMin, y1);
-                        yMin = Math.Min(yMin, y2);
-                        xMax = Math.Max(xMax, x1);
-                        xMax = Math.Max(xMax, x2);
-                        yMax = Math.Max(yMax, y1);
-                        yMax = Math.Max(yMax, y2);
+                        for (int i = 0; i < _ls.Pt.Count - 1; i++)
+                        {
+                            x1 = _ls.Pt[i].X;
+                            y1 = _ls.Pt[i].Y;
+                            x2 = _ls.Pt[i + 1].X;
+                            y2 = _ls.Pt[i + 1].Y;
+                            xMin = Math.Min(xMin, x1);
+                            xMin = Math.Min(xMin, x2);
+                            yMin = Math.Min(yMin, y1);
+                            yMin = Math.Min(yMin, y2);
+                            xMax = Math.Max(xMax, x1);
+                            xMax = Math.Max(xMax, x2);
+                            yMax = Math.Max(yMax, y1);
+                            yMax = Math.Max(yMax, y2);
+                        }
                     }
+
                     data8 = WriteDoubleLittle(xMin);
                     fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
                     data8 = WriteDoubleLittle(yMin);
                     fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
                     data8 = WriteDoubleLittle(xMax);
                     fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
                     data8 = WriteDoubleLittle(yMax);
                     fs.Write(data8, 0, 8);
-                    //the number of parts in the polyline
-                    data = WriteIntLittle(1);
-                    fs.Write(data, 0, 4);
-                    //the total number of points of all polylines
-                    data = WriteIntLittle(_ls.Pt.Count);
-                    fs.Write(data, 0, 4);
-                    //index of first point of each polyline
-                    data = WriteIntLittle(0);
-                    fs.Write(data, 0, 4);
-                    //points of each polyline
-                    for (int i = 0; i < _ls.Pt.Count; i++)
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+                    //write records: header and record to .shp file
+                    //offset and index to .shx file
+                    foreach (LineSourceData _ls in domain.EditLS.ItemData)
                     {
-                        x1 = _ls.Pt[i].X;
-                        y1 = _ls.Pt[i].Y;
-                        data8 = WriteDoubleLittle(x1);
+                        recordNumber += 1;
+                        int sourcegroups = _ls.Poll.Count;
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 24 + 8 * _ls.Pt.Count;
+                        //content length
+                        data = WriteIntBig(24 + 8 * _ls.Pt.Count);
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(3);
+                        fs.Write(data, 0, 4);
+                        //Box
+                        xMin = 10000000;
+                        yMin = 10000000;
+                        xMax = -10000000;
+                        yMax = -10000000;
+                        for (int i = 0; i < _ls.Pt.Count - 1; i++)
+                        {
+                            x1 = _ls.Pt[i].X;
+                            y1 = _ls.Pt[i].Y;
+                            x2 = _ls.Pt[i + 1].X;
+                            y2 = _ls.Pt[i + 1].Y;
+                            xMin = Math.Min(xMin, x1);
+                            xMin = Math.Min(xMin, x2);
+                            yMin = Math.Min(yMin, y1);
+                            yMin = Math.Min(yMin, y2);
+                            xMax = Math.Max(xMax, x1);
+                            xMax = Math.Max(xMax, x2);
+                            yMax = Math.Max(yMax, y1);
+                            yMax = Math.Max(yMax, y2);
+                        }
+                        data8 = WriteDoubleLittle(xMin);
                         fs.Write(data8, 0, 8);
-                        data8 = WriteDoubleLittle(y1);
+                        data8 = WriteDoubleLittle(yMin);
                         fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(xMax);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMax);
+                        fs.Write(data8, 0, 8);
+                        //the number of parts in the polyline
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //the total number of points of all polylines
+                        data = WriteIntLittle(_ls.Pt.Count);
+                        fs.Write(data, 0, 4);
+                        //index of first point of each polyline
+                        data = WriteIntLittle(0);
+                        fs.Write(data, 0, 4);
+                        //points of each polyline
+                        for (int i = 0; i < _ls.Pt.Count; i++)
+                        {
+                            x1 = _ls.Pt[i].X;
+                            y1 = _ls.Pt[i].Y;
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
+                        }
                     }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
                 }
-
-                //filelength updated
-                double dummy = Convert.ToDouble(fs.Length * 0.5);
-                int filelength = (int)dummy;
-
-                data = WriteIntBig(filelength);
-                fs.Position = 24;
-                fs.Write(data, 0, 4);
-                fs.Close();
-                fshx.Close();
             }
             //export area sources
             else if (shapetype == 5)
             {
                 //write main file header
-                FileStream fs = new FileStream(filename, FileMode.Create);
-                FileStream fshx = new FileStream(ShxFile, FileMode.Create);
-                Byte[] data = new Byte[4];
-                Byte[] data8 = new Byte[8];
-                //version
-                data = WriteIntBig(9994);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //not used
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //filelength (needs to be updated at the end of the stream
-                data = WriteIntBig(1000);
-                fs.Write(data, 0, 4);
-                //filelength of .shx file =50+4*records
-                int filelong = 50 + 4 * domain.EditAS.ItemData.Count;
-                data = WriteIntBig(filelong);
-                fshx.Write(data, 0, 4);
-                //version
-                data = WriteIntLittle(1000);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //shape type
-                data = WriteIntLittle(shapetype);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //bounding box
-                xMin = 10000000;
-                yMin = 10000000;
-                xMax = -10000000;
-                yMax = -10000000;
-                double x1 = 0;
-                double y1 = 0;
-                
-                foreach (AreaSourceData _as in domain.EditAS.ItemData)
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, domain.EditAS.ItemData.Count);
+                if (fs != null && fshx != null)
                 {
-                    for (int i = 0; i < _as.Pt.Count; i++)
+                    //bounding box
+                    xMin = 10000000;
+                    yMin = 10000000;
+                    xMax = -10000000;
+                    yMax = -10000000;
+                    double x1 = 0;
+                    double y1 = 0;
+
+                    foreach (AreaSourceData _as in domain.EditAS.ItemData)
                     {
-                        x1 = _as.Pt[i].X;
-                        y1 = _as.Pt[i].Y;
+                        for (int i = 0; i < _as.Pt.Count; i++)
+                        {
+                            x1 = _as.Pt[i].X;
+                            y1 = _as.Pt[i].Y;
+                            xMin = Math.Min(xMin, x1);
+                            yMin = Math.Min(yMin, y1);
+                            xMax = Math.Max(xMax, x1);
+                            yMax = Math.Max(yMax, y1);
+                        }
+                    }
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+
+                    //write records: header and record
+                    foreach (AreaSourceData _as in domain.EditAS.ItemData)
+                    {
+                        recordNumber += 1;
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 24 + 8 * (_as.Pt.Count + 1);
+                        //content length
+                        data = WriteIntBig(24 + 8 * (_as.Pt.Count + 1));
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(5);
+                        fs.Write(data, 0, 4);
+                        //Box
+                        xMin = 10000000;
+                        yMin = 10000000;
+                        xMax = -10000000;
+                        yMax = -10000000;
+
+                        for (int i = 0; i < _as.Pt.Count; i++)
+                        {
+                            x1 = _as.Pt[i].X;
+                            y1 = _as.Pt[i].Y;
+                            xMin = Math.Min(xMin, x1);
+                            yMin = Math.Min(yMin, y1);
+                            xMax = Math.Max(xMax, x1);
+                            yMax = Math.Max(yMax, y1);
+                        }
+                        data8 = WriteDoubleLittle(xMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(xMax);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMax);
+                        fs.Write(data8, 0, 8);
+                        //the number of parts in the polyline
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //the total number of points of all polylines
+                        data = WriteIntLittle(_as.Pt.Count + 1);
+                        fs.Write(data, 0, 4);
+                        //index of first point of each polyline
+                        data = WriteIntLittle(0);
+                        fs.Write(data, 0, 4);
+                        //points of each polyline -> have to exported in clockwise direction!
+                        //seek the most northern point
+                        double ynorth = _as.Pt[0].Y;
+                        double xnorth = _as.Pt[0].X;
+                        double x_minus;
+                        double x_plus;
+                        double y_minus;
+                        double y_plus;
+                        int inorth = 0;
+                        for (int i = 1; i < _as.Pt.Count; i++)
+                        {
+                            x1 = _as.Pt[i].X;
+                            y1 = _as.Pt[i].Y;
+                            if (y1 > ynorth)
+                            {
+                                xnorth = x1;
+                                ynorth = y1;
+                                inorth = i;
+                            }
+                        }
+                        //check direction
+                        if (inorth > 0)
+                        {
+                            x_minus = Convert.ToDouble(_as.Pt[(inorth - 1)].X);
+                            y_minus = Convert.ToDouble(_as.Pt[(inorth - 1)].Y);
+                        }
+                        else
+                        {
+                            x_minus = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].X);
+                            y_minus = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].Y);
+                        }
+                        //check direction
+                        if (inorth < _as.Pt.Count - 1)
+                        {
+                            x_plus = Convert.ToDouble(_as.Pt[(inorth + 1)].X);
+                            y_plus = Convert.ToDouble(_as.Pt[(inorth + 1)].Y);
+                        }
+                        else
+                        {
+                            x_plus = Convert.ToDouble(_as.Pt[0].X);
+                            y_plus = Convert.ToDouble(_as.Pt[0].Y);
+                        }
+
+                        bool clockwise = true;
+                        if (x_plus < x_minus)
+                        {
+                            clockwise = false;
+                        }
+
+                        if ((x_plus < xnorth) && (x_minus < xnorth))
+                        {
+                            if (y_minus < y_plus)
+                            {
+                                clockwise = false;
+                            }
+                        }
+
+                        if ((x_plus > xnorth) && (x_minus > xnorth))
+                        {
+                            if (y_minus > y_plus)
+                            {
+                                clockwise = false;
+                            }
+                        }
+
+                        if (clockwise == true)
+                        {
+                            for (int i = 0; i < _as.Pt.Count; i++)
+                            {
+                                x1 = Convert.ToDouble(_as.Pt[i].X);
+                                y1 = Convert.ToDouble(_as.Pt[i].Y);
+
+                                data8 = WriteDoubleLittle(x1);
+                                fs.Write(data8, 0, 8);
+                                data8 = WriteDoubleLittle(y1);
+                                fs.Write(data8, 0, 8);
+                            }
+                            //write first point again to close the polygon
+                            x1 = Convert.ToDouble(_as.Pt[0].X);
+                            y1 = Convert.ToDouble(_as.Pt[0].Y);
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
+                        }
+                        else
+                        {
+                            for (int i = _as.Pt.Count - 1; i > -1; i--)
+                            {
+                                x1 = Convert.ToDouble(_as.Pt[i].X);
+                                y1 = Convert.ToDouble(_as.Pt[i].Y);
+                                data8 = WriteDoubleLittle(x1);
+                                fs.Write(data8, 0, 8);
+                                data8 = WriteDoubleLittle(y1);
+                                fs.Write(data8, 0, 8);
+                            }
+                            //write last point again to close the polygon
+                            x1 = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].X);
+                            y1 = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].Y);
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
+                        }
+                    }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
+                }
+            }
+            //export point sources
+            else if (shapetype == 1)
+            {
+                //write main file header
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, domain.EditPS.ItemData.Count);
+                if (fs != null && fshx != null)
+                {
+                    //bounding box
+                    xMin = 10000000;
+                    yMin = 10000000;
+                    xMax = -10000000;
+                    yMax = -10000000;
+                    double x1 = 0;
+                    double y1 = 0;
+
+                    foreach (PointSourceData _psdata in domain.EditPS.ItemData)
+                    {
+                        x1 = _psdata.Pt.X;
+                        y1 = _psdata.Pt.Y;
                         xMin = Math.Min(xMin, x1);
                         yMin = Math.Min(yMin, y1);
                         xMax = Math.Max(xMax, x1);
                         yMax = Math.Max(yMax, y1);
                     }
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+
+                    //write records: header and record
+                    foreach (PointSourceData _psdata in domain.EditPS.ItemData)
+                    {
+                        recordNumber += 1;
+
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 2 + 8;
+                        //content length
+                        data = WriteIntBig(2 + 8);
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //write points
+                        x1 = _psdata.Pt.X;
+                        y1 = _psdata.Pt.Y;
+                        data8 = WriteDoubleLittle(x1);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(y1);
+                        fs.Write(data8, 0, 8);
+                    }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
                 }
-                data8 = WriteDoubleLittle(xMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(xMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                int recordNumber = 0;
-                int offset = 50;
-                
-                //write records: header and record
-                foreach (AreaSourceData _as in domain.EditAS.ItemData)
+            }
+            
+            //export receptors
+            else if (shapetype == 0)
+            {
+                shapetype = 1;
+                //write main file header
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, domain.EditR.ItemData.Count);
+                if (fs != null && fshx != null)
                 {
+                    //bounding box
+                    xMin = 10000000;
+                    yMin = 10000000;
+                    xMax = -10000000;
+                    yMax = -10000000;
+                    double x1 = 0;
+                    double y1 = 0;
+
+                    foreach (ReceptorData _rd in domain.EditR.ItemData)
+                    {
+                        x1 = Math.Round(_rd.Pt.X, 1);
+                        y1 = Math.Round(_rd.Pt.Y, 1);
+                        xMin = Math.Min(xMin, x1);
+                        yMin = Math.Min(yMin, y1);
+                        xMax = Math.Max(xMax, x1);
+                        yMax = Math.Max(yMax, y1);
+                    }
+
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+                    //write records: header and record
+                    foreach (ReceptorData _rd in domain.EditR.ItemData)
+                    {
+                        recordNumber++;
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 2 + 8;
+                        //content length
+                        data = WriteIntBig(2 + 8);
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //write points
+                        x1 = Math.Round(_rd.Pt.X, 1);
+                        y1 = Math.Round(_rd.Pt.Y, 1);
+                        data8 = WriteDoubleLittle(x1);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(y1);
+                        fs.Write(data8, 0, 8);
+                    }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
+                }
+            }
+            //export buildings
+            else if (shapetype == 10)
+            {
+                shapetype = 5; // shapetype polygon
+                //write main file header
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, domain.EditB.ItemData.Count);
+                if (fs != null && fshx != null)
+                {
+                    //bounding box
+                    xMin = 10000000;
+                    yMin = 10000000;
+                    xMax = -10000000;
+                    yMax = -10000000;
+                    double x1 = 0;
+                    double y1 = 0;
+
+                    foreach (BuildingData _bu in domain.EditB.ItemData)
+                    {
+                        for (int i = 0; i < _bu.Pt.Count; i++)
+                        {
+                            x1 = _bu.Pt[i].X;
+                            y1 = _bu.Pt[i].Y;
+                            xMin = Math.Min(xMin, x1);
+                            yMin = Math.Min(yMin, y1);
+                            xMax = Math.Max(xMax, x1);
+                            yMax = Math.Max(yMax, y1);
+                        }
+                    }
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+
+                    //write records: header and record
+                    foreach (BuildingData _bu in domain.EditB.ItemData)
+                    {
+                        recordNumber += 1;
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 24 + 8 * (_bu.Pt.Count);
+                        //content length
+                        data = WriteIntBig(24 + 8 * (_bu.Pt.Count));
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(5);
+                        fs.Write(data, 0, 4);
+                        //Box
+                        xMin = 10000000;
+                        yMin = 10000000;
+                        xMax = -10000000;
+                        yMax = -10000000;
+
+                        for (int i = 0; i < _bu.Pt.Count; i++)
+                        {
+                            x1 = _bu.Pt[i].X;
+                            y1 = _bu.Pt[i].Y;
+                            xMin = Math.Min(xMin, x1);
+                            yMin = Math.Min(yMin, y1);
+                            xMax = Math.Max(xMax, x1);
+                            yMax = Math.Max(yMax, y1);
+                        }
+                        data8 = WriteDoubleLittle(xMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(xMax);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMax);
+                        fs.Write(data8, 0, 8);
+                        //the number of parts in the polyline
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //the total number of points of all polylines
+                        data = WriteIntLittle(_bu.Pt.Count);
+                        fs.Write(data, 0, 4);
+                        //index of first point of each polyline
+                        data = WriteIntLittle(0);
+                        fs.Write(data, 0, 4);
+                        //points of each polyline -> have to exported in clockwise direction!
+                        //seek the most northern point
+                        double ynorth = _bu.Pt[0].Y;
+                        double xnorth = _bu.Pt[0].X;
+                        double x_minus;
+                        double x_plus;
+                        double y_minus;
+                        double y_plus;
+                        int inorth = 0;
+                        for (int i = 1; i < _bu.Pt.Count; i++)
+                        {
+                            x1 = _bu.Pt[i].X;
+                            y1 = _bu.Pt[i].Y;
+                            if (y1 > ynorth)
+                            {
+                                xnorth = x1;
+                                ynorth = y1;
+                                inorth = i;
+                            }
+                        }
+                        //check direction
+                        if (inorth > 0)
+                        {
+                            x_minus = Convert.ToDouble(_bu.Pt[(inorth - 1)].X);
+                            y_minus = Convert.ToDouble(_bu.Pt[(inorth - 1)].Y);
+                        }
+                        else
+                        {
+                            x_minus = Convert.ToDouble(_bu.Pt[_bu.Pt.Count - 1].X);
+                            y_minus = Convert.ToDouble(_bu.Pt[_bu.Pt.Count - 1].Y);
+                        }
+                        //check direction
+                        if (inorth < _bu.Pt.Count - 1)
+                        {
+                            x_plus = Convert.ToDouble(_bu.Pt[(inorth + 1)].X);
+                            y_plus = Convert.ToDouble(_bu.Pt[(inorth + 1)].Y);
+                        }
+                        else
+                        {
+                            x_plus = Convert.ToDouble(_bu.Pt[0].X);
+                            y_plus = Convert.ToDouble(_bu.Pt[0].Y);
+                        }
+
+                        bool clockwise = true;
+                        if (x_plus < x_minus)
+                        {
+                            clockwise = false;
+                        }
+
+                        if ((x_plus < xnorth) && (x_minus < xnorth))
+                        {
+                            if (y_minus < y_plus)
+                            {
+                                clockwise = false;
+                            }
+                        }
+
+                        if ((x_plus > xnorth) && (x_minus > xnorth))
+                        {
+                            if (y_minus > y_plus)
+                            {
+                                clockwise = false;
+                            }
+                        }
+
+                        if (clockwise == true)
+                        {
+                            for (int i = 0; i < _bu.Pt.Count; i++)
+                            {
+                                x1 = Convert.ToDouble(_bu.Pt[i].X);
+                                y1 = Convert.ToDouble(_bu.Pt[i].Y);
+
+                                data8 = WriteDoubleLittle(x1);
+                                fs.Write(data8, 0, 8);
+                                data8 = WriteDoubleLittle(y1);
+                                fs.Write(data8, 0, 8);
+                            }
+                            //write first point again to close the polygon
+                        }
+                        else
+                        {
+                            for (int i = _bu.Pt.Count - 1; i > -1; i--)
+                            {
+                                x1 = Convert.ToDouble(_bu.Pt[i].X);
+                                y1 = Convert.ToDouble(_bu.Pt[i].Y);
+                                data8 = WriteDoubleLittle(x1);
+                                fs.Write(data8, 0, 8);
+                                data8 = WriteDoubleLittle(y1);
+                                fs.Write(data8, 0, 8);
+                            }
+                        }
+                    }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
+                }
+            }
+            //export domain area
+            else if (shapetype == 11)
+            {
+                shapetype = 5; // shapetype polygon
+                int edgePoints = 5;
+                //write main file header
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, edgePoints);
+                if (fs != null && fshx != null)
+                {
+                    //bounding box
+                    xMin = domain.MainForm.GralDomRect.West;
+                    yMin = domain.MainForm.GralDomRect.North;
+                    xMax = domain.MainForm.GralDomRect.East;
+                    yMax = domain.MainForm.GralDomRect.South;
+
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+
                     recordNumber += 1;
                     //record number
                     data = WriteIntBig(recordNumber);
@@ -316,9 +841,9 @@ namespace GralShape
                     //offset
                     data = WriteIntBig(offset);
                     fshx.Write(data, 0, 4);
-                    offset = offset + 4 + 24 + 8 * (_as.Pt.Count + 1);
+                    offset = offset + 4 + 24 + 8 * edgePoints;
                     //content length
-                    data = WriteIntBig(24 + 8 * (_as.Pt.Count + 1));
+                    data = WriteIntBig(24 + 8 * edgePoints);
                     fs.Write(data, 0, 4);
                     fshx.Write(data, 0, 4);
                     //shape type
@@ -329,16 +854,7 @@ namespace GralShape
                     yMin = 10000000;
                     xMax = -10000000;
                     yMax = -10000000;
-                    
-                    for (int i = 0; i < _as.Pt.Count; i++)
-                    {
-                        x1 = _as.Pt[i].X;
-                        y1 = _as.Pt[i].Y;
-                        xMin = Math.Min(xMin, x1);
-                        yMin = Math.Min(yMin, y1);
-                        xMax = Math.Max(xMax, x1);
-                        yMax = Math.Max(yMax, y1);
-                    }
+
                     data8 = WriteDoubleLittle(xMin);
                     fs.Write(data8, 0, 8);
                     data8 = WriteDoubleLittle(yMin);
@@ -351,382 +867,54 @@ namespace GralShape
                     data = WriteIntLittle(1);
                     fs.Write(data, 0, 4);
                     //the total number of points of all polylines
-                    data = WriteIntLittle(_as.Pt.Count + 1);
+                    data = WriteIntLittle(edgePoints);
                     fs.Write(data, 0, 4);
                     //index of first point of each polyline
                     data = WriteIntLittle(0);
                     fs.Write(data, 0, 4);
                     //points of each polyline -> have to exported in clockwise direction!
-                    //seek the most northern point
-                    double ynorth = _as.Pt[0].Y;
-                    double xnorth = _as.Pt[0].X;
-                    double x_minus;
-                    double x_plus;
-                    double y_minus;
-                    double y_plus;
-                    int inorth = 0;
-                    for (int i = 1; i < _as.Pt.Count; i++)
-                    {
-                        x1 = _as.Pt[i].X;
-                        y1 = _as.Pt[i].Y;
-                        if (y1 > ynorth)
-                        {
-                            xnorth = x1;
-                            ynorth = y1;
-                            inorth = i;
-                        }
-                    }
-                    //check direction
-                    if (inorth > 0)
-                    {
-                        x_minus = Convert.ToDouble(_as.Pt[(inorth - 1)].X);
-                        y_minus = Convert.ToDouble(_as.Pt[(inorth - 1)].Y);
-                    }
-                    else
-                    {
-                        x_minus = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].X);
-                        y_minus = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].Y);
-                    }
-                    //check direction
-                    if (inorth < _as.Pt.Count - 1)
-                    {
-                        x_plus = Convert.ToDouble(_as.Pt[(inorth + 1)].X);
-                        y_plus = Convert.ToDouble(_as.Pt[(inorth + 1)].Y);
-                    }
-                    else
-                    {
-                        x_plus = Convert.ToDouble(_as.Pt[0].X);
-                        y_plus = Convert.ToDouble(_as.Pt[0].Y);
-                    }
 
-                    bool clockwise = true;
-                    if (x_plus < x_minus)
-                    {
-                        clockwise = false;
-                    }
-
-                    if ((x_plus < xnorth) && (x_minus < xnorth))
-                    {
-                        if (y_minus < y_plus)
-                        {
-                            clockwise = false;
-                        }
-                    }
-
-                    if ((x_plus > xnorth) && (x_minus > xnorth))
-                    {
-                        if (y_minus > y_plus)
-                        {
-                            clockwise = false;
-                        }
-                    }
-
-                    if (clockwise == true)
-                    {
-                        for (int i = 0; i < _as.Pt.Count; i++)
-                        {
-                            x1 = Convert.ToDouble(_as.Pt[i].X);
-                            y1 = Convert.ToDouble(_as.Pt[i].Y);
-                                                                        
-                            data8 = WriteDoubleLittle(x1);
-                            fs.Write(data8, 0, 8);
-                            data8 = WriteDoubleLittle(y1);
-                            fs.Write(data8, 0, 8);
-                        }
-                        //write first point again to close the polygon
-                        x1 = Convert.ToDouble(_as.Pt[0].X);
-                        y1 = Convert.ToDouble(_as.Pt[0].Y);
-                        data8 = WriteDoubleLittle(x1);
-                        fs.Write(data8, 0, 8);
-                        data8 = WriteDoubleLittle(y1);
-                        fs.Write(data8, 0, 8);
-                    }
-                    else
-                    {
-                        for (int i = _as.Pt.Count - 1; i > -1; i--)
-                        {
-                            x1 = Convert.ToDouble(_as.Pt[i].X);
-                            y1 = Convert.ToDouble(_as.Pt[i].Y);
-                            data8 = WriteDoubleLittle(x1);
-                            fs.Write(data8, 0, 8);
-                            data8 = WriteDoubleLittle(y1);
-                            fs.Write(data8, 0, 8);
-                        }
-                        //write last point again to close the polygon
-                        x1 = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].X);
-                        y1 = Convert.ToDouble(_as.Pt[_as.Pt.Count - 1].Y);
-                        data8 = WriteDoubleLittle(x1);
-                        fs.Write(data8, 0, 8);
-                        data8 = WriteDoubleLittle(y1);
-                        fs.Write(data8, 0, 8);
-                    }
-                }
-
-                //filelength updated
-                double dummy = Convert.ToDouble(fs.Length * 0.5);
-                int filelength = (int)dummy;
-
-                data = WriteIntBig(filelength);
-                fs.Position = 24;
-                fs.Write(data, 0, 4);
-                fs.Close();
-                fshx.Close();
-            }
-            //export point sources
-            else if (shapetype == 1)
-            {
-                //write main file header
-                FileStream fs = new FileStream(filename, FileMode.Create);
-                FileStream fshx = new FileStream(ShxFile, FileMode.Create);
-                Byte[] data = new Byte[4];
-                Byte[] data8 = new Byte[8];
-                //version
-                data = WriteIntBig(9994);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //not used
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //filelength (needs to be updated at the end of the stream
-                data = WriteIntBig(1000);
-                fs.Write(data, 0, 4);
-                //filelength of .shx file =50+4*records
-                int filelong = 50 + 4 * domain.EditPS.ItemData.Count;
-                data = WriteIntBig(filelong);
-                fshx.Write(data, 0, 4);
-                //version
-                data = WriteIntLittle(1000);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //shape type
-                data = WriteIntLittle(shapetype);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //bounding box
-                xMin = 10000000;
-                yMin = 10000000;
-                xMax = -10000000;
-                yMax = -10000000;
-                double x1 = 0;
-                double y1 = 0;
-                
-                
-                foreach (PointSourceData _psdata in domain.EditPS.ItemData)
-                {
-                    x1 = _psdata.Pt.X;
-                    y1 = _psdata.Pt.Y;
-                    xMin = Math.Min(xMin, x1);
-                    yMin = Math.Min(yMin, y1);
-                    xMax = Math.Max(xMax, x1);
-                    yMax = Math.Max(yMax, y1);
-                }
-                data8 = WriteDoubleLittle(xMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(xMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                int recordNumber = 0;
-                int offset = 50;
-                
-                //write records: header and record
-                foreach (PointSourceData _psdata in domain.EditPS.ItemData)
-                {
-                    recordNumber += 1;
-                    
-                    //record number
-                    data = WriteIntBig(recordNumber);
-                    fs.Write(data, 0, 4);
-                    //offset
-                    data = WriteIntBig(offset);
-                    fshx.Write(data, 0, 4);
-                    offset = offset + 4 + 2 + 8;
-                    //content length
-                    data = WriteIntBig(2 + 8);
-                    fs.Write(data, 0, 4);
-                    fshx.Write(data, 0, 4);
-                    //shape type
-                    data = WriteIntLittle(1);
-                    fs.Write(data, 0, 4);
-                    //write points
-                    x1 = _psdata.Pt.X;
-                    y1 = _psdata.Pt.Y;
-                    data8 = WriteDoubleLittle(x1);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.West);
                     fs.Write(data8, 0, 8);
-                    data8 = WriteDoubleLittle(y1);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.North);
                     fs.Write(data8, 0, 8);
-                }
 
-                //filelength updated
-                double dummy = Convert.ToDouble(fs.Length * 0.5);
-                int filelength = (int)dummy;
-
-                data = WriteIntBig(filelength);
-                fs.Position = 24;
-                fs.Write(data, 0, 4);
-                fs.Close();
-                fshx.Close();
-            }
-            
-            //export receptors
-            else if (shapetype == 0)
-            {
-                //write main file header
-                FileStream fs = new FileStream(filename, FileMode.Create);
-                FileStream fshx = new FileStream(ShxFile, FileMode.Create);
-                Byte[] data = new Byte[4];
-                Byte[] data8 = new Byte[8];
-                //version
-                data = WriteIntBig(9994);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //not used
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                data = WriteIntBig(0);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //filelength (needs to be updated at the end of the stream
-                data = WriteIntBig(1000);
-                fs.Write(data, 0, 4);
-                //filelength of .shx file =50+4*records
-                int filelong = 50 + 4 * domain.EditR.ItemData.Count;
-                data = WriteIntBig(filelong);
-                fshx.Write(data, 0, 4);
-                //version
-                data = WriteIntLittle(1000);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //shape type
-                data = WriteIntLittle(1);
-                fs.Write(data, 0, 4);
-                fshx.Write(data, 0, 4);
-                //bounding box
-                xMin = 10000000;
-                yMin = 10000000;
-                xMax = -10000000;
-                yMax = -10000000;
-                double x1 = 0;
-                double y1 = 0;
-                
-                foreach (ReceptorData _rd in domain.EditR.ItemData)
-                {
-                    x1 = Math.Round(_rd.Pt.X, 1);
-                    y1 = Math.Round(_rd.Pt.Y, 1);
-                    xMin = Math.Min(xMin, x1);
-                    yMin = Math.Min(yMin, y1);
-                    xMax = Math.Max(xMax, x1);
-                    yMax = Math.Max(yMax, y1);
-                }
-                
-                data8 = WriteDoubleLittle(xMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(xMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                int recordNumber = 0;
-                int offset = 50;
-                //write records: header and record
-                foreach (ReceptorData _rd in domain.EditR.ItemData)
-                {
-                    recordNumber++;
-                    //record number
-                    data = WriteIntBig(recordNumber);
-                    fs.Write(data, 0, 4);
-                    //offset
-                    data = WriteIntBig(offset);
-                    fshx.Write(data, 0, 4);
-                    offset = offset + 4 + 2 + 8;
-                    //content length
-                    data = WriteIntBig(2 + 8);
-                    fs.Write(data, 0, 4);
-                    fshx.Write(data, 0, 4);
-                    //shape type
-                    data = WriteIntLittle(1);
-                    fs.Write(data, 0, 4);
-                    //write points
-                    x1 = Math.Round(_rd.Pt.X, 1);
-                    y1 = Math.Round(_rd.Pt.Y, 1);
-                    data8 = WriteDoubleLittle(x1);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.East);
                     fs.Write(data8, 0, 8);
-                    data8 = WriteDoubleLittle(y1);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.North);
                     fs.Write(data8, 0, 8);
+
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.East);
+                    fs.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.South);
+                    fs.Write(data8, 0, 8);
+
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.West);
+                    fs.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.South);
+                    fs.Write(data8, 0, 8);
+
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.West);
+                    fs.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.North);
+                    fs.Write(data8, 0, 8);
+
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
                 }
-
-                //filelength updated
-                double dummy = Convert.ToDouble(fs.Length * 0.5);
-                int filelength = (int)dummy;
-
-                data = WriteIntBig(filelength);
-                fs.Position = 24;
-                fs.Write(data, 0, 4);
-                fs.Close();
-                fshx.Close();
             }
             //export contour lines
             else if (shapetype == 12)
             {
-                shapetype = 3; // shapetype polline
+                shapetype = 3; // shapetype polyline
                 // search drawing object
                 GralDomain.DrawingObjects _drobj = new GralDomain.DrawingObjects("");
                 foreach (GralDomain.DrawingObjects _dr in domain.ItemOptions)
@@ -737,10 +925,177 @@ namespace GralShape
                         break;
                     }
                 }
-                
+
                 //write main file header
-                FileStream fs = new FileStream(filename, FileMode.Create);
-                FileStream fshx = new FileStream(ShxFile, FileMode.Create);
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, _drobj.ContourPolygons.Count);
+                if (fs != null && fshx != null)
+                {
+                    //bounding box
+                    xMin = 10000000;
+                    yMin = 10000000;
+                    xMax = -10000000;
+                    yMax = -10000000;
+                    double x1 = 0;
+                    double y1 = 0;
+                    double x2 = 0;
+                    double y2 = 0;
+
+                    for (int j = 0; j < _drobj.ContourPolygons.Count; j++)  // loop over all iso-rings
+                    {
+                        GralDomain.PointD[] _pts = _drobj.ContourPolygons[j].EdgePoints;
+                        for (int i = 0; i < _pts.Length; i++)
+                        {
+                            x1 = _pts[i].X;
+                            y1 = _pts[i].Y;
+
+                            xMin = Math.Min(xMin, x1);
+                            yMin = Math.Min(yMin, y1);
+                            xMax = Math.Max(xMax, x1);
+                            yMax = Math.Max(yMax, y1);
+                        }
+                    }
+
+                    data8 = WriteDoubleLittle(xMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMin);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(xMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(yMax);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    data8 = WriteDoubleLittle(0);
+                    fs.Write(data8, 0, 8);
+                    fshx.Write(data8, 0, 8);
+                    int recordNumber = 0;
+                    int offset = 50;
+                    //write records: header and record to .shp file
+                    //offset and index to .shx file
+                    for (int j = 0; j < _drobj.ContourPolygons.Count; j++)  // loop over all iso-rings
+                    {
+                        GralDomain.PointD[] _pts = _drobj.ContourPolygons[j].EdgePoints;
+
+                        recordNumber += 1;
+
+                        //record number
+                        data = WriteIntBig(recordNumber);
+                        fs.Write(data, 0, 4);
+                        //offset
+                        data = WriteIntBig(offset);
+                        fshx.Write(data, 0, 4);
+                        offset = offset + 4 + 24 + 8 * (_pts.Length + 1);
+                        //content length
+                        data = WriteIntBig(24 + 8 * (_pts.Length + 1));
+                        fs.Write(data, 0, 4);
+                        fshx.Write(data, 0, 4);
+                        //shape type
+                        data = WriteIntLittle(3);
+                        fs.Write(data, 0, 4);
+                        //Box
+                        xMin = 10000000;
+                        yMin = 10000000;
+                        xMax = -10000000;
+                        yMax = -10000000;
+                        for (int i = 0; i < _pts.Length; i++)
+                        {
+                            x1 = _pts[i].X;
+                            y1 = _pts[i].Y;
+                            if (i == _pts.Length - 1) // last point
+                            {
+                                x2 = _pts[0].X;
+                                y2 = _pts[0].Y;
+                            }
+                            else
+                            {
+                                x2 = _pts[i + 1].X;
+                                y2 = _pts[i + 1].Y;
+                            }
+                            xMin = Math.Min(xMin, x1);
+                            xMin = Math.Min(xMin, x2);
+                            yMin = Math.Min(yMin, y1);
+                            yMin = Math.Min(yMin, y2);
+                            xMax = Math.Max(xMax, x1);
+                            xMax = Math.Max(xMax, x2);
+                            yMax = Math.Max(yMax, y1);
+                            yMax = Math.Max(yMax, y2);
+                        }
+                        data8 = WriteDoubleLittle(xMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMin);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(xMax);
+                        fs.Write(data8, 0, 8);
+                        data8 = WriteDoubleLittle(yMax);
+                        fs.Write(data8, 0, 8);
+                        //the number of parts in the polyline
+                        data = WriteIntLittle(1);
+                        fs.Write(data, 0, 4);
+                        //the total number of points of all polylines
+                        data = WriteIntLittle(_pts.Length + 1);
+                        fs.Write(data, 0, 4);
+                        //index of first point of each polyline
+                        data = WriteIntLittle(0);
+                        fs.Write(data, 0, 4);
+                        //points of each polyline
+                        for (int i = 0; i <= _pts.Length; i++)
+                        {
+                            if (i < _pts.Length)
+                            {
+                                x1 = _pts[i].X;
+                                y1 = _pts[i].Y;
+                            }
+                            else // last point
+                            {
+                                x1 = _pts[0].X;
+                                y1 = _pts[0].Y;
+                            }
+                            data8 = WriteDoubleLittle(x1);
+                            fs.Write(data8, 0, 8);
+                            data8 = WriteDoubleLittle(y1);
+                            fs.Write(data8, 0, 8);
+                        }
+                    }
+
+                    //filelength updated
+                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    int filelength = (int)dummy;
+
+                    data = WriteIntBig(filelength);
+                    fs.Position = 24;
+                    fs.Write(data, 0, 4);
+                    fs.Close(); fshx.Close();
+                    fs.Dispose(); fshx.Dispose();
+                }
+            }
+            else
+            {
+                MessageBox.Show("Unknown shape type, unable to export file", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+            }
+        }
+
+        private (FileStream, FileStream) writeHeader(string fileName, int shapeType, int numberOfItems)
+        {
+            FileStream fs = null;
+            FileStream fshx = null;
+            try
+            {
+                //construct file name for index file .shx
+                string shxFile = fileName.Replace(".shp", ".shx");
+                //write main file header
+                fs = new FileStream(fileName, FileMode.Create);
+                fshx = new FileStream(shxFile, FileMode.Create);
                 Byte[] data = new Byte[4];
                 Byte[] data8 = new Byte[8];
                 //version
@@ -767,7 +1122,7 @@ namespace GralShape
                 data = WriteIntBig(1000);
                 fs.Write(data, 0, 4);
                 //filelength of .shx file =50+4*records
-                int filelong = 50 + 4 * _drobj.ContourPolygons.Count;
+                int filelong = 50 + 4 * numberOfItems;
                 data = WriteIntBig(filelong);
                 fshx.Write(data, 0, 4);
                 //version
@@ -775,161 +1130,16 @@ namespace GralShape
                 fs.Write(data, 0, 4);
                 fshx.Write(data, 0, 4);
                 //shape type
-                data = WriteIntLittle(shapetype);
+                data = WriteIntLittle(shapeType);
                 fs.Write(data, 0, 4);
                 fshx.Write(data, 0, 4);
-                //bounding box
-                xMin = 10000000;
-                yMin = 10000000;
-                xMax = -10000000;
-                yMax = -10000000;
-                double x1 = 0;
-                double y1 = 0;
-                double x2 = 0;
-                double y2 = 0;
-                
-                for (int j = 0; j < _drobj.ContourPolygons.Count; j++)  // loop over all iso-rings
-                {
-                    GralDomain.PointD[] _pts = _drobj.ContourPolygons[j].EdgePoints;
-                    for (int i = 0; i < _pts.Length; i++)
-                    {
-                        x1 = _pts[i].X;
-                        y1 = _pts[i].Y;
-                        
-                        xMin = Math.Min(xMin, x1);
-                        yMin = Math.Min(yMin, y1);
-                        xMax = Math.Max(xMax, x1);
-                        yMax = Math.Max(yMax, y1);
-                    }
-                }
-
-                data8 = WriteDoubleLittle(xMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMin);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(xMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(yMax);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                data8 = WriteDoubleLittle(0);
-                fs.Write(data8, 0, 8);
-                fshx.Write(data8, 0, 8);
-                int recordNumber = 0;
-                int offset = 50;
-                //write records: header and record to .shp file
-                //offset and index to .shx file
-                for (int j = 0; j < _drobj.ContourPolygons.Count; j++)  // loop over all iso-rings
-                {
-                    GralDomain.PointD[] _pts = _drobj.ContourPolygons[j].EdgePoints;
-
-                    recordNumber += 1;
-
-                    //record number
-                    data = WriteIntBig(recordNumber);
-                    fs.Write(data, 0, 4);
-                    //offset
-                    data = WriteIntBig(offset);
-                    fshx.Write(data, 0, 4);
-                    offset = offset + 4 + 24 + 8 * (_pts.Length + 1);
-                    //content length
-                    data = WriteIntBig(24 + 8 * (_pts.Length + 1));
-                    fs.Write(data, 0, 4);
-                    fshx.Write(data, 0, 4);
-                    //shape type
-                    data = WriteIntLittle(3);
-                    fs.Write(data, 0, 4);
-                    //Box
-                    xMin = 10000000;
-                    yMin = 10000000;
-                    xMax = -10000000;
-                    yMax = -10000000;
-                    for (int i = 0; i < _pts.Length; i++)
-                    {
-                        x1 = _pts[i].X;
-                        y1 = _pts[i].Y;
-                        if (i == _pts.Length - 1) // last point
-                        {
-                            x2 = _pts[0].X;
-                            y2 = _pts[0].Y;
-                        }
-                        else
-                        {
-                            x2 = _pts[i + 1].X;
-                            y2 = _pts[i + 1].Y;
-                        }
-                        xMin = Math.Min(xMin, x1);
-                        xMin = Math.Min(xMin, x2);
-                        yMin = Math.Min(yMin, y1);
-                        yMin = Math.Min(yMin, y2);
-                        xMax = Math.Max(xMax, x1);
-                        xMax = Math.Max(xMax, x2);
-                        yMax = Math.Max(yMax, y1);
-                        yMax = Math.Max(yMax, y2);
-                    }
-                    data8 = WriteDoubleLittle(xMin);
-                    fs.Write(data8, 0, 8);
-                    data8 = WriteDoubleLittle(yMin);
-                    fs.Write(data8, 0, 8);
-                    data8 = WriteDoubleLittle(xMax);
-                    fs.Write(data8, 0, 8);
-                    data8 = WriteDoubleLittle(yMax);
-                    fs.Write(data8, 0, 8);
-                    //the number of parts in the polyline
-                    data = WriteIntLittle(1);
-                    fs.Write(data, 0, 4);
-                    //the total number of points of all polylines
-                    data = WriteIntLittle(_pts.Length + 1);
-                    fs.Write(data, 0, 4);
-                    //index of first point of each polyline
-                    data = WriteIntLittle(0);
-                    fs.Write(data, 0, 4);
-                    //points of each polyline
-                    for (int i = 0; i <= _pts.Length; i++)
-                    {
-                        if (i < _pts.Length)
-                        {
-                            x1 = _pts[i].X;
-                            y1 = _pts[i].Y;
-                        }
-                        else // last point
-                        {
-                            x1 = _pts[0].X;
-                            y1 = _pts[0].Y;
-                        }
-                        data8 = WriteDoubleLittle(x1);
-                        fs.Write(data8, 0, 8);
-                        data8 = WriteDoubleLittle(y1);
-                        fs.Write(data8, 0, 8);
-                    }
-                }
-                
-                //filelength updated
-                double dummy = Convert.ToDouble(fs.Length * 0.5);
-                int filelength = (int)dummy;
-
-                data = WriteIntBig(filelength);
-                fs.Position = 24;
-                fs.Write(data, 0, 4);
-                fs.Close();
-                fshx.Close();
             }
-            else
+            catch
             {
-                MessageBox.Show("Unknown shape type, unable to export file", "GRAL GUI", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                fs = null;
+                fshx = null;
             }
+            return (fs, fshx);
         }
 
         private byte[] WriteIntBig(int numb)

--- a/src/GRALShapeFiles/Shapewriter.cs
+++ b/src/GRALShapeFiles/Shapewriter.cs
@@ -10,8 +10,12 @@
 ///</remarks>
 #endregion
 
+using GralDomain;
 using GralItemData;
 using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Drawing;
 using System.Globalization;
 using System.IO;
 using System.Windows.Forms;
@@ -171,7 +175,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -181,6 +185,7 @@ namespace GralShape
                     fs.Dispose(); fshx.Dispose();
                 }
             }
+
             //export area sources
             else if (shapetype == 5)
             {
@@ -392,7 +397,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -482,7 +487,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -573,7 +578,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -782,7 +787,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -798,7 +803,7 @@ namespace GralShape
                 shapetype = 5; // shapetype polygon
                 int edgePoints = 5;
                 //write main file header
-                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, edgePoints);
+                (FileStream fs, FileStream fshx) = writeHeader(filename, shapetype, 1);
                 if (fs != null && fshx != null)
                 {
                     //bounding box
@@ -899,9 +904,8 @@ namespace GralShape
                     data8 = WriteDoubleLittle(domain.MainForm.GralDomRect.North);
                     fs.Write(data8, 0, 8);
 
-
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);
@@ -911,7 +915,7 @@ namespace GralShape
                     fs.Dispose(); fshx.Dispose();
                 }
             }
-            //export contour lines
+            //export spline line contour lines
             else if (shapetype == 12)
             {
                 shapetype = 3; // shapetype polyline
@@ -1069,7 +1073,7 @@ namespace GralShape
                     }
 
                     //filelength updated
-                    double dummy = Convert.ToDouble(fs.Length * 0.5);
+                    long dummy = fs.Length / 2;
                     int filelength = (int)dummy;
 
                     data = WriteIntBig(filelength);

--- a/src/GRALShapeFiles/Shapewriter.cs
+++ b/src/GRALShapeFiles/Shapewriter.cs
@@ -10,18 +10,18 @@
 ///</remarks>
 #endregion
 
-using System;
-using System.Windows.Forms;
-using System.IO;
-using System.Globalization;
 using GralItemData;
+using System;
+using System.Globalization;
+using System.IO;
+using System.Windows.Forms;
 
 namespace GralShape
 {
     /// <summary>
     /// Write a shape file
     /// </summary>
-    public class ShapeWriter
+    public partial class ShapeWriter
     {
         double xMin, yMin, xMax, yMax;
         public GralDomain.Domain domain = null;
@@ -492,7 +492,7 @@ namespace GralShape
                     fs.Dispose(); fshx.Dispose();
                 }
             }
-            
+
             //export receptors
             else if (shapetype == 0)
             {

--- a/src/Gral.csproj
+++ b/src/Gral.csproj
@@ -64,7 +64,7 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <BaseAddress>4194304</BaseAddress>
     <RegisterForComInterop>False</RegisterForComInterop>
@@ -74,7 +74,7 @@
     <CodeAnalysisRuleSet>MinimumRecommendedRules.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <DebugType>full</DebugType>
+    <DebugType>embedded</DebugType>
     <PlatformTarget>x64</PlatformTarget>
     <BaseAddress>4194304</BaseAddress>
     <RegisterForComInterop>False</RegisterForComInterop>

--- a/src/Gral.csproj
+++ b/src/Gral.csproj
@@ -32,7 +32,7 @@
     <ImportWindowsDesktopTargets>true</ImportWindowsDesktopTargets>
     <ImplicitUsings>disable</ImplicitUsings>
     <SignAssembly>False</SignAssembly>
-    <PackageLicenseFile>D:\GitHub\GUI_NET6\License.md</PackageLicenseFile>
+    <PackageLicenseFile>License.md</PackageLicenseFile>
     <EnableNETAnalyzers>False</EnableNETAnalyzers>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <ApplicationDefaultFont>Segoe UI,9pt</ApplicationDefaultFont>
@@ -200,6 +200,12 @@
   </ItemGroup>
   <ItemGroup>
     <None Remove="Resources\Thumbs.db" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\License.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.Text.Encoding.CodePages" Version="6.0.0" />

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -2905,7 +2905,8 @@ namespace Gral
             if (GRALSettings.WriteESRIResult ||
                 File.Exists(Path.Combine(Main.ProjectName, "Computation", "KeepAndReadTransientTempFiles.dat")) ||
                 !GRALSettings.WaitForKeyStroke ||
-                GRALSettings.PrognosticSubDomainsSizeSourceRadius >= 50)
+                GRALSettings.PrognosticSubDomainsSizeSourceRadius >= 50 ||
+                GRALSettings.ReproducibleResults)
             {
                 button57.BackgroundImage = Gral.Properties.Resources.WrenchYellow;
             }

--- a/src/Main.cs
+++ b/src/Main.cs
@@ -3606,6 +3606,7 @@ namespace Gral
                     MSp.LogLevel = GRALSettings.Loglevel;
                     MSp.RadiusForPrognosticFlowField = GRALSettings.PrognosticSubDomainsSizeSourceRadius;
                     MSp.GRALOnlineFunctions = GRALSettings.UseGRALOnlineFunctions;
+                    MSp.GRALReproducibleResults = GRALSettings.ReproducibleResults;
 
                     MSp.StartPosition = FormStartPosition.Manual;
                     MSp.Left = Left + 80;
@@ -3616,12 +3617,14 @@ namespace Gral
                         if (MSp.WriteASCiiOutput != GRALSettings.WriteESRIResult ||
                             MSp.KeyStrokeWhenExitGRAL != GRALSettings.WaitForKeyStroke ||
                             MSp.RadiusForPrognosticFlowField != GRALSettings.PrognosticSubDomainsSizeSourceRadius ||
-                            MSp.GRALOnlineFunctions != GRALSettings.UseGRALOnlineFunctions)
+                            MSp.GRALOnlineFunctions != GRALSettings.UseGRALOnlineFunctions ||
+                            MSp.GRALReproducibleResults != GRALSettings.ReproducibleResults)
                         {
                             GRALSettings.WriteESRIResult = MSp.WriteASCiiOutput;
                             GRALSettings.WaitForKeyStroke = MSp.KeyStrokeWhenExitGRAL;
                             GRALSettings.PrognosticSubDomainsSizeSourceRadius = MSp.RadiusForPrognosticFlowField;
                             GRALSettings.UseGRALOnlineFunctions = MSp.GRALOnlineFunctions;
+                            GRALSettings.ReproducibleResults = MSp.GRALReproducibleResults;
                             ResetInDat();
                         }
                         GRALSettings.Loglevel = MSp.LogLevel;

--- a/src/Properties/AssemblyInfo.cs
+++ b/src/Properties/AssemblyInfo.cs
@@ -42,6 +42,6 @@ using System.Resources;
 // Sie können alle Werte angeben oder die standardmäßigen Build- und Revisionsnummern 
 // übernehmen, indem Sie "*" eingeben:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("2.4.0.4")]
-[assembly: AssemblyFileVersion("2.4.0.4")]
+[assembly: AssemblyVersion("2.4.1.1")]
+[assembly: AssemblyFileVersion("2.4.1.1")]
 [assembly: NeutralResourcesLanguageAttribute("")]


### PR DESCRIPTION
### New features
- New optional smoothing of Bourke contour lines using an adjustable Gaussian filter 
- Draw wind rose segments in pie shapes instead of triangles 
- Enable the export of shape files for “Bourke” contour lines, buildings and the dispersion area
- Enable the evaluation of hourly means for a percentile evaluation when the calculation has been performed with sub-hourly dispersion times (15, 20 or 30 minutes) 
- Add support for the “GRAL Reproducible Results” option 

### Bug fixes

- Fixed a bug that crashed the percentile evaluation for odour calculations due to a missing parameter
- Fixed a bug when adding a source group but not saving it, and then trying to remove the existing source group in a source item dialog box
